### PR TITLE
➖ zvariant: remove libc dependency

### DIFF
--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -30,7 +30,6 @@ enumflags2 = { version = "0.7.7", features = ["serde"], optional = true }
 zvariant_derive = { version = "=3.15.0", path = "../zvariant_derive" }
 serde_bytes = { version = "0.11", optional = true }
 static_assertions = "1.1.0"
-libc = "0.2.137"
 uuid = { version = "1.2.1", features = ["serde"], optional = true }
 url = { version = "2.3.1", features = ["serde"], optional = true }
 time = { version = "0.3.16", features = ["serde"], optional = true }

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -47,7 +47,7 @@ impl Serialize for Fd {
     where
         S: Serializer,
     {
-        serializer.serialize_i32(self.0)
+        self.as_raw_fd().serialize(serializer)
     }
 }
 
@@ -56,7 +56,7 @@ impl<'de> Deserialize<'de> for Fd {
     where
         D: Deserializer<'de>,
     {
-        Ok(Fd(i32::deserialize(deserializer)?))
+        Ok(Fd(io::RawFd::deserialize(deserializer)?))
     }
 }
 
@@ -120,7 +120,7 @@ impl Serialize for OwnedFd {
     where
         S: Serializer,
     {
-        serializer.serialize_i32(self.as_raw_fd())
+        self.as_raw_fd().serialize(serializer)
     }
 }
 
@@ -129,7 +129,7 @@ impl<'de> Deserialize<'de> for OwnedFd {
     where
         D: Deserializer<'de>,
     {
-        let fd = i32::deserialize(deserializer)?;
+        let fd = io::RawFd::deserialize(deserializer)?;
         let fd = unsafe { io::BorrowedFd::borrow_raw(fd) };
         let fd = fd.try_clone_to_owned().map_err(D::Error::custom)?;
         Ok(OwnedFd { inner: fd })


### PR DESCRIPTION
This PR implements `OwnedFd` using the built-in `std::os::fd::OwnedFd` without the use of `libc::close()` or `dup()`. `std::os::fd::OwnedFd` is only stable since rust 1.63, but zbus' MSRV is 1.64 now.

Also I don't think there is a need to assume that `RawFd` is an `i32`.