### PR TITLE
📝 add toolchain to test command in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ than waiting for the CI servers to run tests for you.
 
 ```sh
 # Run the full test suite, including doc test and compile-tests
-cargo test --all-features
+cargo +nightly test --all-features
 ```
 
 Also please ensure that code is formatted correctly by running:


### PR DESCRIPTION
Updated the test command in the contributing guide, since the tests currently require the nightly toolchain to run.

```
$ cargo test --all-features
   Compiling zbus_macros v4.0.0 (/home/jonas/projects/temp/zbus/zbus_macros)
   Compiling thiserror v1.0.44
error[E0554]: `#![feature]` may not be used on the stable release channel
   --> /home/jonas/.cargo/registry/src/index.crates.io-6f17d22bba15001f/thiserror-1.0.44/src/lib.rs:239:34
    |
239 | #![cfg_attr(provide_any, feature(provide_any))]
    |                                  ^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.

```