### PR TITLE
🐛 zx: Fix declaring proxies for writable properties

### DIFF
--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -21,5 +21,6 @@ trait SampleInterface0 {
     /// Bar property
     #[dbus_proxy(property)]
     fn bar(&self) -> zbus::Result<u8>;
+    #[dbus_proxy(property)]
     fn set_bar(&self, value: u8) -> zbus::Result<()>;
 }


### PR DESCRIPTION
The `#[dbus_proxy(property)]` attribute needs to be present also at the `set_foo` function, otherwise the proxy will call a `SetFoo` method instead of `Set`ting the `Foo` property.

Example:
https://github.com/openSUSE/agama/pull/712