### PR TITLE
Drop deprecated APIs

### DIFF
--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1250,21 +1250,6 @@ impl Connection {
             .monitor_activity()
     }
 
-    /// Returns the peer process ID, or Ok(None) if it cannot be returned for the associated socket.
-    #[deprecated(
-        since = "3.13.0",
-        note = "Use `peer_credentials` instead, which returns `ConnectionCredentials` which includes
-                the peer PID."
-    )]
-    pub fn peer_pid(&self) -> io::Result<Option<u32>> {
-        self.inner
-            .raw_conn
-            .lock()
-            .expect("poisoned lock")
-            .socket()
-            .peer_pid()
-    }
-
     /// Returns the peer credentials.
     ///
     /// The fields are populated on the best effort basis. Some or all fields may not even make

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1273,7 +1273,6 @@ impl Connection {
     /// # Caveats
     ///
     /// Currently `unix_group_ids` and `linux_security_label` fields are not populated.
-    #[allow(deprecated)]
     pub async fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
         let raw_conn = self.inner.raw_conn.lock().expect("poisoned lock");
         let socket = raw_conn.socket();

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -22,9 +22,6 @@ pub enum Error {
     /// Invalid D-Bus address.
     Address(String),
     /// An I/O error.
-    #[deprecated(note = "Use `Error::InputOutput` instead")]
-    Io(io::Error),
-    /// An I/O error.
     InputOutput(Arc<io::Error>),
     /// Invalid message field.
     InvalidField,
@@ -90,8 +87,6 @@ impl PartialEq for Error {
             (Self::Variant(s), Self::Variant(o)) => s == o,
             (Self::Names(s), Self::Names(o)) => s == o,
             (Self::NameTaken, Self::NameTaken) => true,
-            #[allow(deprecated)]
-            (Error::Io(_), Self::Io(_)) => false,
             (Error::InputOutput(_), Self::InputOutput(_)) => false,
             #[cfg(feature = "xml")]
             (Self::QuickXml(_), Self::QuickXml(_)) => false,
@@ -106,8 +101,6 @@ impl error::Error for Error {
         match self {
             Error::InterfaceNotFound => None,
             Error::Address(_) => None,
-            #[allow(deprecated)]
-            Error::Io(e) => Some(e),
             Error::InputOutput(e) => Some(e),
             Error::ExcessData => None,
             Error::Handshake(_) => None,
@@ -138,8 +131,6 @@ impl fmt::Display for Error {
             Error::InterfaceNotFound => write!(f, "Interface not found"),
             Error::Address(e) => write!(f, "address error: {e}"),
             Error::ExcessData => write!(f, "excess data"),
-            #[allow(deprecated)]
-            Error::Io(e) => write!(f, "I/O error: {e}"),
             Error::InputOutput(e) => write!(f, "I/O error: {e}"),
             Error::Handshake(e) => write!(f, "D-Bus handshake failed: {e}"),
             Error::IncorrectEndian => write!(f, "incorrect endian"),
@@ -176,8 +167,6 @@ impl Clone for Error {
             Error::InterfaceNotFound => Error::InterfaceNotFound,
             Error::Address(e) => Error::Address(e.clone()),
             Error::ExcessData => Error::ExcessData,
-            #[allow(deprecated)]
-            Error::Io(e) => Error::Io(io::Error::new(e.kind(), e.to_string())),
             Error::InputOutput(e) => Error::InputOutput(e.clone()),
             Error::Handshake(e) => Error::Handshake(e.clone()),
             Error::IncorrectEndian => Error::IncorrectEndian,

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -703,10 +703,6 @@ macro_rules! gen_dbus_proxy {
         )]
         trait DBus {
             /// Adds a match rule to match messages going through the message bus
-            #[deprecated(since = "3.5.0", note = "Use `add_match_rule` instead")]
-            fn add_match(&self, rule: &str) -> Result<()>;
-
-            /// Adds a match rule to match messages going through the message bus
             #[dbus_proxy(name = "AddMatch")]
             fn add_match_rule(&self, rule: crate::MatchRule<'_>) -> Result<()>;
 
@@ -759,10 +755,6 @@ macro_rules! gen_dbus_proxy {
 
             /// Reload server configuration.
             fn reload_config(&self) -> Result<()>;
-
-            /// Removes the first rule that matches.
-            #[deprecated(since = "3.5.0", note = "Use `remove_match_rule` instead")]
-            fn remove_match(&self, rule: &str) -> Result<()>;
 
             /// Removes the first rule that matches.
             #[dbus_proxy(name = "RemoveMatch")]

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -564,27 +564,21 @@ assert_impl_all!(ReleaseNameReply: Send, Sync, Unpin);
 #[zvariant(signature = "a{sv}")]
 pub struct ConnectionCredentials {
     #[zvariant(rename = "UnixUserID")]
-    #[deprecated(since = "3.13.0", note = "Use `unix_user_id` method")]
-    pub unix_user_id: Option<u32>,
+    pub(crate) unix_user_id: Option<u32>,
 
     #[zvariant(rename = "UnixGroupIDs")]
-    #[deprecated(since = "3.13.0", note = "Use `unix_group_ids` method")]
-    pub unix_group_ids: Option<Vec<u32>>,
+    pub(crate) unix_group_ids: Option<Vec<u32>>,
 
     #[zvariant(rename = "ProcessID")]
-    #[deprecated(since = "3.13.0", note = "Use `process_id` method")]
-    pub process_id: Option<u32>,
+    pub(crate) process_id: Option<u32>,
 
     #[zvariant(rename = "WindowsSID")]
-    #[deprecated(since = "3.13.0", note = "Use `windows_sid` method")]
-    pub windows_sid: Option<String>,
+    pub(crate) windows_sid: Option<String>,
 
     #[zvariant(rename = "LinuxSecurityLabel")]
-    #[deprecated(since = "3.13.0", note = "Use `linux_security_label` method")]
-    pub linux_security_label: Option<Vec<u8>>,
+    pub(crate) linux_security_label: Option<Vec<u8>>,
 }
 
-#[allow(deprecated)]
 impl ConnectionCredentials {
     /// The numeric Unix user ID, as defined by POSIX.
     pub fn unix_user_id(&self) -> Option<u32> {

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -204,22 +204,6 @@ impl<'m> Builder<'m> {
 
     /// Set 0th argument's namespace.
     ///
-    /// This function is deprecated because the choice of `InterfaceName` was too restrictive.
-    #[deprecated = "use arg0ns instead"]
-    pub fn arg0namespace<I>(mut self, namespace: I) -> Result<Self>
-    where
-        I: TryInto<InterfaceName<'m>>,
-        I::Error: Into<Error>,
-    {
-        let namespace = namespace.try_into().map_err(Into::into)?;
-        self.0.arg0namespace = Some(namespace.clone());
-        self.0.arg0ns = Some(namespace.into());
-
-        Ok(self)
-    }
-
-    /// Set 0th argument's namespace.
-    ///
     /// The namespace be a valid bus name or a valid element of a bus name. For more information,
     /// see [the spec](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus).
     ///

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -150,14 +150,6 @@ impl<'m> MatchRule<'m> {
     }
 
     /// Match messages whose first argument is within the specified namespace.
-    ///
-    /// This function is deprecated because the choice of `InterfaceName` was too restrictive.
-    #[deprecated = "use arg0ns instead"]
-    pub fn arg0namespace(&self) -> Option<&InterfaceName<'_>> {
-        self.arg0namespace.as_ref()
-    }
-
-    /// Match messages whose first argument is within the specified namespace.
     pub fn arg0ns(&self) -> Option<&Str<'m>> {
         self.arg0ns.as_ref()
     }

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -40,9 +40,6 @@ pub enum Error {
     Message(String),
 
     /// Wrapper for [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html)
-    #[deprecated(note = "Use `Error::InputOutput` instead")]
-    Io(std::io::Error),
-    /// Wrapper for [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html)
     InputOutput(Arc<std::io::Error>),
     /// Type conversions errors.
     IncorrectType,
@@ -85,8 +82,6 @@ impl PartialEq for Error {
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            #[allow(deprecated)]
-            Error::Io(e) => Some(e),
             Error::InputOutput(e) => Some(e),
             Error::Utf8(e) => Some(e),
             _ => None,
@@ -98,8 +93,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Message(s) => write!(f, "{s}"),
-            #[allow(deprecated)]
-            Error::Io(e) => e.fmt(f),
             Error::InputOutput(e) => e.fmt(f),
             Error::IncorrectType => write!(f, "incorrect type"),
             Error::Utf8(e) => write!(f, "{e}"),
@@ -130,8 +123,6 @@ impl Clone for Error {
     fn clone(&self) -> Self {
         match self {
             Error::Message(s) => Error::Message(s.clone()),
-            #[allow(deprecated)]
-            Error::Io(e) => Error::Message(e.to_string()),
             Error::InputOutput(e) => Error::InputOutput(e.clone()),
             Error::IncorrectType => Error::IncorrectType,
             Error::Utf8(e) => Error::Utf8(*e),

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -95,7 +95,7 @@ mod signature_parser;
 
 mod container_depths;
 
-pub use zvariant_derive::{DeserializeDict, OwnedValue, SerializeDict, Type, TypeDict, Value};
+pub use zvariant_derive::{DeserializeDict, OwnedValue, SerializeDict, Type, Value};
 
 // Required for the macros to function within this crate.
 extern crate self as zvariant;

--- a/zvariant_derive/src/dict.rs
+++ b/zvariant_derive/src/dict.rs
@@ -5,27 +5,6 @@ use zvariant_utils::{case, macros};
 
 use crate::utils::*;
 
-pub fn expand_type_derive(input: DeriveInput) -> Result<TokenStream, Error> {
-    let name = match input.data {
-        Data::Struct(_) => input.ident,
-        _ => return Err(Error::new(input.span(), "only structs supported")),
-    };
-
-    let zv = zvariant_path();
-    let generics = input.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    Ok(quote! {
-        impl #impl_generics #zv::Type for #name #ty_generics
-        #where_clause
-        {
-            fn signature() -> #zv::Signature<'static> {
-                #zv::Signature::from_static_str_unchecked("a{sv}")
-            }
-        }
-    })
-}
-
 fn dict_name_for_field(
     f: &Field,
     rename_attr: Option<String>,

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -170,21 +170,6 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derive macro to add [`Type`] implementation to structs serialized as `a{sv}` type.
-///
-/// [`Type`]: ../zvariant/trait.Type.html
-#[proc_macro_derive(TypeDict)]
-#[deprecated(
-    since = "3.1.0",
-    note = "Please use `Type` macro with `#[zvariant(signature = \"dict\")]` attribute instead."
-)]
-pub fn type_dict_macro_derive(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = syn::parse(input).unwrap();
-    dict::expand_type_derive(ast)
-        .unwrap_or_else(|err| err.to_compile_error())
-        .into()
-}
-
 /// Adds [`Serialize`] implementation to structs to be serialized as `a{sv}` type.
 ///
 /// This macro serializes the deriving struct as a D-Bus dictionary type, where keys are strings and


### PR DESCRIPTION
Time to drop deprecated APIs, excluding the new aliases/re-exports.