### PR TITLE
zv: Optional::default shouldn't call NoneValue::null_value

### DIFF
--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -127,6 +127,7 @@ mod tests {
 
     use crate::{
         from_slice, from_slice_for_signature, to_bytes, to_bytes_for_signature, MaxDepthExceeded,
+        Optional,
     };
     #[cfg(unix)]
     use crate::{from_slice_fds, to_bytes_fds};
@@ -1890,5 +1891,12 @@ mod tests {
         //
         // * Test deserializers.
         // * Test gvariant format.
+    }
+
+    #[test]
+    fn issue_343() {
+        // The Default impl was causing a stack overflow by calling NoneValue::null_value(), which
+        // in turn called Default::default().
+        let _ = Optional::<()>::default();
     }
 }

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -121,6 +121,6 @@ impl<T> DerefMut for Optional<T> {
 
 impl<T> Default for Optional<T> {
     fn default() -> Self {
-        Self::null_value()
+        Self(None)
     }
 }


### PR DESCRIPTION
Otherwise we end up with a infinite mutual recursion between these calls and hence a stack overflow.

Fixes #343.