### PR TITLE
Monitoring proxy improvements

### DIFF
--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -390,7 +390,11 @@ macro_rules! gen_monitoring_proxy {
         trait Monitoring {
             /// Converts the connection into a monitor connection which can be used as a
             /// debugging/monitoring tool.
-            fn become_monitor(&self, n1: &[&str], n2: u32) -> Result<()>;
+            fn become_monitor(
+                &self,
+                match_rules: &[crate::MatchRule<'_>],
+                flags: u32,
+            ) -> Result<()>;
         }
     };
 }

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -391,7 +391,7 @@ macro_rules! gen_monitoring_proxy {
             /// Converts the connection into a monitor connection which can be used as a
             /// debugging/monitoring tool.
             fn become_monitor(
-                &self,
+                self,
                 match_rules: &[crate::MatchRule<'_>],
                 flags: u32,
             ) -> Result<()>;

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -390,6 +390,24 @@ macro_rules! gen_monitoring_proxy {
         trait Monitoring {
             /// Converts the connection into a monitor connection which can be used as a
             /// debugging/monitoring tool.
+            ///
+            /// After this call successfully returns, sending any messages on the bus will result
+            /// in an error. This is why this method takes ownership of `self`, since there is not
+            /// much use for the proxy anymore. It is highly recommended to convert the underlying
+            /// [`Connection`] to a [`MessageStream`] and iterate over messages from the stream,
+            /// after this call.
+            ///
+            /// See [the spec] for details on all the implications and caveats.
+            /// 
+            /// # Arguments
+            ///
+            /// * `match_rules` - A list of match rules describing the messages you want to receive.
+            ///   An empty list means you are want to receive all messages going through the bus.
+            /// * `flags` - This argument is currently unused by the bus. Just pass a `0`.
+            ///
+            /// [the spec]: https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-become-monitor
+            /// [`Connection`]: https://docs.rs/zbus/3/zbus/struct.Connection.html
+            /// [`MessageStream`]: https://docs.rs/zbus/3/zbus/struct.MessageStream.html
             fn become_monitor(
                 self,
                 match_rules: &[crate::MatchRule<'_>],


### PR DESCRIPTION
This proxy was obviously added in a hurry, w/o much thought given but we also didn't have the `MatchRule` type then to use.

Since 2 commits here are breaking API, I will contact the [only](https://github.com/azymohliad/watchmate/blob/3fb3fa89fc76a783f46abdc5f07e9a59ed23ac1f/infinitime/src/freedesktop/notifications.rs#L32) [2](https://github.com/tau-OS/kiri-desktop/blob/97b86e48731e30ba14572b16aec864cdbfa0a171/d5/src/notify.rs#L102) users of this API I could find on Github and see if they'd mind us breaking API for this.