### PR TITLE
zv,zb: Add missing container depth checks + Reject empty structs in signatures

### DIFF
--- a/zbus/src/message_header.rs
+++ b/zbus/src/message_header.rs
@@ -260,7 +260,6 @@ pub struct MessageHeader<'m> {
     primary: MessagePrimaryHeader,
     #[serde(borrow)]
     fields: MessageFields<'m>,
-    end: ((),), // To ensure header end on 8-byte boundary
 }
 
 assert_impl_all!(MessageHeader<'_>: Send, Sync, Unpin);
@@ -288,11 +287,7 @@ macro_rules! get_field_u32 {
 impl<'m> MessageHeader<'m> {
     /// Create a new `MessageHeader` instance.
     pub fn new(primary: MessagePrimaryHeader, fields: MessageFields<'m>) -> Self {
-        Self {
-            primary,
-            fields,
-            end: ((),),
-        }
+        Self { primary, fields }
     }
 
     /// Get a reference to the primary header.

--- a/zvariant/src/container_depths.rs
+++ b/zvariant/src/container_depths.rs
@@ -27,8 +27,6 @@ impl ContainerDepths {
         self.check()
     }
 
-    #[cfg(feature = "gvariant")]
-    // This is only used by gvariant code.
     pub fn dec_structure(mut self) -> Self {
         self.structure -= 1;
         self

--- a/zvariant/src/signature_parser.rs
+++ b/zvariant/src/signature_parser.rs
@@ -208,16 +208,19 @@ impl<'s> SignatureParser<'s> {
             ));
         }
 
+        let mut bytes = signature.as_bytes().iter();
         // We can't get None here cause we already established there are at least 2 chars above
-        let c = signature
-            .as_bytes()
-            .first()
-            .map(|b| *b as char)
-            .expect("empty signature");
+        let c = bytes.next().map(|b| *b as char).expect("empty signature");
         if c != STRUCT_SIG_START_CHAR {
             return Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Char(c),
                 &crate::STRUCT_SIG_START_STR,
+            ));
+        }
+        if bytes.next().map(|b| *b as char).expect("empty signature") == STRUCT_SIG_END_CHAR {
+            return Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str("()"),
+                &"at least one field signature between `(` and `)`",
             ));
         }
 


### PR DESCRIPTION
This is to address some issues spotted during recent fuzzing runs in the CI:

https://github.com/dbus2/zbus-old/actions/runs/4915689965/jobs/8778478660
https://github.com/dbus2/zbus-old/actions/runs/4927346573/jobs/8804199850