### PR TITLE
✨ zv: from_slice now also return number of bytes parsed

### DIFF
--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -325,7 +325,8 @@ impl<'a> Builder<'a> {
         write_body(&mut cursor)?;
 
         let primary_header = header.into_primary();
-        let header: Header<'_> = zvariant::from_slice(&bytes, ctxt)?;
+        let (header, actual_hdr_len): (Header<'_>, _) = zvariant::from_slice(&bytes, ctxt)?;
+        assert_eq!(hdr_len, actual_hdr_len);
         let quick_fields = QuickFields::new(&bytes, &header)?;
 
         Ok(Message {

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -178,8 +178,9 @@ impl PrimaryHeader {
 
     pub(crate) fn read(buf: &[u8]) -> Result<(PrimaryHeader, u32), Error> {
         let ctx = EncodingContext::<byteorder::NativeEndian>::new_dbus(0);
-        let primary_header = zvariant::from_slice(buf, ctx)?;
-        let fields_len = zvariant::from_slice(&buf[PRIMARY_HEADER_SIZE..], ctx)?;
+        let (primary_header, size) = zvariant::from_slice(buf, ctx)?;
+        assert_eq!(size, PRIMARY_HEADER_SIZE);
+        let (fields_len, _) = zvariant::from_slice(&buf[PRIMARY_HEADER_SIZE..], ctx)?;
         Ok((primary_header, fields_len))
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -243,7 +243,7 @@ impl Message {
         }
 
         let (primary_header, fields_len) = PrimaryHeader::read(&bytes)?;
-        let header = zvariant::from_slice(&bytes, dbus_context!(0))?;
+        let (header, _) = zvariant::from_slice(&bytes, dbus_context!(0))?;
         #[cfg(unix)]
         let fds = Arc::new(RwLock::new(Fds::Owned(fds)));
 
@@ -323,7 +323,9 @@ impl Message {
     ///
     /// Note: prefer using the direct access methods if possible; they are more efficient.
     pub fn header(&self) -> Result<Header<'_>> {
-        zvariant::from_slice(&self.bytes, dbus_context!(0)).map_err(Error::from)
+        zvariant::from_slice(&self.bytes, dbus_context!(0))
+            .map_err(Error::from)
+            .map(|h| h.0)
     }
 
     /// Deserialize the fields.
@@ -331,7 +333,9 @@ impl Message {
     /// Note: prefer using the direct access methods if possible; they are more efficient.
     pub fn fields(&self) -> Result<Fields<'_>> {
         let ctxt = dbus_context!(header::PRIMARY_HEADER_SIZE);
-        zvariant::from_slice(&self.bytes[header::PRIMARY_HEADER_SIZE..], ctxt).map_err(Error::from)
+        zvariant::from_slice(&self.bytes[header::PRIMARY_HEADER_SIZE..], ctxt)
+            .map_err(Error::from)
+            .map(|f| f.0)
     }
 
     /// The message type.
@@ -379,6 +383,7 @@ impl Message {
             }
         }
         .map_err(Error::from)
+        .map(|b| b.0)
     }
 
     /// Deserialize the body using the contained signature.
@@ -433,6 +438,7 @@ impl Message {
             }
         }
         .map_err(Error::from)
+        .map(|b| b.0)
     }
 
     #[cfg(unix)]

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -30,24 +30,24 @@ let ctxt = Context::<LE>::new_dbus(0);
 
 // i16
 let encoded = to_bytes(ctxt, &42i16).unwrap();
-let decoded: i16 = from_slice(&encoded, ctxt).unwrap();
+let decoded: i16 = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, 42);
 
 // strings
 let encoded = to_bytes(ctxt, &"hello").unwrap();
-let decoded: &str = from_slice(&encoded, ctxt).unwrap();
+let decoded: &str = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, "hello");
 
 // tuples
 let t = ("hello", 42i32, true);
 let encoded = to_bytes(ctxt, &t).unwrap();
