### PR TITLE
⚰️ zb: remove unused arg0namespace from match rule

### DIFF
--- a/book-1.0/src/server.md
+++ b/book-1.0/src/server.md
@@ -102,7 +102,6 @@ Let see how to use it:
 
 ```rust,no_run
 # use std::error::Error;
-# use std::convert::TryInto;
 # use zbus::{dbus_interface, fdo};
 #
 struct Greeter;

--- a/zbus/src/address.rs
+++ b/zbus/src/address.rs
@@ -22,7 +22,7 @@ use nix::unistd::Uid;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(all(unix, not(feature = "tokio")))]
 use std::os::unix::net::UnixStream;
-use std::{collections::HashMap, convert::TryFrom, env, str::FromStr};
+use std::{collections::HashMap, env, str::FromStr};
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
 #[cfg(all(unix, feature = "tokio"))]

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -1,5 +1,4 @@
 use static_assertions::assert_impl_all;
-use std::convert::TryInto;
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
 #[cfg(all(unix, not(feature = "tokio")))]

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -3,7 +3,7 @@
 use enumflags2::BitFlags;
 use event_listener::EventListener;
 use static_assertions::assert_impl_all;
-use std::{convert::TryInto, io, ops::Deref, sync::Arc};
+use std::{io, ops::Deref, sync::Arc};
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName};
 use zvariant::ObjectPath;
 

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use static_assertions::assert_impl_all;
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     blocking::Connection, message::Message, utils::block_on, MatchRule, OwnedMatchRule, Result,

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -1,6 +1,6 @@
 //! The object server API.
 
-use std::{convert::TryInto, ops::Deref};
+use std::ops::Deref;
 
 use static_assertions::assert_impl_all;
 use zvariant::ObjectPath;

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use static_assertions::assert_impl_all;
 use zbus_names::{BusName, InterfaceName};
 use zvariant::ObjectPath;

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -3,11 +3,7 @@
 use enumflags2::BitFlags;
 use futures_util::StreamExt;
 use static_assertions::assert_impl_all;
-use std::{
-    convert::{TryFrom, TryInto},
-    ops::Deref,
-    sync::Arc,
-};
+use std::{ops::Deref, sync::Arc};
 use zbus_names::{BusName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, OwnedValue, Value};
 

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -8,7 +8,6 @@ use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    convert::TryInto,
     sync::Arc,
 };
 #[cfg(feature = "tokio")]

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -4,7 +4,6 @@ use futures_util::{future::poll_fn, StreamExt};
 use nix::unistd::Uid;
 use std::{
     collections::VecDeque,
-    convert::{TryFrom, TryInto},
     fmt::{self, Debug},
     path::PathBuf,
     str::FromStr,

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -7,7 +7,6 @@ use ordered_stream::{OrderedFuture, OrderedStream, PollResult};
 use static_assertions::assert_impl_all;
 use std::{
     collections::HashMap,
-    convert::TryInto,
     io::{self, ErrorKind},
     ops::Deref,
     pin::Pin,

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -1001,7 +1001,6 @@ mod tests {
     use crate::{fdo, message::Message, DBusError, Error};
     use futures_util::StreamExt;
     use ntest::timeout;
-    use std::convert::TryInto;
     use test_log::test;
     use tokio::runtime;
     use zbus_names::WellKnownName;

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::{Borrow, BorrowMut},
-    convert::{TryFrom, TryInto},
     fmt,
     iter::repeat_with,
     ops::{Deref, DerefMut},

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -211,7 +211,6 @@ use zvariant::OwnedFd;
 mod tests {
     use std::{
         collections::HashMap,
-        convert::{TryFrom, TryInto},
         sync::{mpsc::channel, Arc, Condvar, Mutex},
     };
     #[cfg(unix)]

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 use static_assertions::assert_impl_all;
 
@@ -257,8 +257,7 @@ impl<'m> Builder<'m> {
             return Err(Error::InvalidMatchRule);
         }
 
-        self.0.arg0ns = Some(namespace.clone());
-        self.0.arg0namespace = InterfaceName::try_from(namespace).ok();
+        self.0.arg0ns = Some(namespace);
 
         Ok(self)
     }
@@ -274,7 +273,6 @@ impl<'m> Builder<'m> {
             destination: None,
             args: Vec::with_capacity(MAX_ARGS as usize),
             arg_paths: Vec::with_capacity(MAX_ARGS as usize),
-            arg0namespace: None,
             arg0ns: None,
         })
     }

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use static_assertions::assert_impl_all;
 
 use crate::{

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -97,7 +97,6 @@ pub struct MatchRule<'m> {
     pub(crate) destination: Option<UniqueName<'m>>,
     pub(crate) args: Vec<(u8, Str<'m>)>,
     pub(crate) arg_paths: Vec<(u8, ObjectPath<'m>)>,
-    pub(crate) arg0namespace: Option<InterfaceName<'m>>,
     pub(crate) arg0ns: Option<Str<'m>>,
 }
 
@@ -169,7 +168,6 @@ impl<'m> MatchRule<'m> {
                 .iter()
                 .map(|(i, p)| (*i, p.to_owned()))
                 .collect(),
-            arg0namespace: self.arg0namespace.as_ref().map(|a| a.to_owned()),
             arg0ns: self.arg0ns.as_ref().map(|a| a.to_owned()),
         }
     }
@@ -193,7 +191,6 @@ impl<'m> MatchRule<'m> {
                 .into_iter()
                 .map(|(i, p)| (i, p.into_owned()))
                 .collect(),
-            arg0namespace: self.arg0namespace.map(|a| a.into_owned()),
             arg0ns: self.arg0ns.map(|a| a.into_owned()),
         }
     }

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -1,7 +1,7 @@
 //! Bus match rule API.
 
 use core::panic;
-use std::{convert::TryFrom, ops::Deref};
+use std::ops::Deref;
 
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::{Into, TryInto},
-    io::{Cursor, Write},
-};
+use std::io::{Cursor, Write};
 
 #[cfg(unix)]
 use crate::message::Fds;

--- a/zbus/src/message/field.rs
+++ b/zbus/src/message/field.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use serde::{
     de::{Deserialize, Deserializer, Error},
     ser::{Serialize, Serializer},

--- a/zbus/src/message/fields.rs
+++ b/zbus/src/message/fields.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use static_assertions::assert_impl_all;
-use std::convert::{TryFrom, TryInto};
 use zbus_names::{InterfaceName, MemberName};
 use zvariant::{ObjectPath, Type};
 

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use enumflags2::{bitflags, BitFlags};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -382,11 +380,7 @@ impl<'m> Header<'m> {
 mod tests {
     use crate::message::{Field, Fields, Header, PrimaryHeader, Type};
 
-    use std::{
-        convert::{TryFrom, TryInto},
-        error::Error,
-        result::Result,
-    };
+    use std::{error::Error, result::Result};
     use test_log::test;
     use zbus_names::{InterfaceName, MemberName};
     use zvariant::{ObjectPath, Signature};

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -1,9 +1,5 @@
 //! D-Bus Message.
-use std::{
-    convert::{Into, TryFrom, TryInto},
-    fmt,
-    io::Cursor,
-};
+use std::{fmt, io::Cursor};
 
 #[cfg(unix)]
 use std::{

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryInto,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -4,7 +4,6 @@ use event_listener::{Event, EventListener};
 use serde::Serialize;
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
-    convert::TryInto,
     fmt::Write,
     marker::PhantomData,
     ops::{Deref, DerefMut},

--- a/zbus/src/object_server/signal_context.rs
+++ b/zbus/src/object_server/signal_context.rs
@@ -1,7 +1,6 @@
 use zbus_names::BusName;
 
 use crate::{zvariant::ObjectPath, Connection, Error, Result};
-use std::convert::TryInto;
 
 /// A signal emission context.
 ///

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, convert::TryInto, marker::PhantomData, sync::Arc};
+use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 
 use static_assertions::assert_impl_all;
 use zbus_names::{BusName, InterfaceName};

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -9,7 +9,6 @@ use ordered_stream::{join as join_streams, FromFuture, Join, OrderedStream, Poll
 use static_assertions::assert_impl_all;
 use std::{
     collections::{HashMap, HashSet},
-    convert::{TryFrom, TryInto},
     future::Future,
     ops::Deref,
     pin::Pin,

--- a/zbus/src/xml.rs
+++ b/zbus/src/xml.rs
@@ -16,7 +16,6 @@ use quick_xml::{de::Deserializer, se::to_writer};
 use serde::{Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
-    convert::{TryFrom, TryInto},
     io::{BufReader, Read, Write},
     result::Result,
 };

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_names)]
+use std::collections::HashMap;
 #[cfg(all(unix, not(feature = "tokio")))]
 use std::os::unix::net::UnixStream;
-use std::{collections::HashMap, convert::TryInto};
 #[cfg(all(unix, feature = "tokio"))]
 use tokio::net::UnixStream;
 

--- a/zbus/tests/xml.rs
+++ b/zbus/tests/xml.rs
@@ -1,10 +1,7 @@
 #![cfg(feature = "xml")]
 
 use quick_xml::de::DeError;
-use std::{
-    convert::{TryFrom, TryInto},
-    error::Error,
-};
+use std::error::Error;
 use test_log::test;
 
 use zbus::xml::{ArgDirection, Node};

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -2,7 +2,7 @@ use futures_util::{
     future::{select, Either},
     stream::StreamExt,
 };
-use std::{convert::TryInto, future::ready};
+use std::future::ready;
 use zbus::{block_on, fdo, object_server::SignalContext, proxy::CacheProperties};
 use zbus_macros::{dbus_interface, dbus_proxy, DBusError};
 

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -1,10 +1,9 @@
 use core::{
     borrow::Borrow,
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
 };
-use std::{borrow::Cow, convert::TryInto, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use crate::{Error, OwnedUniqueName, OwnedWellKnownName, Result, UniqueName, WellKnownName};
 use serde::{de, Deserialize, Serialize};

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
     sync::Arc,

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
     sync::Arc,

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
     sync::Arc,

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
     sync::Arc,

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     ops::Deref,
     sync::Arc,

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_idioms)]
 
 use std::{
-    convert::TryInto,
     env::args,
     error::Error,
     fs::File,

--- a/zvariant/src/array.rs
+++ b/zvariant/src/array.rs
@@ -4,10 +4,7 @@ use serde::{
     ser::{Serialize, SerializeSeq, Serializer},
 };
 use static_assertions::assert_impl_all;
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt::{Display, Write},
-};
+use std::fmt::{Display, Write};
 
 use crate::{
     value::{value_display_fmt, SignatureSeed},

--- a/zvariant/src/complete_type.rs
+++ b/zvariant/src/complete_type.rs
@@ -1,7 +1,4 @@
-use core::{
-    convert::TryFrom,
-    fmt::{self, Debug, Display, Formatter},
-};
+use core::fmt::{self, Debug, Display, Formatter};
 use serde::de::{Deserialize, Deserializer};
 use static_assertions::assert_impl_all;
 

--- a/zvariant/src/dbus/de.rs
+++ b/zvariant/src/dbus/de.rs
@@ -1,5 +1,3 @@
-use core::convert::TryFrom;
-
 use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, Visitor};
 use static_assertions::assert_impl_all;
 

--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    convert::TryFrom,
     fmt::{Display, Write},
     hash::BuildHasher,
 };

--- a/zvariant/src/from_value.rs
+++ b/zvariant/src/from_value.rs
@@ -8,7 +8,7 @@ use crate::{
 #[cfg(unix)]
 use crate::Fd;
 
-use std::{collections::HashMap, convert::TryFrom, hash::BuildHasher};
+use std::{collections::HashMap, hash::BuildHasher};
 
 macro_rules! value_try_from {
     ($kind:ident, $to:ty) => {

--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -1,5 +1,3 @@
-use core::convert::TryFrom;
-
 use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, Visitor};
 use static_assertions::assert_impl_all;
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -114,7 +114,6 @@ pub mod export {
 mod tests {
     use std::{
         collections::HashMap,
-        convert::{TryFrom, TryInto},
         net::{IpAddr, Ipv4Addr, Ipv6Addr},
     };
 

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, Serializer};
 use static_assertions::assert_impl_all;
-use std::{convert::TryFrom, fmt::Display};
+use std::fmt::Display;
 
 use crate::{value_display_fmt, Error, Signature, Type, Value};
 

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -1,4 +1,4 @@
-use core::{convert::TryFrom, fmt::Debug, str};
+use core::{fmt::Debug, str};
 use serde::{
     de::{self, Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryInto,
     fmt::Display,
     ops::{Deref, DerefMut},
 };

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use static_assertions::assert_impl_all;
-use std::{collections::HashMap, convert::TryFrom, hash::BuildHasher};
+use std::{collections::HashMap, hash::BuildHasher};
 
 use crate::{
     Array, Dict, ObjectPath, OwnedObjectPath, OwnedSignature, Signature, Str, Structure, Type,
@@ -236,7 +236,7 @@ impl<'de> Deserialize<'de> for OwnedValue {
 #[cfg(test)]
 mod tests {
     use byteorder::LE;
-    use std::{collections::HashMap, convert::TryFrom, error::Error, result::Result};
+    use std::{collections::HashMap, error::Error, result::Result};
 
     use crate::{from_slice, to_bytes, EncodingContext, OwnedValue, Value};
 

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -1,5 +1,4 @@
 use core::{
-    convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
     str,
 };

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -4,10 +4,7 @@ use serde::{
     ser::{Serialize, SerializeTupleStruct, Serializer},
 };
 use static_assertions::assert_impl_all;
-use std::{
-    convert::TryInto,
-    fmt::{Display, Write},
-};
+use std::fmt::{Display, Write};
 
 use crate::{
     signature_parser::SignatureParser, value::SignatureSeed, value_display_fmt, DynamicDeserialize,
@@ -108,7 +105,7 @@ impl<'a> StructureSeed<'a> {
     }
 }
 
-impl<'a> std::convert::TryFrom<Signature<'a>> for StructureSeed<'a> {
+impl<'a> TryFrom<Signature<'a>> for StructureSeed<'a> {
     type Error = zvariant::Error;
 
     fn try_from(signature: Signature<'a>) -> Result<Self, zvariant::Error> {
@@ -315,9 +312,9 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<'a, E, $($name),+> std::convert::TryFrom<Structure<'a>> for ($($name),+,)
+            impl<'a, E, $($name),+> TryFrom<Structure<'a>> for ($($name),+,)
             where
-                $($name: std::convert::TryFrom<Value<'a>, Error = E>,)+
+                $($name: TryFrom<Value<'a>, Error = E>,)+
                 crate::Error: From<E>,
 
             {
@@ -332,9 +329,9 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<'a, E, $($name),+> std::convert::TryFrom<Value<'a>> for ($($name),+,)
+            impl<'a, E, $($name),+> TryFrom<Value<'a>> for ($($name),+,)
             where
-                $($name: std::convert::TryFrom<Value<'a>, Error = E>,)+
+                $($name: TryFrom<Value<'a>, Error = E>,)+
                 crate::Error: From<E>,
 
             {
@@ -345,9 +342,9 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<E, $($name),+> std::convert::TryFrom<OwnedValue> for ($($name),+,)
+            impl<E, $($name),+> TryFrom<OwnedValue> for ($($name),+,)
             where
-                $($name: std::convert::TryFrom<Value<'static>, Error = E>,)+
+                $($name: TryFrom<Value<'static>, Error = E>,)+
                 crate::Error: From<E>,
 
             {

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -1,7 +1,6 @@
 use crate::{utils::*, Signature};
 use serde::de::{Deserialize, DeserializeSeed};
 use std::{
-    convert::TryInto,
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::{Path, PathBuf},

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -1,6 +1,5 @@
 use core::str;
 use std::{
-    convert::TryFrom,
     fmt::{Display, Write},
     marker::PhantomData,
 };


### PR DESCRIPTION
It was replaced by arg0ns and is now unused.