### PR TITLE
Fix gvariant offsets on 32-bit systems + fix gvariant tests on big endian hosts

### DIFF
--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -4,8 +4,7 @@ use byteorder::{ByteOrder, WriteBytesExt, LE};
 // Used internally for GVariant encoding and decoding.
 //
 // GVariant containers keeps framing offsets at the end and size of these offsets is dependent on
-// the size of the container (which includes offsets themselves.
-
+// the size of the container (which includes offsets themselves).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(usize)]
 pub(crate) enum FramingOffsetSize {

--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -12,7 +12,6 @@ pub(crate) enum FramingOffsetSize {
     U16 = 2,
     U32 = 4,
     U64 = 8,
-    U128 = 16,
 }
 
 impl FramingOffsetSize {
@@ -26,7 +25,7 @@ impl FramingOffsetSize {
 
             offset_size = offset_size
                 .bump_up()
-                .expect("Can't handle container too large for a 128-bit pointer");
+                .expect("Can't handle container too large for a 64-bit pointer");
         }
     }
 
@@ -43,7 +42,6 @@ impl FramingOffsetSize {
             FramingOffsetSize::U16 => writer.write_u16::<LE>(offset as u16),
             FramingOffsetSize::U32 => writer.write_u32::<LE>(offset as u32),
             FramingOffsetSize::U64 => writer.write_u64::<LE>(offset as u64),
-            FramingOffsetSize::U128 => writer.write_u128::<LE>(offset as u128),
         }
         .map_err(|e| Error::InputOutput(e.into()))
     }
@@ -59,7 +57,6 @@ impl FramingOffsetSize {
             FramingOffsetSize::U16 => LE::read_u16(&buffer[end - 2..end]) as usize,
             FramingOffsetSize::U32 => LE::read_u32(&buffer[end - 4..end]) as usize,
             FramingOffsetSize::U64 => LE::read_u64(&buffer[end - 8..end]) as usize,
-            FramingOffsetSize::U128 => LE::read_u128(&buffer[end - 16..end]) as usize,
         }
     }
 
@@ -69,7 +66,6 @@ impl FramingOffsetSize {
             FramingOffsetSize::U16 => std::u16::MAX as usize,
             FramingOffsetSize::U32 => std::u32::MAX as usize,
             FramingOffsetSize::U64 => std::u64::MAX as usize,
-            FramingOffsetSize::U128 => std::u128::MAX as usize,
         }
     }
 
@@ -78,8 +74,7 @@ impl FramingOffsetSize {
             FramingOffsetSize::U8 => Some(FramingOffsetSize::U16),
             FramingOffsetSize::U16 => Some(FramingOffsetSize::U32),
             FramingOffsetSize::U32 => Some(FramingOffsetSize::U64),
-            FramingOffsetSize::U64 => Some(FramingOffsetSize::U128),
-            FramingOffsetSize::U128 => None,
+            FramingOffsetSize::U64 => None,
         }
     }
 }

--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -11,6 +11,7 @@ pub(crate) enum FramingOffsetSize {
     U8 = 1,
     U16 = 2,
     U32 = 4,
+    #[cfg(not(target_pointer_width = "32"))]
     U64 = 8,
 }
 
@@ -41,6 +42,7 @@ impl FramingOffsetSize {
             FramingOffsetSize::U8 => writer.write_u8(offset as u8),
             FramingOffsetSize::U16 => writer.write_u16::<LE>(offset as u16),
             FramingOffsetSize::U32 => writer.write_u32::<LE>(offset as u32),
+            #[cfg(not(target_pointer_width = "32"))]
             FramingOffsetSize::U64 => writer.write_u64::<LE>(offset as u64),
         }
         .map_err(|e| Error::InputOutput(e.into()))
@@ -56,6 +58,7 @@ impl FramingOffsetSize {
             FramingOffsetSize::U8 => buffer[end - 1] as usize,
             FramingOffsetSize::U16 => LE::read_u16(&buffer[end - 2..end]) as usize,
             FramingOffsetSize::U32 => LE::read_u32(&buffer[end - 4..end]) as usize,
+            #[cfg(not(target_pointer_width = "32"))]
             FramingOffsetSize::U64 => LE::read_u64(&buffer[end - 8..end]) as usize,
         }
     }
@@ -65,6 +68,7 @@ impl FramingOffsetSize {
             FramingOffsetSize::U8 => std::u8::MAX as usize,
             FramingOffsetSize::U16 => std::u16::MAX as usize,
             FramingOffsetSize::U32 => std::u32::MAX as usize,
+            #[cfg(not(target_pointer_width = "32"))]
             FramingOffsetSize::U64 => std::u64::MAX as usize,
         }
     }
@@ -73,8 +77,12 @@ impl FramingOffsetSize {
         match self {
             FramingOffsetSize::U8 => Some(FramingOffsetSize::U16),
             FramingOffsetSize::U16 => Some(FramingOffsetSize::U32),
+            #[cfg(not(target_pointer_width = "32"))]
             FramingOffsetSize::U32 => Some(FramingOffsetSize::U64),
+            #[cfg(not(target_pointer_width = "32"))]
             FramingOffsetSize::U64 => None,
+            #[cfg(target_pointer_width = "32")]
+            FramingOffsetSize::U32 => None,
         }
     }
 }
@@ -105,6 +113,7 @@ mod tests {
             FramingOffsetSize::for_bare_container(std::u32::MAX as usize - 12, 3),
             FramingOffsetSize::U32
         );
+        #[cfg(not(target_pointer_width = "32"))]
         assert_eq!(
             FramingOffsetSize::for_bare_container(std::u32::MAX as usize - 11, 3),
             FramingOffsetSize::U64


### PR DESCRIPTION
Fixes #357 and #358.