### PR TITLE
🧑‍💻 zv, zn: Improve Str, Owned*Name, BusName Debug impls

### DIFF
--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -1,6 +1,6 @@
 use core::{
     borrow::Borrow,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
 };
 use std::{borrow::Cow, sync::Arc};
@@ -330,7 +330,7 @@ impl<'a> From<&'a OwnedWellKnownName> for BusName<'a> {
 }
 
 /// Owned sibling of [`BusName`].
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, PartialOrd, Ord, Type)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, PartialOrd, Ord, Type)]
 pub struct OwnedBusName(#[serde(borrow)] BusName<'static>);
 
 impl OwnedBusName {
@@ -359,9 +359,15 @@ impl Borrow<str> for OwnedBusName {
     }
 }
 
+impl Debug for OwnedBusName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedBusName").field(&self.as_str()).finish()
+    }
+}
+
 impl Display for OwnedBusName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        BusName::from(self).fmt(f)
+        Display::fmt(&BusName::from(self), f)
     }
 }
 

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -43,7 +43,7 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [bus name]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(untagged)]
 pub enum BusName<'name> {
     #[serde(borrow)]
@@ -109,6 +109,21 @@ impl Deref for BusName<'_> {
 impl Borrow<str> for BusName<'_> {
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl Debug for BusName<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BusName::Unique(name) => f
+                .debug_tuple("BusName::Unique")
+                .field(&name.as_str())
+                .finish(),
+            BusName::WellKnown(name) => f
+                .debug_tuple("BusName::WellKnown")
+                .field(&name.as_str())
+                .finish(),
+        }
     }
 }
 
@@ -361,7 +376,16 @@ impl Borrow<str> for OwnedBusName {
 
 impl Debug for OwnedBusName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("OwnedBusName").field(&self.as_str()).finish()
+        match &self.0 {
+            BusName::Unique(name) => f
+                .debug_tuple("OwnedBusName::Unique")
+                .field(&name.as_str())
+                .finish(),
+            BusName::WellKnown(name) => f
+                .debug_tuple("OwnedBusName::WellKnown")
+                .field(&name.as_str())
+                .finish(),
+        }
     }
 }
 

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -3,7 +3,7 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
@@ -239,9 +239,7 @@ impl<'name> NoneValue for ErrorName<'name> {
 }
 
 /// Owned sibling of [`ErrorName`].
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedErrorName(#[serde(borrow)] ErrorName<'static>);
 
 assert_impl_all!(OwnedErrorName: Send, Sync, Unpin);
@@ -319,9 +317,17 @@ impl PartialEq<ErrorName<'_>> for OwnedErrorName {
     }
 }
 
+impl Debug for OwnedErrorName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedErrorName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
 impl Display for OwnedErrorName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        ErrorName::from(self).fmt(f)
+        Display::fmt(&ErrorName::from(self), f)
     }
 }
 

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -3,7 +3,7 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
@@ -237,9 +237,7 @@ impl<'name> NoneValue for InterfaceName<'name> {
 }
 
 /// Owned sibling of [`InterfaceName`].
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedInterfaceName(#[serde(borrow)] InterfaceName<'static>);
 
 assert_impl_all!(OwnedInterfaceName: Send, Sync, Unpin);
@@ -317,9 +315,17 @@ impl PartialEq<InterfaceName<'_>> for OwnedInterfaceName {
     }
 }
 
+impl Debug for OwnedInterfaceName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedInterfaceName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
 impl Display for OwnedInterfaceName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        InterfaceName::from(self).fmt(f)
+        Display::fmt(&InterfaceName::from(self), f)
     }
 }
 

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -3,7 +3,7 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
@@ -215,9 +215,7 @@ impl<'name> NoneValue for MemberName<'name> {
 }
 
 /// Owned sibling of [`MemberName`].
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedMemberName(#[serde(borrow)] MemberName<'static>);
 
 assert_impl_all!(OwnedMemberName: Send, Sync, Unpin);
@@ -295,9 +293,17 @@ impl PartialEq<MemberName<'_>> for OwnedMemberName {
     }
 }
 
