### PR TITLE
🚸 zb: Specify object path for Monitoring & Debug.Stats proxies

### DIFF
--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -384,6 +384,7 @@ macro_rules! gen_monitoring_proxy {
         #[dbus_proxy(
             interface = "org.freedesktop.DBus.Monitoring",
             default_service = "org.freedesktop.DBus",
+            default_path = "/org/freedesktop/DBus",
             assume_defaults = true,
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
@@ -428,6 +429,7 @@ macro_rules! gen_stats_proxy {
         #[dbus_proxy(
             interface = "org.freedesktop.DBus.Debug.Stats",
             default_service = "org.freedesktop.DBus",
+            default_path = "/org/freedesktop/DBus",
             assume_defaults = true,
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,


### PR DESCRIPTION
The object path defaults to be based on the interface name otherwise and that's not the expected bhaviour.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
