### PR TITLE
Add safe-io feature

### DIFF
--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -8,7 +8,7 @@ use std::{
 use event_listener::{Event, EventListener};
 
 #[cfg(unix)]
-use crate::OwnedFd;
+use crate::Fd;
 use crate::{
     message::{
         header::{MAX_MESSAGE_SIZE, MIN_MESSAGE_SIZE},
@@ -37,7 +37,7 @@ pub struct Connection<S> {
     event: Event,
     raw_in_buffer: Vec<u8>,
     #[cfg(unix)]
-    raw_in_fds: Vec<OwnedFd>,
+    raw_in_fds: Vec<Fd>,
     raw_in_pos: usize,
     out_pos: usize,
     out_msgs: VecDeque<Arc<Message>>,

--- a/zbus/src/connection/raw/socket.rs
+++ b/zbus/src/connection/raw/socket.rs
@@ -31,10 +31,10 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 
 #[cfg(unix)]
-use crate::{utils::FDS_MAX, OwnedFd};
+use crate::{utils::FDS_MAX, Fd};
 
 #[cfg(unix)]
-fn fd_recvmsg(fd: RawFd, buffer: &mut [u8]) -> io::Result<(usize, Vec<OwnedFd>)> {
+fn fd_recvmsg(fd: RawFd, buffer: &mut [u8]) -> io::Result<(usize, Vec<Fd>)> {
     let mut iov = [IoSliceMut::new(buffer)];
     let mut cmsgspace = cmsg_space!([RawFd; FDS_MAX]);
 
@@ -52,7 +52,7 @@ fn fd_recvmsg(fd: RawFd, buffer: &mut [u8]) -> io::Result<(usize, Vec<OwnedFd>)>
             continue;
         }
         if let ControlMessageOwned::ScmRights(fd) = cmsg {
-            fds.extend(fd.iter().map(|&f| unsafe { OwnedFd::from_raw_fd(f) }));
+            fds.extend(fd.iter().map(|&f| unsafe { Fd::from_raw_fd(f) }));
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -153,7 +153,7 @@ fn send_zero_byte(fd: &impl AsRawFd) -> io::Result<usize> {
 }
 
 #[cfg(unix)]
-type PollRecvmsg = Poll<io::Result<(usize, Vec<OwnedFd>)>>;
+type PollRecvmsg = Poll<io::Result<(usize, Vec<Fd>)>>;
 
 #[cfg(not(unix))]
 type PollRecvmsg = Poll<io::Result<usize>>;

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -192,7 +192,7 @@ pub use zbus_names as names;
 pub use zvariant;
 
 #[cfg(unix)]
-use zvariant::OwnedFd;
+use zvariant::Fd;
 
 #[cfg(test)]
 mod tests {
@@ -201,10 +201,7 @@ mod tests {
         sync::{mpsc::channel, Arc, Condvar, Mutex},
     };
     #[cfg(unix)]
-    use std::{
-        fs::File,
-        os::unix::io::{AsRawFd, FromRawFd},
-    };
+    use std::{fs::File, os::unix::io::AsRawFd};
 
     use crate::utils::block_on;
     use enumflags2::BitFlags;
@@ -336,7 +333,7 @@ mod tests {
         let fd: Fd = reply.body().unwrap();
         let _fds = reply.take_fds();
         assert!(fd.as_raw_fd() >= 0);
-        let f = unsafe { File::from_raw_fd(fd.as_raw_fd()) };
+        let f = File::from(std::os::fd::OwnedFd::from(fd));
         f.metadata().unwrap();
     }
 

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -168,12 +168,7 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
             u64::SIGNATURE_CHAR => "u64".into(),
             f64::SIGNATURE_CHAR => "f64".into(),
             // xmlgen accepts 'h' on Windows, only for code generation
-            'h' => (if input {
-                "zbus::zvariant::Fd"
-            } else {
-                "zbus::zvariant::OwnedFd"
-            })
-            .into(),
+            'h' => "zbus::zvariant::Fd".into(),
             <&str>::SIGNATURE_CHAR => (if input || as_ref { "&str" } else { "String" }).into(),
             ObjectPath::SIGNATURE_CHAR => (if input {
                 if as_ref {

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -30,7 +30,6 @@ enumflags2 = { version = "0.7.7", features = ["serde"], optional = true }
 zvariant_derive = { version = "=4.0.0", path = "../zvariant_derive" }
 serde_bytes = { version = "0.11", optional = true }
 static_assertions = "1.1.0"
-libc = "0.2.137"
 uuid = { version = "1.2.1", features = ["serde"], optional = true }
 url = { version = "2.3.1", features = ["serde"], optional = true }
 time = { version = "0.3.16", features = ["serde"], optional = true }

--- a/zvariant/src/de.rs
+++ b/zvariant/src/de.rs
@@ -31,13 +31,14 @@ use crate::Fd;
 /// # Examples
 ///
 /// ```
+/// use std::os::unix::io::FromRawFd;
 /// use zvariant::{to_bytes_fds, from_slice_fds};
 /// use zvariant::{EncodingContext, Fd};
 ///
 /// let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
-/// let (encoded, fds) = to_bytes_fds(ctxt, &Fd::from(42)).unwrap();
-/// let decoded: Fd = from_slice_fds(&encoded, Some(&fds), ctxt).unwrap().0;
-/// assert_eq!(decoded, Fd::from(42));
+/// let (encoded, fds) = to_bytes_fds(ctxt, &Fd::from_raw_fd(42)).unwrap();
+/// let decoded: Fd = from_slice_fds(&encoded, Some(&fds), ctxt).unwrap();
+/// assert_eq!(decoded, unsafe { Fd::from_raw_fd(42) });
 /// ```
 ///
 /// # Return value

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -1,14 +1,16 @@
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 use static_assertions::assert_impl_all;
-use std::os::unix::io;
+use std::{
+    cmp::PartialEq,
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+    sync::Arc,
+};
 
 use crate::{Basic, EncodingFormat, Signature, Type};
 
-/// A [`RawFd`](https://doc.rust-lang.org/std/os/unix/io/type.RawFd.html) wrapper.
+/// A [`OwnedFd`](https://doc.rust-lang.org/std/os/fd/struct.OwnedFd.html) wrapper.
 ///
-/// See also `OwnedFd` if you need a wrapper that takes ownership of the file.
-///
-/// We wrap the `RawFd` type so that we can implement [`Serialize`] and [`Deserialize`] for it.
+/// We wrap the `OwnedFd` type so that we can implement [`Serialize`] and [`Deserialize`] for it.
 /// File descriptors are serialized in a special way and you need to use specific [serializer] and
 /// [deserializer] API when file descriptors are or could be involved.
 ///
@@ -16,140 +18,117 @@ use crate::{Basic, EncodingFormat, Signature, Type};
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
 /// [deserializer]: fn.from_slice_fds.html
 /// [serializer]: fn.to_bytes_fds.html
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Fd(io::RawFd);
+#[derive(Debug)]
+pub struct Fd(OwnedFd);
 
-macro_rules! fd_impl {
-    ($i:ident) => {
-        assert_impl_all!($i: Send, Sync, Unpin);
+assert_impl_all!(Fd: Send, Sync, Unpin);
 
-        impl Basic for $i {
-            const SIGNATURE_CHAR: char = 'h';
-            const SIGNATURE_STR: &'static str = "h";
+impl Basic for Fd {
+    const SIGNATURE_CHAR: char = 'h';
+    const SIGNATURE_STR: &'static str = "h";
 
-            fn alignment(format: EncodingFormat) -> usize {
-                u32::alignment(format)
-            }
-        }
-
-        impl Type for $i {
-            fn signature() -> Signature<'static> {
-                Signature::from_static_str_unchecked(Self::SIGNATURE_STR)
-            }
-        }
-    };
-}
-
-fd_impl!(Fd);
-
-impl Serialize for Fd {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_i32(self.0)
+    fn alignment(format: EncodingFormat) -> usize {
+        u32::alignment(format)
     }
 }
 
-impl<'de> Deserialize<'de> for Fd {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Fd(i32::deserialize(deserializer)?))
+impl Type for Fd {
+    fn signature() -> Signature<'static> {
+        Signature::from_static_str_unchecked(Self::SIGNATURE_STR)
     }
 }
 
-impl From<io::RawFd> for Fd {
-    fn from(value: io::RawFd) -> Self {
-        Self(value)
+impl<T: Into<OwnedFd>> From<T> for Fd {
+    fn from(fd: T) -> Self {
+        Self(fd.into())
     }
 }
 
-impl<T> From<&T> for Fd
-where
-    T: io::AsRawFd,
-{
-    fn from(t: &T) -> Self {
-        Self(t.as_raw_fd())
+impl FromRawFd for Fd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self(OwnedFd::from_raw_fd(fd))
     }
 }
 
-impl io::AsRawFd for Fd {
-    fn as_raw_fd(&self) -> io::RawFd {
+impl AsRawFd for Fd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl AsFd for Fd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+#[derive(Debug)]
+pub struct FdWrapper(Arc<Fd>);
+
+assert_impl_all!(FdWrapper: Send, Sync, Unpin);
+
+impl FdWrapper {
+    pub(crate) fn new(fd: Fd) -> Self {
+        Self(Arc::new(fd))
+    }
+
+    pub fn into_inner(self) -> Arc<Fd> {
         self.0
     }
 }
 
-impl std::fmt::Display for Fd {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+impl Clone for FdWrapper {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
     }
 }
 
-/// An owned [`RawFd`](https://doc.rust-lang.org/std/os/unix/io/type.RawFd.html) wrapper.
-///
-/// See also [`Fd`]. This type owns the file and will close it on drop. On deserialize, it will
-/// duplicate the file descriptor.
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct OwnedFd {
-    inner: io::RawFd,
-}
-
-impl Drop for OwnedFd {
-    fn drop(&mut self) {
-        unsafe {
-            libc::close(self.inner);
-        }
+impl PartialEq for FdWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_raw_fd() == other.0.as_raw_fd()
     }
 }
 
-fd_impl!(OwnedFd);
-
-impl Serialize for OwnedFd {
+impl Serialize for FdWrapper {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_i32(self.inner)
+        let dupped = self.0 .0.try_clone().map_err(Error::custom)?;
+        let raw_fd = dupped.into_raw_fd();
+        serializer.serialize_i32(raw_fd)
     }
 }
 
-impl<'de> Deserialize<'de> for OwnedFd {
+impl<'de> Deserialize<'de> for FdWrapper {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let fd = unsafe { libc::dup(i32::deserialize(deserializer)?) };
-        if fd < 0 {
-            return Err(D::Error::custom(std::io::Error::last_os_error()));
-        }
-        Ok(OwnedFd { inner: fd })
+        let raw_fd = RawFd::deserialize(deserializer)?;
+        let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+        Ok(Self(Arc::new(Fd::from(owned_fd))))
     }
 }
 
-impl io::FromRawFd for OwnedFd {
-    unsafe fn from_raw_fd(fd: io::RawFd) -> Self {
-        Self { inner: fd }
+impl Basic for FdWrapper {
+    const SIGNATURE_CHAR: char = 'h';
+    const SIGNATURE_STR: &'static str = "h";
+
+    fn alignment(format: EncodingFormat) -> usize {
+        u32::alignment(format)
     }
 }
 
-impl io::AsRawFd for OwnedFd {
-    fn as_raw_fd(&self) -> io::RawFd {
-        self.inner
+impl Type for FdWrapper {
+    fn signature() -> Signature<'static> {
+        Signature::from_static_str_unchecked(Self::SIGNATURE_STR)
     }
 }
 
-impl io::IntoRawFd for OwnedFd {
-    fn into_raw_fd(self) -> io::RawFd {
-        let fd = self.inner;
-        std::mem::forget(self);
-        fd
-    }
-}
-
-impl std::fmt::Display for OwnedFd {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
+impl AsRawFd for FdWrapper {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
     }
 }

--- a/zvariant/src/from_value.rs
+++ b/zvariant/src/from_value.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[cfg(unix)]
-use crate::Fd;
+use crate::FdWrapper;
 
 use std::{collections::HashMap, hash::BuildHasher};
 
@@ -76,7 +76,7 @@ value_try_from_all!(I64, i64);
 value_try_from_all!(U64, u64);
 value_try_from_all!(F64, f64);
 #[cfg(unix)]
-value_try_from_all!(Fd, Fd);
+value_try_from_all!(Fd, FdWrapper);
 
 value_try_from_all!(Str, Str<'a>);
 value_try_from_all!(Signature, Signature<'a>);

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -5,7 +5,7 @@ use crate::Maybe;
 use crate::{Array, Dict, NoneValue, ObjectPath, Optional, Signature, Str, Structure, Type, Value};
 
 #[cfg(unix)]
-use crate::Fd;
+use crate::FdWrapper;
 
 //
 // Conversions from encodable types to `Value`
@@ -38,7 +38,7 @@ into_value!(i64, I64);
 into_value!(f32, F64);
 into_value!(f64, F64);
 #[cfg(unix)]
-into_value!(Fd, Fd);
+into_value!(FdWrapper, Fd);
 
 into_value!(&'a str, Str);
 into_value!(Str<'a>, Str);

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -359,9 +359,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fd_value() {
-        basic_type_test!(LE, DBus, Fd::from(42), 4, Fd, 4, Fd, 8);
+        let file = std::fs::File::create("foo.txt").unwrap();
+        let fd = Fd::from(file);
+        basic_type_test!(LE, DBus, fd, 4, Fd, 4, Fd, 8);
         #[cfg(feature = "gvariant")]
-        basic_type_test!(LE, GVariant, Fd::from(42), 4, Fd, 4, Fd, 6);
+        basic_type_test!(LE, GVariant, fd, 4, Fd, 4, Fd, 6);
     }
 
     #[test]
@@ -1535,7 +1537,7 @@ mod tests {
         #[cfg(unix)]
         {
             let stdout = std::io::stdout();
-            let l = crate::serialized_size_fds(ctxt, &Fd::from(&stdout)).unwrap();
+            let l = crate::serialized_size_fds(ctxt, &Fd::from(stdout)).unwrap();
             assert_eq!(l, (4, 1));
         }
 

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[cfg(unix)]
-use crate::Fd;
+use crate::FdWrapper;
 
 #[cfg(feature = "gvariant")]
 use crate::Maybe;
@@ -77,7 +77,7 @@ ov_try_from!(Maybe<'static>);
 ov_try_from!(Str<'static>);
 ov_try_from!(Structure<'static>);
 #[cfg(unix)]
-ov_try_from!(Fd);
+ov_try_from!(FdWrapper);
 
 ov_try_from_ref!(u8);
 ov_try_from_ref!(bool);
@@ -97,8 +97,6 @@ ov_try_from_ref!(&'a Str<'a>);
 ov_try_from_ref!(&'a Structure<'a>);
 #[cfg(feature = "gvariant")]
 ov_try_from_ref!(&'a Maybe<'a>);
-#[cfg(unix)]
-ov_try_from_ref!(Fd);
 
 impl<'a, T> TryFrom<OwnedValue> for Vec<T>
 where
@@ -223,7 +221,7 @@ to_value!(Signature<'a>);
 to_value!(Structure<'a>);
 to_value!(ObjectPath<'a>);
 #[cfg(unix)]
-to_value!(Fd);
+to_value!(FdWrapper);
 
 impl From<OwnedValue> for Value<'static> {
     fn from(v: OwnedValue) -> Value<'static> {


### PR DESCRIPTION
Adds a new `safe-io` feature that adds types `zvariant::OwnedFd` and `zvariant::BorrowedFd<'a>`. Introduced a big api break so it is gated behind a feature flag.

Fixes: https://github.com/dbus2/zbus/issues/286