-let decoded: (&str, i32, bool) = from_slice(&encoded, ctxt).unwrap();
+let decoded: (&str, i32, bool) = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, t);
 
 // Vec
 let v = vec!["hello", "world!"];
 let encoded = to_bytes(ctxt, &v).unwrap();
-let decoded: Vec<&str> = from_slice(&encoded, ctxt).unwrap();
+let decoded: Vec<&str> = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, v);
 
 // Dictionary
@@ -55,7 +55,7 @@ let mut map: HashMap<i64, &str> = HashMap::new();
 map.insert(1, "123");
 map.insert(2, "456");
 let encoded = to_bytes(ctxt, &map).unwrap();
-let decoded: HashMap<i64, &str> = from_slice(&encoded, ctxt).unwrap();
+let decoded: HashMap<i64, &str> = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded[&1], "123");
 assert_eq!(decoded[&2], "456");
 
@@ -75,7 +75,7 @@ let s = Struct {
 };
 let ctxt = Context::<LE>::new_dbus(0);
 let encoded = to_bytes(ctxt, &s).unwrap();
-let decoded: Struct = from_slice(&encoded, ctxt).unwrap();
+let decoded: Struct = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, s);
 
 // It can handle enums too, just that all variants must have the same number and types of fields.
@@ -98,7 +98,7 @@ let e = Enum::Variant3 {
     f3: "hello",
 };
 let encoded = to_bytes(ctxt, &e).unwrap();
