### PR TITLE
Add explicit return statement for readability

### DIFF
--- a/zbus/src/address.rs
+++ b/zbus/src/address.rs
@@ -422,7 +422,8 @@ impl Address {
                         .unwrap_or_else(|_| format!("/run/user/{}", Uid::effective()));
                     let path = format!("unix:path={runtime_dir}/bus");
 
-                    Self::from_str(&path)
+                    #[allow(clippy::needless_return)]
+                    return Self::from_str(&path);
                 }
 
                 #[cfg(target_os = "macos")]


### PR DESCRIPTION
A typo fix and an explicit `return` to match the surrounding code