### PR TITLE
zb: Connection::peer_credentials now async

### DIFF
--- a/zbus/src/blocking/connection.rs
+++ b/zbus/src/blocking/connection.rs
@@ -1,13 +1,13 @@
 use enumflags2::BitFlags;
 use event_listener::EventListener;
 use static_assertions::assert_impl_all;
-use std::{convert::TryInto, ops::Deref, sync::Arc};
+use std::{convert::TryInto, io, ops::Deref, sync::Arc};
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName};
 use zvariant::ObjectPath;
 
 use crate::{
     blocking::ObjectServer,
-    fdo::{RequestNameFlags, RequestNameReply},
+    fdo::{ConnectionCredentials, RequestNameFlags, RequestNameReply},
     utils::block_on,
     DBusError, Error, Message, Result,
 };
@@ -246,6 +246,18 @@ impl Connection {
     /// This function is meant for the caller to implement idle or timeout on inactivity.
     pub fn monitor_activity(&self) -> EventListener {
         self.inner.monitor_activity()
+    }
+
+    /// Returns the peer credentials.
+    ///
+    /// The fields are populated on the best effort basis. Some or all fields may not even make
+    /// sense for certain sockets or on certain platforms and hence will be set to `None`.
+    ///
+    /// # Caveats
+    ///
+    /// Currently `unix_group_ids` and `linux_security_label` fields are not populated.
+    pub fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
+        block_on(self.inner.peer_credentials())
     }
 }
 

--- a/zbus/src/connection.rs
+++ b/zbus/src/connection.rs
@@ -1264,7 +1264,12 @@ impl Connection {
                 the peer PID."
     )]
     pub fn peer_pid(&self) -> io::Result<Option<u32>> {
-        self.peer_credentials().map(|c| c.process_id())
+        self.inner
+            .raw_conn
+            .lock()
+            .expect("poisoned lock")
+            .socket()
+            .peer_pid()
     }
 
     /// Returns the peer credentials.
@@ -1276,7 +1281,7 @@ impl Connection {
     ///
     /// Currently `unix_group_ids` and `linux_security_label` fields are not populated.
     #[allow(deprecated)]
-    pub fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
+    pub async fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
         let raw_conn = self.inner.raw_conn.lock().expect("poisoned lock");
         let socket = raw_conn.socket();
 


### PR DESCRIPTION
Most likely, querying the group IDs will involve potentially blocking calls (e.g `getgrouplist` is blocking on Linux) so best be safe and keep it async from the get go so we don't have to break API.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
