### PR TITLE
⚡  zvariant, zbus: use borrowed clone if possible

### DIFF
--- a/zbus/src/message_field.rs
+++ b/zbus/src/message_field.rs
@@ -130,7 +130,7 @@ impl<'f> Serialize for MessageField<'f> {
         S: Serializer,
     {
         let tuple: (MessageFieldCode, Value<'_>) = match self {
-            MessageField::Path(value) => (MessageFieldCode::Path, value.clone().into()),
+            MessageField::Path(value) => (MessageFieldCode::Path, value.as_ref().into()),
             MessageField::Interface(value) => (MessageFieldCode::Interface, value.as_str().into()),
             MessageField::Member(value) => (MessageFieldCode::Member, value.as_str().into()),
             MessageField::ErrorName(value) => (MessageFieldCode::ErrorName, value.as_str().into()),
@@ -139,7 +139,7 @@ impl<'f> Serialize for MessageField<'f> {
                 (MessageFieldCode::Destination, value.as_str().into())
             }
             MessageField::Sender(value) => (MessageFieldCode::Sender, value.as_str().into()),
-            MessageField::Signature(value) => (MessageFieldCode::Signature, value.clone().into()),
+            MessageField::Signature(value) => (MessageFieldCode::Signature, value.as_ref().into()),
             MessageField::UnixFDs(value) => (MessageFieldCode::UnixFDs, (*value).into()),
             // This is a programmer error
             MessageField::Invalid => panic!("Attempt to serialize invalid MessageField"),

--- a/zvariant/src/from_value.rs
+++ b/zvariant/src/from_value.rs
@@ -89,7 +89,14 @@ value_try_from_all!(Maybe, Maybe<'a>);
 
 value_try_from!(Str, String);
 value_try_from_ref!(Str, str);
-value_try_from_ref_clone!(Str, String);
+
+impl<'a> TryFrom<&'a Value<'a>> for String {
+    type Error = Error;
+
+    fn try_from(value: &'a Value<'_>) -> Result<Self, Self::Error> {
+        Ok(<&str>::try_from(value)?.into())
+    }
+}
 
 impl<'a, T> TryFrom<Value<'a>> for Vec<T>
 where

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -35,6 +35,15 @@ impl<'b> Bytes<'b> {
     fn owned(bytes: Vec<u8>) -> Self {
         Self::Owned(bytes.into())
     }
+
+    /// A borrowed clone (this never allocates, unlike clone).
+    fn as_ref(&self) -> Bytes<'_> {
+        match &self {
+            Bytes::Static(s) => Bytes::Static(s),
+            Bytes::Borrowed(s) => Bytes::Borrowed(s),
+            Bytes::Owned(s) => Bytes::Borrowed(s),
+        }
+    }
 }
 
 impl<'b> std::ops::Deref for Bytes<'b> {
@@ -102,6 +111,15 @@ impl<'a> Signature<'a> {
     /// The signature bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[self.pos..self.end]
+    }
+
+    /// A borrowed clone (this never allocates, unlike clone).
+    pub fn as_ref(&self) -> Signature<'_> {
+        Signature {
+            bytes: self.bytes.as_ref(),
+            pos: self.pos,
+            end: self.end,
+        }
     }
 
     /// Create a new Signature from given bytes.

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -248,13 +248,13 @@ impl<'a> Default for Structure<'a> {
 
 impl<'a> DynamicType for Structure<'a> {
     fn dynamic_signature(&self) -> Signature<'_> {
-        self.signature.clone()
+        self.signature.as_ref()
     }
 }
 
 impl<'a> DynamicType for StructureSeed<'a> {
     fn dynamic_signature(&self) -> Signature<'_> {
-        self.0.clone()
+        self.0.as_ref()
     }
 }
 
@@ -274,7 +274,7 @@ impl<'a> DynamicDeserialize<'a> for Structure<'a> {
         }
 
         // The signature might be something like "(i)u(i)" - we need to parse it to check.
-        let mut parser = SignatureParser::new(signature.clone());
+        let mut parser = SignatureParser::new(signature.as_ref());
         parser.parse_next_signature()?;
         if !parser.done() {
             // more than one element - we must wrap it

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -114,7 +114,7 @@ where
             return Ok(PhantomData);
         }
 
-        let mut signature = original.clone();
+        let mut signature = original.as_ref();
         while expected.len() < signature.len()
             && signature.starts_with(STRUCT_SIG_START_CHAR)
             && signature.ends_with(STRUCT_SIG_END_CHAR)

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -218,11 +218,11 @@ impl<'a> Value<'a> {
             Value::Value(_) => Signature::from_static_str_unchecked("v"),
 
             // Container types
-            Value::Array(value) => value.full_signature().clone(),
-            Value::Dict(value) => value.full_signature().clone(),
-            Value::Structure(value) => value.full_signature().clone(),
+            Value::Array(value) => value.full_signature().as_ref(),
+            Value::Dict(value) => value.full_signature().as_ref(),
+            Value::Structure(value) => value.full_signature().as_ref(),
             #[cfg(feature = "gvariant")]
-            Value::Maybe(value) => value.full_signature().clone(),
+            Value::Maybe(value) => value.full_signature().as_ref(),
 
             #[cfg(unix)]
             Value::Fd(_) => Fd::signature(),
@@ -584,7 +584,7 @@ impl<'de> SignatureSeed<'de> {
         let mut builder = StructureBuilder::new();
         while i < signature_end {
             let fields_signature = self.signature.slice(i..signature_end);
-            let parser = SignatureParser::new(fields_signature.clone());
+            let parser = SignatureParser::new(fields_signature.as_ref());
             let len = parser.next_signature().map_err(Error::custom)?.len();
             let field_signature = fields_signature.slice(0..len);
             i += field_signature.len();


### PR DESCRIPTION
This PR implements `Signature::as_ref()` to get a borrowed clone of a `Signature`. The code is a copy of `Str::as_ref()`.
  
Even though cloning an `Arc` is cheap, it's not exactly for free. An atomic increment has some inherent overhead, and `Arc::clone()` also `panic!()`s if there are excessively many strong references to an `Arc`. For every `panic!()` some code to unwind the stack has to be generated, which hurts cache locality, and bloats the generated code.
