### PR TITLE
zb: add arg0ns to match rule, deprecate arg0namespace

### DIFF
--- a/zbus/src/match_rule.rs
+++ b/zbus/src/match_rule.rs
@@ -284,8 +284,10 @@ impl<'m> MatchRule<'m> {
         // The arg0 namespace.
         if let Some(arg0_ns) = self.arg0ns() {
             if let Ok(arg0) = msg.body_unchecked::<BusName<'_>>() {
-                if !arg0.starts_with(arg0_ns.as_str()) {
-                    return Ok(false);
+                match arg0.strip_prefix(arg0_ns.as_str()) {
+                    None => return Ok(false),
+                    Some(s) if !s.is_empty() && !s.starts_with('.') => return Ok(false),
+                    _ => (),
                 }
             } else {
                 return Ok(false);

--- a/zbus/src/match_rule.rs
+++ b/zbus/src/match_rule.rs
@@ -93,6 +93,7 @@ pub struct MatchRule<'m> {
     pub(crate) args: Vec<(u8, Str<'m>)>,
     pub(crate) arg_paths: Vec<(u8, ObjectPath<'m>)>,
     pub(crate) arg0namespace: Option<InterfaceName<'m>>,
+    pub(crate) arg0ns: Option<Str<'m>>,
 }
 
 assert_impl_all!(MatchRule<'_>: Send, Sync, Unpin);
@@ -153,6 +154,11 @@ impl<'m> MatchRule<'m> {
         self.arg0namespace.as_ref()
     }
 
+    /// Match messages whose first argument is within the specified namespace.
+    pub fn arg0ns(&self) -> Option<&Str<'m>> {
+        self.arg0ns.as_ref()
+    }
+
     /// Creates an owned clone of `self`.
     pub fn to_owned(&self) -> MatchRule<'static> {
         MatchRule {
@@ -169,6 +175,7 @@ impl<'m> MatchRule<'m> {
                 .map(|(i, p)| (*i, p.to_owned()))
                 .collect(),
             arg0namespace: self.arg0namespace.as_ref().map(|a| a.to_owned()),
+            arg0ns: self.arg0ns.as_ref().map(|a| a.to_owned()),
         }
     }
 
@@ -192,6 +199,7 @@ impl<'m> MatchRule<'m> {
                 .map(|(i, p)| (i, p.into_owned()))
                 .collect(),
             arg0namespace: self.arg0namespace.map(|a| a.into_owned()),
+            arg0ns: self.arg0ns.map(|a| a.into_owned()),
         }
     }
 
@@ -276,8 +284,8 @@ impl<'m> MatchRule<'m> {
         }
 
         // The arg0 namespace.
-        if let Some(arg0_ns) = self.arg0namespace() {
-            if let Ok(arg0) = msg.body_unchecked::<InterfaceName<'_>>() {
+        if let Some(arg0_ns) = self.arg0ns() {
+            if let Ok(arg0) = msg.body_unchecked::<BusName<'_>>() {
                 if !arg0.starts_with(arg0_ns.as_str()) {
                     return Ok(false);
                 }
@@ -362,7 +370,7 @@ impl ToString for MatchRule<'_> {
         for (i, arg_path) in self.arg_paths() {
             add_match_rule_string_component(&mut s, &format!("arg{i}path"), arg_path);
         }
-        if let Some(arg0namespace) = self.arg0namespace() {
+        if let Some(arg0namespace) = self.arg0ns() {
             add_match_rule_string_component(&mut s, "arg0namespace", arg0namespace)
         }
 
@@ -417,7 +425,7 @@ impl<'m> TryFrom<&'m str> for MatchRule<'m> {
                 "path" => builder.path(value)?,
                 "path_namespace" => builder.path_namespace(value)?,
                 "destination" => builder.destination(value)?,
-                "arg0namespace" => builder.arg0namespace(value)?,
+                "arg0namespace" => builder.arg0ns(value)?,
                 key if key.starts_with("arg") => {
                     if let Some(trailing_idx) = key.find("path") {
                         let idx = key[3..trailing_idx]

--- a/zbus/src/match_rule.rs
+++ b/zbus/src/match_rule.rs
@@ -146,10 +146,8 @@ impl<'m> MatchRule<'m> {
 
     /// Match messages whose first argument is within the specified namespace.
     ///
-    /// Note that while the spec allows this to be any string that's a valid bus or interface name
-    /// except that it can lack `.`, we only allow valid interface names. The reason is not only to
-    /// keep things simple and type safe at the same time but also for the fact that use cases of
-    /// only matching on the first component of a bus or interface name are unheard of.
+    /// This function is deprecated because the choice of `InterfaceName` was too restrictive.
+    #[deprecated = "use arg0ns instead"]
     pub fn arg0namespace(&self) -> Option<&InterfaceName<'_>> {
         self.arg0namespace.as_ref()
     }

--- a/zbus/src/match_rule_builder.rs
+++ b/zbus/src/match_rule_builder.rs
@@ -13,6 +13,7 @@ const MAX_ARGS: u8 = 64;
 /// Builder for [`MatchRule`].
 ///
 /// This is created by [`MatchRule::builder`].
+#[derive(Debug)]
 pub struct MatchRuleBuilder<'m>(MatchRule<'m>);
 
 assert_impl_all!(MatchRuleBuilder<'_>: Send, Sync, Unpin);

--- a/zbus/src/match_rule_builder.rs
+++ b/zbus/src/match_rule_builder.rs
@@ -201,6 +201,9 @@ impl<'m> MatchRuleBuilder<'m> {
     }
 
     /// Set 0th argument's namespace.
+    ///
+    /// This function is deprecated because the choice of `InterfaceName` was too restrictive.
+    #[deprecated = "use arg0ns instead"]
     pub fn arg0namespace<I>(mut self, namespace: I) -> Result<Self>
     where
         I: TryInto<InterfaceName<'m>>,


### PR DESCRIPTION
arg0namespace has an overly restrictive type (InterfaceName), which disallows valid values (e.g. those containing '-' or single-element names such as 'org').

Further more, a MatchRule with arg0namespace previously would not match a message whose arg0 is not a valid InterfaceName (even if it is a valid BusName).

fixes #382