### PR TITLE
🩹 🚸 zv: Equal `Signature`s irrespective of D-Bus marshalled state

### DIFF
--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -96,7 +96,7 @@ impl<'b> std::ops::Deref for Bytes<'b> {
 ///
 /// [identifies]: https://dbus.freedesktop.org/doc/dbus-specification.html#type-system
 /// [`slice`]: #method.slice
-#[derive(Eq, Hash, Clone)]
+#[derive(Hash, Clone)]
 pub struct Signature<'a> {
     bytes: Bytes<'a>,
     pos: usize,
@@ -446,6 +446,10 @@ impl<'a> PartialEq<&str> for Signature<'a> {
         self.as_bytes() == other.as_bytes()
     }
 }
+
+// According to the docs, `Eq` derive should only be used on structs if all its fields are
+// are `Eq`. Hence the manual implementation.
+impl Eq for Signature<'_> {}
 
 impl<'a> Display for Signature<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -403,9 +403,35 @@ impl<'a> std::ops::Deref for Signature<'a> {
     }
 }
 
+/// Checks whether the string slice has balanced parentheses.
+fn has_balanced_parentheses(signature_str: &str) -> bool {
+    signature_str.chars().fold(0, |count, ch| match ch {
+        '(' => count + 1,
+        ')' if count != 0 => count - 1,
+        _ => count,
+    }) == 0
+}
+
+/// Determines whether the signature has outer parentheses and if so, return the
+/// string slice without those parentheses.
+fn without_outer_parentheses<'a, 'b>(sig: &'a Signature<'b>) -> &'a str
+where
+    'b: 'a,
+{
+    let sig_str = sig.as_str();
+
+    if let Some(subslice) = sig_str.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
+        if has_balanced_parentheses(subslice) {
+            return subslice;
+        }
+    }
+    sig_str
+}
+
+/// Evaluate equality of two signatures, ignoring outer parentheses if needed.
 impl<'a, 'b> PartialEq<Signature<'a>> for Signature<'b> {
     fn eq(&self, other: &Signature<'_>) -> bool {
-        self.as_bytes() == other.as_bytes()
+        without_outer_parentheses(self) == without_outer_parentheses(other)
     }
 }
 

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -556,4 +556,19 @@ mod tests {
         assert_eq!(slice, "t");
         assert_eq!(slice.slice(1..), "");
     }
+
+    #[test]
+    fn signature_equality() {
+        let sig_a = Signature::from_str_unchecked("(asta{sv})");
+        let sig_b = Signature::from_str_unchecked("asta{sv}");
+        assert_eq!(sig_a, sig_b);
+
+        let sig_a = Signature::from_str_unchecked("((so)ii(uu))");
+        let sig_b = Signature::from_str_unchecked("(so)ii(uu)");
+        assert_eq!(sig_a, sig_b);
+
+        let sig_a = Signature::from_str_unchecked("(so)i");
+        let sig_b = Signature::from_str_unchecked("(so)u");
+        assert_ne!(sig_a, sig_b);
+    }
 }


### PR DESCRIPTION
This adjusts the `PartialEq` impls to evaluate equality irrespective of
of marshalling of the type.

Two signatures representing the same type can differ as a result of
D-Bus marshalling. D-Bus marshalling will omit outer parentheses from body
singatures.

Consider a `MyType { a: i32, b: i32}`:

`MyType::signature()` returns a "(ii)" `Signature` whereas
`Message::body_signature()` with `MyType` as body, would return
a "ii" `Signature`, which may lead to unexpected inequality of `Signature`s.

Note: `PartialEq` on `Signature` accounts for marshalling only.
One can construct- or deserialize into deeper nested structs or tuples than
than the signature describes but at that point the divergence is expected.
