### PR TITLE
✨ zb: add ProxyImpl trait

### DIFF
--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -527,3 +527,19 @@ mod tests {
         assert!(signal.args().unwrap().name() == well_known);
     }
 }
+
+/// This trait is implemented by all blocking proxies, which were
+/// generated with the [`dbus_proxy`](zbus::dbus_proxy) macro.
+pub trait ProxyImpl<'c>
+where
+    Self: Sized,
+{
+    /// Returns a customizable builder for this proxy.
+    fn builder(conn: &Connection) -> Builder<'c, Self>;
+
+    /// Consumes `self`, returning the underlying `zbus::Proxy`.
+    fn into_inner(self) -> Proxy<'c>;
+
+    /// The reference to the underlying `zbus::Proxy`.
+    fn inner(&self) -> &Proxy<'c>;
+}

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1504,3 +1504,19 @@ mod tests {
         Ok(())
     }
 }
+
+/// This trait is implemented by all async proxies, which were
+/// generated with the [`dbus_proxy`](zbus::dbus_proxy) macro.
+pub trait ProxyImpl<'c>
+where
+    Self: Sized,
+{
+    /// Returns a customizable builder for this proxy.
+    fn builder(conn: &Connection) -> Builder<'c, Self>;
+
+    /// Consumes `self`, returning the underlying `zbus::Proxy`.
+    fn into_inner(self) -> Proxy<'c>;
+
+    /// The reference to the underlying `zbus::Proxy`.
+    fn inner(&self) -> &Proxy<'c>;
+}


### PR DESCRIPTION
This PR fixes #433 by adding a `ProxyImpl` trait for macro generated proxy-structs to allow narrowing generic arguments to D-Bus proxies.