### PR TITLE
🚸 zv: Make signature parameter generic

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zbus"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "API for D-Bus communication"

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -29,7 +29,6 @@ pub use builder::Builder;
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # use zbus::MatchRule;
-/// use std::convert::TryFrom;
 ///
 /// // Let's take the most typical example of match rule to subscribe to properties' changes:
 /// let rule = MatchRule::builder()

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Marc-André Lureau <marcandre.lureau@redhat.com>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "proc-macros for zbus"

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -339,7 +339,7 @@ pub fn expand(args: AttributeArgs, mut input: ItemImpl) -> syn::Result<TokenStre
                 p.ty = Some(get_property_type(output)?);
                 p.read = true;
                 let inner = if is_fallible_property {
-                    quote!(self.#ident()#method_await#handle_fallible_property)
+                    quote!(self.#ident() #method_await #handle_fallible_property)
                 } else {
                     quote!(::std::result::Result::Ok(
                         ::std::convert::Into::into(

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -567,7 +567,7 @@ fn gen_proxy_method_call(
     if let Some(proxy_name) = proxy_object {
         let proxy = Ident::new(&proxy_name, Span::call_site());
         let signature = quote! {
-            fn #method#ty_generics(#inputs) -> #zbus::Result<#proxy<'c>>
+            fn #method #ty_generics(#inputs) -> #zbus::Result<#proxy<'c>>
             #where_clause
         };
 
@@ -602,7 +602,7 @@ fn gen_proxy_method_call(
 
         let output = &m.sig.output;
         let signature = quote! {
-            fn #method#ty_generics(#inputs) #output
+            fn #method #ty_generics(#inputs) #output
             #where_clause
         };
 
@@ -736,7 +736,7 @@ fn gen_proxy_property(
                 );
                 quote! {
                     #[doc = #gen_doc]
-                    pub #usage fn #receive#ty_generics(
+                    pub #usage fn #receive #ty_generics(
                         &self
                     ) -> #prop_stream<'c, <#ret_type as #zbus::ResultAdapter>::Ok>
                     #where_clause
@@ -1001,7 +1001,7 @@ fn gen_proxy_signal(
         quote! {
             impl #signal_name_ident {
                 /// Retrieve the signal arguments.
-                pub fn args#ty_generics(&'s self) -> #zbus::Result<#signal_args #ty_generics>
+                pub fn args #ty_generics(&'s self) -> #zbus::Result<#signal_args #ty_generics>
                 #where_clause
                 {
                     ::std::convert::TryFrom::try_from(&**self)

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zbus_names"
 version = "3.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "A collection of D-Bus bus names types"

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -16,7 +16,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::BusName;
 ///
 /// // Valid well-known names.

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -17,7 +17,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::ErrorName;
 ///
 /// // Valid error names.

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -15,7 +15,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::InterfaceName;
 ///
 /// // Valid interface names.

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -15,7 +15,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::MemberName;
 ///
 /// // Valid member names.

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -15,7 +15,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::UniqueName;
 ///
 /// // Valid unique names.

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -15,7 +15,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zbus_names::WellKnownName;
 ///
 /// // Valid well-known names.

--- a/zbus_polkit/Cargo.toml
+++ b/zbus_polkit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zbus_polkit"
 version = "3.0.1"
 authors = ["Marc-André Lureau <marcandre.lureau@redhat.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "PolicyKit binding"

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Tim Small <tim@seoss.co.uk>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "D-Bus XML interface code generator"

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zvariant"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "D-Bus & GVariant encoding & decoding"

--- a/zvariant/fuzz/Cargo.toml
+++ b/zvariant/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zvariant-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -31,16 +31,21 @@ where
     /// Create a D-Bus Serializer struct instance.
     ///
     /// On Windows, there is no `fds` argument.
-    pub fn new<'w: 'ser, 'f: 'ser>(
-        signature: &Signature<'sig>,
+    pub fn new<'w: 'ser, 'f: 'ser, S>(
+        signature: S,
         writer: &'w mut W,
         #[cfg(unix)] fds: &'f mut Vec<RawFd>,
         ctxt: EncodingContext<B>,
-    ) -> Self {
+    ) -> Result<Self>
+    where
+        S: TryInto<Signature<'sig>>,
+        S::Error: Into<Error>,
+    {
         assert_eq!(ctxt.format(), EncodingFormat::DBus);
 
-        let sig_parser = SignatureParser::new(signature.clone());
-        Self(crate::SerializerCommon {
+        let signature = signature.try_into().map_err(Into::into)?;
+        let sig_parser = SignatureParser::new(signature);
+        Ok(Self(crate::SerializerCommon {
             ctxt,
             sig_parser,
             writer,
@@ -50,7 +55,7 @@ where
             value_sign: None,
             container_depths: Default::default(),
             b: PhantomData,
-        })
+        }))
     }
 }
 

--- a/zvariant/src/de.rs
+++ b/zvariant/src/de.rs
@@ -94,7 +94,6 @@ where
 /// want to manually implement `Type` trait either:
 ///
 /// ```
-/// use std::convert::TryInto;
 /// use serde::{Deserialize, Serialize};
 ///
 /// use zvariant::{to_bytes_for_signature, from_slice_for_signature};

--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -27,16 +27,21 @@ where
     /// Create a Deserializer struct instance.
     ///
     /// On Windows, the function doesn't have `fds` argument.
-    pub fn new<'r: 'de>(
+    pub fn new<'r: 'de, S>(
         bytes: &'r [u8],
         #[cfg(unix)] fds: Option<&'f [RawFd]>,
-        signature: &Signature<'sig>,
+        signature: S,
         ctxt: EncodingContext<B>,
-    ) -> Self {
+    ) -> Result<Self>
+    where
+        S: TryInto<Signature<'sig>>,
+        S::Error: Into<Error>,
+    {
         assert_eq!(ctxt.format(), EncodingFormat::GVariant);
 
-        let sig_parser = SignatureParser::new(signature.clone());
-        Self(crate::DeserializerCommon {
+        let signature = signature.try_into().map_err(Into::into)?;
+        let sig_parser = SignatureParser::new(signature);
+        Ok(Self(crate::DeserializerCommon {
             ctxt,
             sig_parser,
             bytes,
@@ -47,7 +52,7 @@ where
             pos: 0,
             container_depths: Default::default(),
             b: PhantomData,
-        })
+        }))
     }
 }
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1288,12 +1288,11 @@ mod tests {
                 (Context::<BE>::new_gvariant(4), 4),
             ],
         ];
-        let signature = "u".try_into().unwrap();
         for ctxts_n_expected_len in ctxts_n_expected_lens {
             for (ctxt, expected_len) in ctxts_n_expected_len {
-                let encoded = to_bytes_for_signature(ctxt, &signature, &Unit::Variant2).unwrap();
+                let encoded = to_bytes_for_signature(ctxt, "u", &Unit::Variant2).unwrap();
                 assert_eq!(encoded.len(), expected_len);
-                let decoded: Unit = from_slice_for_signature(&encoded, ctxt, &signature).unwrap();
+                let decoded: Unit = from_slice_for_signature(&encoded, ctxt, "u").unwrap();
                 assert_eq!(decoded, Unit::Variant2);
             }
         }
@@ -1322,14 +1321,13 @@ mod tests {
                 (Context::<BE>::new_gvariant(4), 10),
             ],
         ];
-        let signature = "(us)".try_into().unwrap();
         for ctxts_n_expected_len in ctxts_n_expected_lens {
             for (ctxt, expected_len) in ctxts_n_expected_len {
                 let encoded =
-                    to_bytes_for_signature(ctxt, &signature, &NewType::Variant2("hello")).unwrap();
+                    to_bytes_for_signature(ctxt, "(us)", &NewType::Variant2("hello")).unwrap();
                 assert_eq!(encoded.len(), expected_len);
                 let decoded: NewType<'_> =
-                    from_slice_for_signature(&encoded, ctxt, &signature).unwrap();
+                    from_slice_for_signature(&encoded, ctxt, "(us)").unwrap();
                 assert_eq!(decoded, NewType::Variant2("hello"));
             }
         }
@@ -1358,21 +1356,19 @@ mod tests {
             ],
         ];
         // TODO: Provide convenience API to create complex signatures
-        let signature = "(u(yu))".try_into().unwrap();
+        let signature = "(u(yu))";
         for ctxts_n_expected_len in ctxts_n_expected_lens {
             for (ctxt, expected_len) in ctxts_n_expected_len {
                 let encoded =
-                    to_bytes_for_signature(ctxt, &signature, &Structs::Tuple(42, 42)).unwrap();
+                    to_bytes_for_signature(ctxt, signature, &Structs::Tuple(42, 42)).unwrap();
                 assert_eq!(encoded.len(), expected_len);
-                let decoded: Structs =
-                    from_slice_for_signature(&encoded, ctxt, &signature).unwrap();
+                let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap();
                 assert_eq!(decoded, Structs::Tuple(42, 42));
 
                 let s = Structs::Struct { y: 42, t: 42 };
-                let encoded = to_bytes_for_signature(ctxt, &signature, &s).unwrap();
+                let encoded = to_bytes_for_signature(ctxt, signature, &s).unwrap();
                 assert_eq!(encoded.len(), expected_len);
-                let decoded: Structs =
-                    from_slice_for_signature(&encoded, ctxt, &signature).unwrap();
+                let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap();
                 assert_eq!(decoded, Structs::Struct { y: 42, t: 42 });
             }
         }

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -15,7 +15,6 @@ use crate::{Basic, EncodingFormat, Error, Result, Signature, Str, Type};
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zvariant::ObjectPath;
 ///
 /// // Valid object paths

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -1,7 +1,7 @@
 use core::{
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
-    panic, str,
+    str,
 };
 use serde::{
     de::{Deserialize, Deserializer, Visitor},
@@ -63,7 +63,6 @@ impl<'b> std::ops::Deref for Bytes<'b> {
 /// # Examples
 ///
 /// ```
-/// use core::convert::TryFrom;
 /// use zvariant::Signature;
 ///
 /// // Valid signatures

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -34,7 +34,6 @@ use crate::Fd;
 /// # Examples
 ///
 /// ```
-/// use std::convert::TryFrom;
 /// use zvariant::{from_slice, to_bytes, EncodingContext, Value};
 ///
 /// // Create a Value from an i16
@@ -54,7 +53,6 @@ use crate::Fd;
 /// Now let's try a more complicated example:
 ///
 /// ```
-/// use std::convert::TryFrom;
 /// use zvariant::{from_slice, to_bytes, EncodingContext};
 /// use zvariant::{Structure, Value, Str};
 ///
@@ -279,7 +277,6 @@ impl<'a> Value<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::convert::TryFrom;
     /// use zvariant::{Result, Value};
     ///
     /// fn value_vec_to_type_vec<'a, T>(values: Vec<Value<'a>>) -> Result<Vec<T>>
@@ -329,7 +326,6 @@ impl<'a> Value<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::convert::TryFrom;
     /// use zvariant::{Result, Value};
     ///
     /// fn value_vec_to_type_vec<'a, T>(values: &'a Vec<Value<'a>>) -> Result<Vec<&'a T>>

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "zvariant_derive"
 # Keep major and minor version in sync with zvariant crate
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "D-Bus & GVariant encoding & decoding"

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -329,7 +329,6 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Simple owned strutures:
 ///
 /// ```
-/// use std::convert::TryFrom;
 /// use zvariant::{OwnedObjectPath, OwnedValue, Value};
 ///
 /// #[derive(Clone, Value, OwnedValue)]
@@ -353,7 +352,6 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Now for the more exciting case of unowned structures:
 ///
 /// ```
-/// # use std::convert::TryFrom;
 /// use zvariant::{ObjectPath, Str};
 /// # use zvariant::{OwnedValue, Value};
 /// #
@@ -380,7 +378,6 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Generic structures also supported:
 ///
 /// ```
-/// # use std::convert::TryFrom;
 /// # use zvariant::{OwnedObjectPath, OwnedValue, Value};
 /// #
 /// #[derive(Clone, Value, OwnedValue)]
@@ -404,7 +401,6 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Enums also supported but currently only simple ones w/ an integer representation:
 ///
 /// ```
-/// # use std::convert::TryFrom;
 /// # use zvariant::{OwnedValue, Value};
 /// #
 /// #[derive(Debug, PartialEq, Value, OwnedValue)]

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "Various utilities used internally by the zvariant crate."


### PR DESCRIPTION
So that people can pass strings directly and let us worry about conversion to a `Signature` instance.

This involves changing some public methods to return a Result but they are rarely used directly.