-let decoded: Enum = from_slice(&encoded, ctxt).unwrap();
+let decoded: Enum = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, e);
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
@@ -112,7 +112,7 @@ enum UnitEnum {
 
 assert_eq!(UnitEnum::signature(), "y");
 let encoded = to_bytes(ctxt, &UnitEnum::Variant2).unwrap();
-let e: UnitEnum = from_slice(&encoded, ctxt).unwrap();
+let e: UnitEnum = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(e, UnitEnum::Variant2);
 
 // Unit enums can also be (de)serialized as strings.

--- a/zvariant/benches/benchmarks.rs
+++ b/zvariant/benches/benchmarks.rs
@@ -20,7 +20,7 @@ fn fixed_size_array(c: &mut Criterion) {
     let enc = to_bytes_for_signature(ctxt, &signature, &ay).unwrap();
     c.bench_function("byte_array_de", |b| {
         b.iter(|| {
-            let _: Vec<u8> =
+            let _: (Vec<u8>, _) =
                 from_slice_for_signature(black_box(&enc), black_box(ctxt), black_box(&signature))
                     .unwrap();
         })
@@ -87,7 +87,7 @@ fn big_array_ser_and_de(c: &mut Criterion) {
     let encoded = to_bytes_for_signature(ctxt, &signature, &element).unwrap();
     c.bench_function("big_array_de_dbus", |b| {
         b.iter(|| {
-            let s: ZVStruct = from_slice_for_signature(
+            let (s, _): (ZVStruct, _) = from_slice_for_signature(
                 black_box(&encoded),
                 black_box(ctxt),
                 black_box(&signature),
@@ -112,7 +112,7 @@ fn big_array_ser_and_de(c: &mut Criterion) {
     let encoded = to_bytes_for_signature(ctxt, &signature, &element).unwrap();
     c.bench_function("big_array_de_gvariant", |b| {
         b.iter(|| {
-            let s: ZVStruct = from_slice_for_signature(
+            let (s, _): (ZVStruct, _) = from_slice_for_signature(
                 black_box(&encoded),
                 black_box(ctxt),
                 black_box(&signature),

--- a/zvariant/fuzz/fuzz_targets/utils.rs
+++ b/zvariant/fuzz/fuzz_targets/utils.rs
@@ -2,7 +2,7 @@ use byteorder::ByteOrder;
 use zvariant::{from_slice, to_bytes, EncodingContext as Context, Value};
 
 pub fn fuzz_for_context<B: ByteOrder>(data: &[u8], ctx: Context<B>) {
-    if let Ok(decoded) = from_slice::<_, Value>(data, ctx) {
+    if let Ok((decoded, _)) = from_slice::<_, Value>(data, ctx) {
         to_bytes(ctx, &decoded).unwrap();
     }
 }

--- a/zvariant/src/de.rs
+++ b/zvariant/src/de.rs
@@ -143,7 +143,6 @@ where
 ///     Struct { y: u8, t: u64 },
 /// }
 ///
-/// // TODO: Provide convenience API to create complex signatures
 /// let signature = "(u(yt))";
 /// let encoded = to_bytes_for_signature(ctxt, signature, &Structs::Tuple(42, 42)).unwrap();
 /// assert_eq!(encoded.len(), 24);

--- a/zvariant/src/de.rs
+++ b/zvariant/src/de.rs
@@ -36,9 +36,13 @@ use crate::Fd;
 ///
 /// let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
 /// let (encoded, fds) = to_bytes_fds(ctxt, &Fd::from(42)).unwrap();
-/// let decoded: Fd = from_slice_fds(&encoded, Some(&fds), ctxt).unwrap();
+/// let decoded: Fd = from_slice_fds(&encoded, Some(&fds), ctxt).unwrap().0;
 /// assert_eq!(decoded, Fd::from(42));
 /// ```
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and numbe number of bytes parsed from the `bytes`.
 ///
 /// [`from_slice`]: fn.from_slice.html
 #[cfg(unix)]
@@ -46,7 +50,7 @@ pub fn from_slice_fds<'d, 'r: 'd, B, T: ?Sized>(
     bytes: &'r [u8],
     fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: Deserialize<'d> + Type,
@@ -67,13 +71,20 @@ where
 ///
 /// let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
 /// let encoded = to_bytes(ctxt, "hello world").unwrap();
-/// let decoded: &str = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: &str = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(decoded, "hello world");
 /// ```
 ///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
+///
 /// [`Fd`]: struct.Fd.html
 /// [`from_slice_fds`]: fn.from_slice_fds.html
-pub fn from_slice<'d, 'r: 'd, B, T: ?Sized>(bytes: &'r [u8], ctxt: EncodingContext<B>) -> Result<T>
+pub fn from_slice<'d, 'r: 'd, B, T: ?Sized>(
+    bytes: &'r [u8],
+    ctxt: EncodingContext<B>,
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: Deserialize<'d> + Type,
@@ -109,7 +120,7 @@ where
 ///
 /// let encoded = to_bytes_for_signature(ctxt, "u", &Unit::Variant2).unwrap();
 /// assert_eq!(encoded.len(), 4);
-/// let decoded: Unit = from_slice_for_signature(&encoded, ctxt, "u").unwrap();
+/// let decoded: Unit = from_slice_for_signature(&encoded, ctxt, "u").unwrap().0;
 /// assert_eq!(decoded, Unit::Variant2);
 ///
 /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -123,7 +134,7 @@ where
 /// let encoded =
 ///     to_bytes_for_signature(ctxt, signature, &NewType::Variant2("hello")).unwrap();
 /// assert_eq!(encoded.len(), 14);
-/// let decoded: NewType<'_> = from_slice_for_signature(&encoded, ctxt, signature).unwrap();
+/// let decoded: NewType<'_> = from_slice_for_signature(&encoded, ctxt, signature).unwrap().0;
 /// assert_eq!(decoded, NewType::Variant2("hello"));
 ///
 /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,25 +147,28 @@ where
 /// let signature = "(u(yt))";
 /// let encoded = to_bytes_for_signature(ctxt, signature, &Structs::Tuple(42, 42)).unwrap();
 /// assert_eq!(encoded.len(), 24);
-/// let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap();
+/// let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap().0;
 /// assert_eq!(decoded, Structs::Tuple(42, 42));
 ///
 /// let s = Structs::Struct { y: 42, t: 42 };
 /// let encoded = to_bytes_for_signature(ctxt, signature, &s).unwrap();
 /// assert_eq!(encoded.len(), 24);
-/// let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap();
+/// let decoded: Structs = from_slice_for_signature(&encoded, ctxt, signature).unwrap().0;
 /// assert_eq!(decoded, Structs::Struct { y: 42, t: 42 });
 /// ```
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
 ///
 /// [`Type`]: trait.Type.html
 /// [`Fd`]: struct.Fd.html
 /// [`from_slice_fds_for_signature`]: fn.from_slice_fds_for_signature.html
-// TODO: Return number of bytes parsed?
 pub fn from_slice_for_signature<'d, 'r: 'd, B, S, T: ?Sized>(
     bytes: &'r [u8],
     ctxt: EncodingContext<B>,
     signature: S,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: Deserialize<'d>,
@@ -179,16 +193,19 @@ where
 ///
 /// This function is not available on Windows.
 ///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
+///
 /// [`from_slice`]: fn.from_slice.html
 /// [`from_slice_for_signature`]: fn.from_slice_for_signature.html
-// TODO: Return number of bytes parsed?
 #[cfg(unix)]
 pub fn from_slice_fds_for_signature<'d, 'r: 'd, B, S, T: ?Sized>(
     bytes: &'r [u8],
     fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
     signature: S,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: Deserialize<'d>,
@@ -203,7 +220,7 @@ fn _from_slice_fds_for_signature<'d, 'r: 'd, B, S, T: ?Sized>(
     #[cfg(unix)] fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
     signature: S,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: Deserialize<'d>,
@@ -232,7 +249,11 @@ where
         .map(Deserializer::DBus)?,
     };
 
-    T::deserialize(&mut de)
+    T::deserialize(&mut de).map(|t| match de {
+        #[cfg(feature = "gvariant")]
+        Deserializer::GVariant(de) => (t, de.0.pos),
+        Deserializer::DBus(de) => (t, de.0.pos),
+    })
 }
 
 /// Deserialize `T` from a given slice of bytes containing file descriptor indices, with the given
@@ -241,11 +262,15 @@ where
 /// Please note that actual file descriptors are not part of the encoding and need to be transferred
 /// via an out-of-band platform specific mechanism. The encoding only contain the indices of the
 /// file descriptors and hence the reason, caller must pass a slice of file descriptors.
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
 pub fn from_slice_for_dynamic_signature<'d, B, S, T>(
     bytes: &'d [u8],
     ctxt: EncodingContext<B>,
     signature: S,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: DynamicDeserialize<'d>,
@@ -265,13 +290,17 @@ where
 /// file descriptors and hence the reason, caller must pass a slice of file descriptors.
 ///
 /// This function is not available on Windows.
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
 #[cfg(unix)]
 pub fn from_slice_fds_for_dynamic_signature<'d, B, S, T>(
     bytes: &'d [u8],
     fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
     signature: S,
-) -> Result<T>
+) -> Result<(T, usize)>
 where
     B: byteorder::ByteOrder,
     T: DynamicDeserialize<'d>,
@@ -289,11 +318,15 @@ where
 /// Please note that actual file descriptors are not part of the encoding and need to be transferred
 /// via an out-of-band platform specific mechanism. The encoding only contain the indices of the
 /// file descriptors and hence the reason, caller must pass a slice of file descriptors.
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
 pub fn from_slice_with_seed<'d, B, S>(
     bytes: &'d [u8],
     ctxt: EncodingContext<B>,
     seed: S,
-) -> Result<S::Value>
+) -> Result<(S::Value, usize)>
 where
     B: byteorder::ByteOrder,
     S: DeserializeSeed<'d> + DynamicType,
@@ -315,13 +348,17 @@ where
 /// file descriptors and hence the reason, caller must pass a slice of file descriptors.
 ///
 /// This function is not available on Windows.
+///
+/// # Return value
+///
+/// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
 #[cfg(unix)]
 pub fn from_slice_fds_with_seed<'d, B, S>(
     bytes: &'d [u8],
     fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
     seed: S,
-) -> Result<S::Value>
+) -> Result<(S::Value, usize)>
 where
     B: byteorder::ByteOrder,
     S: DeserializeSeed<'d> + DynamicType,
@@ -334,7 +371,7 @@ fn _from_slice_fds_with_seed<'d, B, S>(
     #[cfg(unix)] fds: Option<&[RawFd]>,
     ctxt: EncodingContext<B>,
     seed: S,
-) -> Result<S::Value>
+) -> Result<(S::Value, usize)>
 where
     B: byteorder::ByteOrder,
     S: DeserializeSeed<'d> + DynamicType,
@@ -361,7 +398,11 @@ where
         .map(Deserializer::DBus)?,
     };
 
-    seed.deserialize(&mut de)
+    seed.deserialize(&mut de).map(|t| match de {
+        #[cfg(feature = "gvariant")]
+        Deserializer::GVariant(de) => (t, de.0.pos),
+        Deserializer::DBus(de) => (t, de.0.pos),
+    })
 }
 
 /// Our deserialization implementation.

--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -18,7 +18,7 @@ use crate::{Signature, Type, Value};
 /// # let array = [0, 1, 2];
 /// # let v = SerializeValue(&array);
 /// # let encoded = to_bytes(ctxt, &v).unwrap();
-/// let decoded: DeserializeValue<[u8; 3]> = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: DeserializeValue<[u8; 3]> = from_slice(&encoded, ctxt).unwrap().0;
 /// # assert_eq!(decoded.0, array);
 /// ```
 ///

--- a/zvariant/src/encoding_context.rs
+++ b/zvariant/src/encoding_context.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for EncodingFormat {
 ///
 /// // Let's decode the 2nd element of the array only
 /// let ctxt = Context::<LE>::new_dbus(14);
-/// let decoded: &str = from_slice(&encoded[14..], ctxt).unwrap();
+/// let decoded: &str = from_slice(&encoded[14..], ctxt).unwrap().0;
 /// assert_eq!(decoded, "World");
 /// ```
 ///

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -56,7 +56,7 @@ where
 /// let s = Optional::<&str>::default();
 /// let encoded = to_bytes(ctxt, &s).unwrap();
 /// assert_eq!(encoded, &[0, 0, 0, 0, 0]);
-/// let s: Optional<&str> = from_slice(&encoded, ctxt).unwrap();
+/// let s: Optional<&str> = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(*s, None);
 ///
 /// // `Some` case.
@@ -65,7 +65,7 @@ where
 /// assert_eq!(encoded.len(), 10);
 /// // The first byte is the length of the string in Little-Endian format.
 /// assert_eq!(encoded[0], 5);
-/// let s: Optional<&str> = from_slice(&encoded, ctxt).unwrap();
+/// let s: Optional<&str> = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(*s, Some("hello"));
 /// ```
 ///

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -270,8 +270,9 @@ mod tests {
         let ec = EncodingContext::<LE>::new_dbus(0);
         let ov: OwnedValue = Value::from("hi!").into();
         let ser = to_bytes(ec, &ov)?;
-        let de: Value<'_> = from_slice(&ser, ec)?;
+        let (de, parsed): (Value<'_>, _) = from_slice(&ser, ec)?;
         assert_eq!(<&str>::try_from(&de)?, "hi!");
+        assert_eq!(parsed, ser.len());
         Ok(())
     }
 

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -106,7 +106,7 @@ where
 /// let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
 /// let mut cursor = std::io::Cursor::new(vec![]);
 /// to_writer(&mut cursor, ctxt, &42u32).unwrap();
-/// let value: u32 = from_slice(cursor.get_ref(), ctxt).unwrap();
+/// let value: u32 = from_slice(cursor.get_ref(), ctxt).unwrap().0;
 /// assert_eq!(value, 42);
 /// ```
 ///

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -44,7 +44,7 @@ use crate::Fd;
 /// let encoding = to_bytes(ctxt, &v).unwrap();
 ///
 /// // Decode it back
-/// let v: Value = from_slice(&encoding, ctxt).unwrap();
+/// let v: Value = from_slice(&encoding, ctxt).unwrap().0;
 ///
 /// // Check everything is as expected
 /// assert_eq!(i16::try_from(&v).unwrap(), i16::max_value());
@@ -62,7 +62,7 @@ use crate::Fd;
 /// // Same drill as previous example
 /// let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
 /// let encoding = to_bytes(ctxt, &v).unwrap();
-/// let v: Value = from_slice(&encoding, ctxt).unwrap();
+/// let v: Value = from_slice(&encoding, ctxt).unwrap().0;
 ///
 /// // Check everything is as expected
 /// let s = Structure::try_from(v).unwrap();

--- a/zvariant_derive/README.md
+++ b/zvariant_derive/README.md
@@ -29,7 +29,7 @@ let s = Struct {
 };
 let ctxt = EncodingContext::<LE>::new_dbus(0);
 let encoded = to_bytes(ctxt, &s).unwrap();
-let decoded: Struct = from_slice(&encoded, ctxt).unwrap();
+let decoded: Struct = from_slice(&encoded, ctxt).unwrap().0;
 assert_eq!(decoded, s);
 ```
 

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -44,7 +44,7 @@ mod value;
 /// };
 /// let ctxt = EncodingContext::<LE>::new_dbus(0);
 /// let encoded = to_bytes(ctxt, &s).unwrap();
-/// let decoded: Struct = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: Struct = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(decoded, s);
 /// ```
 ///
@@ -67,7 +67,7 @@ mod value;
 /// assert_eq!(Enum::signature(), u8::signature());
 /// let ctxt = EncodingContext::<LE>::new_dbus(0);
 /// let encoded = to_bytes(ctxt, &Enum::Variant2).unwrap();
-/// let decoded: Enum = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: Enum = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(decoded, Enum::Variant2);
 ///
 /// #[repr(i64)]
@@ -131,7 +131,7 @@ mod value;
 /// };
 /// let ctxt = EncodingContext::<LE>::new_dbus(0);
 /// let encoded = to_bytes(ctxt, &s).unwrap();
-/// let decoded: Struct = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: Struct = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(decoded, s);
 /// ```
 ///
@@ -154,7 +154,7 @@ mod value;
 /// let ctxt = EncodingContext::<LE>::new_dbus(0);
 /// let encoded = to_bytes(ctxt, &StrEnum::Variant2).unwrap();
 /// assert_eq!(encoded.len(), 13);
-/// let decoded: StrEnum = from_slice(&encoded, ctxt).unwrap();
+/// let decoded: StrEnum = from_slice(&encoded, ctxt).unwrap().0;
 /// assert_eq!(decoded, StrEnum::Variant2);
 /// ```
 ///

--- a/zvariant_derive/tests/tests.rs
+++ b/zvariant_derive/tests/tests.rs
@@ -59,14 +59,14 @@ fn derive_dict() {
     let ctxt = EncodingContext::<LE>::new(EncodingFormat::DBus, 0);
     let serialized = zvariant::to_bytes(ctxt, &test).unwrap();
     let deserialized: HashMap<String, OwnedValue> =
-        zvariant::from_slice(&serialized, ctxt).unwrap();
+        zvariant::from_slice(&serialized, ctxt).unwrap().0;
 
     assert_eq!(deserialized["fieldA"], Value::from(1u32).into());
     assert_eq!(deserialized["field-b"], Value::from("foo").into());
     assert_eq!(deserialized["fieldC"], Value::from(&[1u8, 2, 3][..]).into());
 
     let serialized = zvariant::to_bytes(ctxt, &deserialized).unwrap();
-    let deserialized: Test = zvariant::from_slice(&serialized, ctxt).unwrap();
+    let deserialized: Test = zvariant::from_slice(&serialized, ctxt).unwrap().0;
 
     assert_eq!(deserialized.field_a, Some(1u32));
     assert_eq!(deserialized.field_b.as_str(), "foo");


### PR DESCRIPTION
The deserializer is driven by the signature and it could happen that not all bytes are consumed from the input slice and this could be useful information for the caller.