### PR TITLE
🚑️ zb: Drop signature & fds from fields in MessageHeader -> MessageBuilder conversion

### DIFF
--- a/zbus/src/message_builder.rs
+++ b/zbus/src/message_builder.rs
@@ -17,8 +17,9 @@ use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use crate::{
     utils::padding_for_8_bytes,
     zvariant::{DynamicType, EncodingContext, ObjectPath, Signature},
-    Error, Message, MessageField, MessageFields, MessageFlags, MessageHeader, MessagePrimaryHeader,
-    MessageSequence, MessageType, QuickMessageFields, Result, MAX_MESSAGE_SIZE,
+    Error, Message, MessageField, MessageFieldCode, MessageFields, MessageFlags, MessageHeader,
+    MessagePrimaryHeader, MessageSequence, MessageType, QuickMessageFields, Result,
+    MAX_MESSAGE_SIZE,
 };
 
 #[cfg(unix)]
@@ -343,7 +344,12 @@ impl<'a> MessageBuilder<'a> {
 }
 
 impl<'m> From<MessageHeader<'m>> for MessageBuilder<'m> {
-    fn from(header: MessageHeader<'m>) -> Self {
+    fn from(mut header: MessageHeader<'m>) -> Self {
+        // Signature and Fds are added by body* methods.
+        let fields = header.fields_mut();
+        fields.remove(MessageFieldCode::Signature);
+        fields.remove(MessageFieldCode::UnixFDs);
+
         Self { header }
     }
 }

--- a/zbus/src/message_fields.rs
+++ b/zbus/src/message_fields.rs
@@ -42,6 +42,7 @@ impl<'m> MessageFields<'m> {
         self.add(field);
         None
     }
+
     /// Returns a slice with all the [`MessageField`] in the message.
     ///
     /// [`MessageField`]: enum.MessageField.html

--- a/zbus/src/message_fields.rs
+++ b/zbus/src/message_fields.rs
@@ -67,6 +67,20 @@ impl<'m> MessageFields<'m> {
     pub fn into_field(self, code: MessageFieldCode) -> Option<MessageField<'m>> {
         self.0.into_iter().find(|f| f.code() == code)
     }
+
+    /// Remove the field matching the `code`.
+    ///
+    /// Returns `true` if a field was found and removed, `false` otherwise.
+    pub(crate) fn remove(&mut self, code: MessageFieldCode) -> bool {
+        match self.0.iter().enumerate().find(|(_, f)| f.code() == code) {
+            Some((i, _)) => {
+                self.0.remove(i);
+
+                true
+            }
+            None => false,
+        }
+    }
 }
 
 /// A byte range of a field in a Message, used in [`QuickMessageFields`].


### PR DESCRIPTION
These fields are dependent on the body and that's specified later.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