+impl Debug for OwnedMemberName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedMemberName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
 impl Display for OwnedMemberName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        MemberName::from(self).fmt(f)
+        Display::fmt(&MemberName::from(self), f)
     }
 }
 

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -3,7 +3,7 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
@@ -231,9 +231,7 @@ impl<'name> NoneValue for UniqueName<'name> {
 }
 
 /// Owned sibling of [`UniqueName`].
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedUniqueName(#[serde(borrow)] UniqueName<'static>);
 
 assert_impl_all!(OwnedUniqueName: Send, Sync, Unpin);
@@ -326,8 +324,16 @@ impl NoneValue for OwnedUniqueName {
     }
 }
 
+impl Debug for OwnedUniqueName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedUniqueName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
 impl Display for OwnedUniqueName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        UniqueName::from(self).fmt(f)
+        Display::fmt(&UniqueName::from(self), f)
     }
 }

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -3,7 +3,7 @@ use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
@@ -232,9 +232,7 @@ impl<'name> NoneValue for WellKnownName<'name> {
 }
 
 /// Owned sibling of [`WellKnownName`].
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedWellKnownName(#[serde(borrow)] WellKnownName<'static>);
 
 assert_impl_all!(OwnedWellKnownName: Send, Sync, Unpin);
@@ -271,9 +269,17 @@ impl AsRef<str> for OwnedWellKnownName {
     }
 }
 
+impl Debug for OwnedWellKnownName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("OwnedWellKnownName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
 impl Display for OwnedWellKnownName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        WellKnownName::from(self).fmt(f)
+        Display::fmt(&WellKnownName::from(self), f)
     }
 }
 

--- a/zvariant/src/str.rs
+++ b/zvariant/src/str.rs
@@ -17,11 +17,11 @@ use crate::{Basic, EncodingFormat, Signature, Type};
 /// [`Value`]: enum.Value.html#variant.Str
 /// [`&str`]: https://doc.rust-lang.org/std/str/index.html
 /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
+#[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
 #[serde(rename(serialize = "zvariant::Str", deserialize = "zvariant::Str"))]
 pub struct Str<'a>(#[serde(borrow)] Inner<'a>);
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Eq, Clone)]
 enum Inner<'a> {
     Static(&'static str),
     Borrowed(&'a str),
@@ -205,9 +205,15 @@ impl<'a> PartialEq<&str> for Str<'a> {
     }
 }
 
+impl<'a> std::fmt::Debug for Str<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
 impl<'a> std::fmt::Display for Str<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.as_str().fmt(f)
+        std::fmt::Display::fmt(self.as_str(), f)
     }
 }
 


### PR DESCRIPTION
This PR reduces Debug impls verbosity but retains possibly useful information.

See also https://github.com/dbus2/zbus/pull/394 

Before:

```
Str::from_static("hello") = Str(
    Static(
        "hello",
    ),
)
Str::from("hello") = Str(
    Borrowed(
        "hello",
    ),
)
Str::from(String::from("hello")) = Str(
    Owned(
        "hello",
    ),
)
UniqueName::from_static_str_unchecked(":1.2") = UniqueName(
    Str(
        Static(
            ":1.2",
        ),
    ),
)
OwnedUniqueName::from(UniqueName::from_static_str_unchecked(":1.2")) = OwnedUniqueName(
    UniqueName(
        Str(
            Static(
                ":1.2",
            ),
        ),
    ),
)
WellKnownName::from_static_str_unchecked("org.gnome.Console") = WellKnownName(
    Str(
        Static(
            "org.gnome.Console",
        ),
    ),
)
OwnedWellKnownName::from(WellKnownName::from_static_str_unchecked("org.gnome.Console")) = OwnedWellKnownName(
    WellKnownName(
        Str(
            Static(
                "org.gnome.Console",
            ),
        ),
    ),
)
BusName::Unique(UniqueName::from_static_str_unchecked(":1.2")) = Unique(
    UniqueName(
        Str(
            Static(
                ":1.2",
            ),
        ),
    ),
)
BusName::WellKnown(WellKnownName::from_static_str_unchecked("org.gnome.Console")) = WellKnown(
    WellKnownName(
        Str(
            Static(
                "org.gnome.Console",
            ),
        ),
    ),
)
OwnedBusName::from(BusName::Unique(UniqueName::from_static_str_unchecked(":1.2"))) = OwnedBusName(
    Unique(
        UniqueName(
            Str(
                Static(
                    ":1.2",
                ),
            ),
        ),
    ),
)
OwnedBusName::from(BusName::WellKnown(WellKnownName::from_static_str_unchecked("org.gnome.Console"))) = OwnedBusName(
    WellKnown(
        WellKnownName(
            Str(
                Static(
                    "org.gnome.Console",
                ),
            ),
        ),
    ),
)
ErrorName::from_static_str_unchecked("org.gnome.Console.Error") = ErrorName(
    Str(
        Static(
            "org.gnome.Console.Error",
        ),
    ),
)
OwnedErrorName::from(ErrorName::from_static_str_unchecked("org.gnome.Console.Error")) = OwnedErrorName(
    ErrorName(
        Str(
            Static(
                "org.gnome.Console.Error",
            ),
        ),
    ),
)
InterfaceName::from_static_str_unchecked("org.gnome.Console.Interface") = InterfaceName(
    Str(
        Static(
            "org.gnome.Console.Interface",
        ),
    ),
)
OwnedInterfaceName::from(InterfaceName::from_static_str_unchecked("org.gnome.Console.Interface")) = OwnedInterfaceName(
    InterfaceName(
        Str(
            Static(
                "org.gnome.Console.Interface",
            ),
        ),
    ),
)
MemberName::from_static_str_unchecked("Member") = MemberName(
    Str(
        Static(
            "Member",
        ),
    ),
)
OwnedMemberName::from(MemberName::from_static_str_unchecked("Member")) = OwnedMemberName(
    MemberName(
        Str(
            Static(
                "Member",
            ),
        ),
    ),
)
```

After:

```
Str::from_static("hello") = "hello"
Str::from("hello") = "hello"
Str::from(String::from("hello")) = "hello"
UniqueName::from_static_str_unchecked(":1.2") = UniqueName(
    ":1.2",
)
OwnedUniqueName::from(UniqueName::from_static_str_unchecked(":1.2")) = OwnedUniqueName(
    ":1.2",
)
WellKnownName::from_static_str_unchecked("org.gnome.Console") = WellKnownName(
    "org.gnome.Console",
)
OwnedWellKnownName::from(WellKnownName::from_static_str_unchecked("org.gnome.Console")) = OwnedWellKnownName(
    "org.gnome.Console",
)
BusName::Unique(UniqueName::from_static_str_unchecked(":1.2")) = BusName::Unique(
    ":1.2",
)
BusName::WellKnown(WellKnownName::from_static_str_unchecked("org.gnome.Console")) = BusName::WellKnown(
    "org.gnome.Console",
)
OwnedBusName::from(BusName::Unique(UniqueName::from_static_str_unchecked(":1.2"))) = OwnedBusName::Unique(
    ":1.2",
)
OwnedBusName::from(BusName::WellKnown(WellKnownName::from_static_str_unchecked("org.gnome.Console"))) = OwnedBusName::WellKnown(
    "org.gnome.Console",
)
ErrorName::from_static_str_unchecked("org.gnome.Console.Error") = ErrorName(
    "org.gnome.Console.Error",
)
OwnedErrorName::from(ErrorName::from_static_str_unchecked("org.gnome.Console.Error")) = OwnedErrorName(
    "org.gnome.Console.Error",
)
InterfaceName::from_static_str_unchecked("org.gnome.Console.Interface") = InterfaceName(
    "org.gnome.Console.Interface",
)
OwnedInterfaceName::from(InterfaceName::from_static_str_unchecked("org.gnome.Console.Interface")) = OwnedInterfaceName(
    "org.gnome.Console.Interface",
)
MemberName::from_static_str_unchecked("Member") = MemberName(
    "Member",
)
OwnedMemberName::from(MemberName::from_static_str_unchecked("Member")) = OwnedMemberName(
    "Member",
)
```

Fixes #431.