### PR TITLE
💥 zb: Improved Socket trait + drop Sink implementation

### DIFF
--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -13,9 +13,7 @@ in panics and hangs. This is not a limitation of zbus but rather a
 
 The only difference to that of [asynchronous `Connection` API] is that you use
 [`blocking::Connection`] type instead. This type's API is almost identical to that of `Connection`,
-except all its methods are blocking. One notable difference is that there is no equivalent of
-[`futures::sink::Sink`] implementation provided. There is however [`blocking::MessageIterator`]
-type, that implements [`std::iter::Iterator`].
+except all its methods are blocking.
 
 ## Client
 
@@ -201,7 +199,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 [asynchronous `Connection` API]: https://docs.rs/zbus/latest/zbus/connection/struct.Connection.html
 [`blocking::Connection`]: https://docs.rs/zbus/latest/zbus/blocking/connection/struct.Connection.html
-[`futures::sink::Sink`]: https://docs.rs/futures/latest/futures/sink/trait.Sink.html
 [`std::iter::Iterator`]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html
 [blocking module]: https://docs.rs/zbus/latest/zbus/blocking/index.html
 [wkgp]: https://rust-lang.github.io/wg-async-foundations/vision/shiny_future/users_manual.html#caveat-beware-the-async-sandwich

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -10,9 +10,9 @@ returns an instance of the connection (if all went well). Similarly, to connect 
 (to communicate with services such as [NetworkManager], [BlueZ] or [PID1]), use
 `Connection::system()`.
 
-Moreover, it also implements [`futures::sink::Sink`] and can be converted to a [`MessageStream`]
-that implements [`futures::stream::Stream`], which can be used to conveniently send and receive
-messages, for the times when low-level API is more appropriate for your use case.
+Moreover, it can be converted to a [`MessageStream`] that implements [`futures::stream::Stream`],
+which can be used to conveniently receive messages, for the times when low-level API is
+more appropriate for your use case.
 
 **Note:** it is common for a D-Bus library to provide a "shared" connection to a bus for a process:
 all `session()` share the same underlying connection for example. At the time of this writing,
@@ -71,7 +71,6 @@ let (client_conn, server_conn) = futures_util::try_join!(
 [BlueZ]: https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc
 [PID1]: https://www.freedesktop.org/wiki/Software/systemd/dbus/
 [`futures::stream::Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
-[`futures::sink::Sink`]: https://docs.rs/futures/latest/futures/sink/trait.Sink.html
 [`MessageStream`]: https://docs.rs/zbus/latest/zbus/struct.MessageStream.html
 [`Builder::address`]: https://docs.rs/zbus/latest/zbus/connection/struct.ConnectionBuilder.html#method.address
 [dspec]: https://dbus.freedesktop.org/doc/dbus-specification.html#addresses

--- a/zbus/src/abstractions/async_lock.rs
+++ b/zbus/src/abstractions/async_lock.rs
@@ -1,4 +1,4 @@
 #[cfg(not(feature = "tokio"))]
-pub(crate) use async_lock::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use async_lock::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(feature = "tokio")]
-pub(crate) use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -267,6 +267,13 @@ impl Connection {
     pub fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
         block_on(self.inner.peer_credentials())
     }
+
+    /// Close the connection.
+    ///
+    /// After this call, all reading and writing operations will fail.
+    pub fn close(self) -> Result<()> {
+        block_on(self.inner.close())
+    }
 }
 
 impl From<crate::Connection> for Connection {

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -20,10 +20,7 @@ pub use builder::Builder;
 
 /// A blocking wrapper of [`zbus::Connection`].
 ///
-/// Most of the API is very similar to [`zbus::Connection`], except it's blocking. One
-/// notable difference is that there is no equivalent of [`Sink`] implementation provided.
-///
-/// [`Sink`]: https://docs.rs/futures/0.3.17/futures/sink/trait.Sink.html
+/// Most of the API is very similar to [`zbus::Connection`], except it's blocking.
 #[derive(derivative::Derivative, Clone)]
 #[derivative(Debug)]
 #[must_use = "Dropping a `Connection` will close the underlying socket."]

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -375,11 +375,11 @@ impl<'a> Builder<'a> {
                     return Err(Error::Unsupported);
                 }
 
+                let creds = stream.read().peer_credentials()?;
                 #[cfg(unix)]
-                let client_uid = stream.read().uid()?;
-
+                let client_uid = creds.unix_user_id();
                 #[cfg(windows)]
-                let client_sid = stream.read().peer_sid();
+                let client_sid = creds.into_windows_sid();
 
                 Authenticated::server(
                     stream,

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -375,7 +375,7 @@ impl<'a> Builder<'a> {
                     return Err(Error::Unsupported);
                 }
 
-                let creds = stream.read().peer_credentials()?;
+                let creds = stream.read().peer_credentials().await?;
                 #[cfg(unix)]
                 let client_uid = creds.unix_user_id();
                 #[cfg(windows)]

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -699,9 +699,7 @@ impl<R: ReadHalf, W: WriteHalf> Handshake<R, W> for ServerHandshake<'_, R, W> {
                 ServerHandshakeStep::WaitingForNull => {
                     trace!("Waiting for NULL");
                     let mut buffer = [0; 1];
-                    let read =
-                        poll_fn(|cx| self.common.socket.read_mut().poll_recvmsg(cx, &mut buffer))
-                            .await?;
+                    let read = self.common.socket.read_mut().recvmsg(&mut buffer).await?;
                     #[cfg(unix)]
                     let read = read.0;
                     // recvmsg cannot return anything else than Ok(1) or Err
@@ -978,7 +976,7 @@ impl<R: ReadHalf, W: WriteHalf> HandshakeCommon<R, W> {
             }
 
             let mut buf = [0; 64];
-            let res = poll_fn(|cx| self.socket.read_mut().poll_recvmsg(cx, &mut buf)).await?;
+            let res = self.socket.read_mut().recvmsg(&mut buf).await?;
             let read = {
                 #[cfg(unix)]
                 {

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -402,6 +402,7 @@ impl<R: ReadHalf, W: WriteHalf> Handshake<R, W> for ClientHandshake<R, W> {
                         .socket
                         .write()
                         .send_zero_byte()
+                        .await
                         .map_err(|e| {
                             Error::Handshake(format!(
                                 "Could not send zero byte with credentials: {}",

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -19,7 +19,10 @@ use xdg_home::home_dir;
 use crate::win32;
 use crate::{file::FileLines, guid::Guid, Error, Result};
 
-use super::raw::{Connection, Socket};
+use super::raw::{
+    socket::{ReadHalf, Split, WriteHalf},
+    Connection,
+};
 
 /// Authentication mechanisms
 ///
@@ -49,8 +52,8 @@ pub enum AuthMechanism {
 /// [`ServerHandshake`]: struct.ServerHandshake.html
 /// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
-pub struct Authenticated<S> {
-    pub(crate) conn: Connection<S>,
+pub struct Authenticated<R, W> {
+    pub(crate) conn: Connection<R, W>,
     /// The server Guid
     pub(crate) server_guid: Guid,
     /// Whether file descriptor passing has been accepted by both sides
@@ -58,12 +61,16 @@ pub struct Authenticated<S> {
     pub(crate) cap_unix_fd: bool,
 }
 
-impl<S> Authenticated<S>
+impl<R, W> Authenticated<R, W>
 where
-    S: Socket + Unpin,
+    R: ReadHalf + Unpin,
+    W: WriteHalf + Unpin,
 {
     /// Create a client-side `Authenticated` for the given `socket`.
-    pub async fn client(socket: S, mechanisms: Option<VecDeque<AuthMechanism>>) -> Result<Self> {
+    pub async fn client(
+        socket: Split<R, W>,
+        mechanisms: Option<VecDeque<AuthMechanism>>,
+    ) -> Result<Self> {
         ClientHandshake::new(socket, mechanisms).perform().await
     }
 
@@ -71,7 +78,7 @@ where
     ///
     /// The function takes `client_uid` on Unix only. On Windows, it takes `client_sid` instead.
     pub async fn server(
-        socket: S,
+        socket: Split<R, W>,
         guid: Guid,
         #[cfg(unix)] client_uid: Option<u32>,
         #[cfg(windows)] client_sid: Option<String>,
@@ -142,23 +149,26 @@ enum Command {
 /// [`Authenticated`]: struct.AUthenticated.html
 /// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
-pub struct ClientHandshake<S> {
-    common: HandshakeCommon<S>,
+pub struct ClientHandshake<R: ReadHalf, W: WriteHalf> {
+    common: HandshakeCommon<R, W>,
     step: ClientHandshakeStep,
 }
 
 #[async_trait]
-pub trait Handshake<S> {
+pub trait Handshake<R: ReadHalf, W: WriteHalf> {
     /// Perform the handshake.
     ///
     /// On a successful handshake, you get an `Authenticated`. If you need to send a Bus Hello,
     /// this remains to be done.
-    async fn perform(mut self) -> Result<Authenticated<S>>;
+    async fn perform(mut self) -> Result<Authenticated<R, W>>;
 }
 
-impl<S: Socket> ClientHandshake<S> {
+impl<R: ReadHalf, W: WriteHalf> ClientHandshake<R, W> {
     /// Start a handshake on this client socket
-    pub fn new(socket: S, mechanisms: Option<VecDeque<AuthMechanism>>) -> ClientHandshake<S> {
+    pub fn new(
+        socket: Split<R, W>,
+        mechanisms: Option<VecDeque<AuthMechanism>>,
+    ) -> ClientHandshake<R, W> {
         let mechanisms = mechanisms.unwrap_or_else(|| {
             let mut mechanisms = VecDeque::new();
             mechanisms.push_back(AuthMechanism::External);
@@ -374,9 +384,9 @@ impl Default for CookieContext<'_> {
 }
 
 #[async_trait]
-impl<S: Socket> Handshake<S> for ClientHandshake<S> {
+impl<R: ReadHalf, W: WriteHalf> Handshake<R, W> for ClientHandshake<R, W> {
     #[instrument(skip(self))]
-    async fn perform(mut self) -> Result<Authenticated<S>> {
+    async fn perform(mut self) -> Result<Authenticated<R, W>> {
         use ClientHandshakeStep::*;
         loop {
             let (next_step, cmd) = match self.step {
@@ -390,6 +400,7 @@ impl<S: Socket> Handshake<S> for ClientHandshake<S> {
                     let written = self
                         .common
                         .socket
+                        .write()
                         .send_zero_byte()
                         .map_err(|e| {
                             Error::Handshake(format!(
@@ -407,7 +418,7 @@ impl<S: Socket> Handshake<S> for ClientHandshake<S> {
                     // leading 0 is sent separately already for `freebsd` and `dragonfly` above.
                     #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
                     let written = poll_fn(|cx| {
-                        self.common.socket.poll_sendmsg(
+                        self.common.socket.write_mut().poll_sendmsg(
                             cx,
                             &[b'\0'],
                             #[cfg(unix)]
@@ -448,7 +459,7 @@ impl<S: Socket> Handshake<S> for ClientHandshake<S> {
                         (WaitingForOK, Command::Ok(guid)) => {
                             trace!("Received OK from server");
                             self.common.server_guid = Some(guid);
-                            if self.common.socket.can_pass_unix_fd() {
+                            if self.common.socket.read_mut().can_pass_unix_fd() {
                                 (WaitingForAgreeUnixFD, Command::NegotiateUnixFD)
                             } else {
                                 (Done, Command::Begin)
@@ -527,8 +538,8 @@ enum ServerHandshakeStep {
 /// [`Authenticated`]: struct.Authenticated.html
 /// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
-pub struct ServerHandshake<'s, S> {
-    common: HandshakeCommon<S>,
+pub struct ServerHandshake<'s, R: ReadHalf, W: WriteHalf> {
+    common: HandshakeCommon<R, W>,
     step: ServerHandshakeStep,
     #[cfg(unix)]
     client_uid: Option<u32>,
@@ -538,16 +549,16 @@ pub struct ServerHandshake<'s, S> {
     cookie_context: CookieContext<'s>,
 }
 
-impl<'s, S: Socket> ServerHandshake<'s, S> {
+impl<'s, R: ReadHalf, W: WriteHalf> ServerHandshake<'s, R, W> {
     pub fn new(
-        socket: S,
+        socket: Split<R, W>,
         guid: Guid,
         #[cfg(unix)] client_uid: Option<u32>,
         #[cfg(windows)] client_sid: Option<String>,
         mechanisms: Option<VecDeque<AuthMechanism>>,
         cookie_id: Option<usize>,
         cookie_context: CookieContext<'s>,
-    ) -> Result<ServerHandshake<'s, S>> {
+    ) -> Result<ServerHandshake<'s, R, W>> {
         let mechanisms = match mechanisms {
             Some(mechanisms) => mechanisms,
             None => {
@@ -680,16 +691,17 @@ impl<'s, S: Socket> ServerHandshake<'s, S> {
 }
 
 #[async_trait]
-impl<S: Socket> Handshake<S> for ServerHandshake<'_, S> {
+impl<R: ReadHalf, W: WriteHalf> Handshake<R, W> for ServerHandshake<'_, R, W> {
     #[instrument(skip(self))]
-    async fn perform(mut self) -> Result<Authenticated<S>> {
+    async fn perform(mut self) -> Result<Authenticated<R, W>> {
         loop {
             match self.step {
                 ServerHandshakeStep::WaitingForNull => {
                     trace!("Waiting for NULL");
                     let mut buffer = [0; 1];
                     let read =
-                        poll_fn(|cx| self.common.socket.poll_recvmsg(cx, &mut buffer)).await?;
+                        poll_fn(|cx| self.common.socket.read_mut().poll_recvmsg(cx, &mut buffer))
+                            .await?;
                     #[cfg(unix)]
                     let read = read.0;
                     // recvmsg cannot return anything else than Ok(1) or Err
@@ -907,8 +919,8 @@ impl FromStr for Command {
 
 // Common code for the client and server side of the handshake.
 #[derive(Debug)]
-pub struct HandshakeCommon<S> {
-    socket: S,
+pub struct HandshakeCommon<R: ReadHalf, W: WriteHalf> {
+    socket: Split<R, W>,
     recv_buffer: Vec<u8>,
     server_guid: Option<Guid>,
     cap_unix_fd: bool,
@@ -916,9 +928,13 @@ pub struct HandshakeCommon<S> {
     mechanisms: VecDeque<AuthMechanism>,
 }
 
-impl<S: Socket> HandshakeCommon<S> {
+impl<R: ReadHalf, W: WriteHalf> HandshakeCommon<R, W> {
     /// Start a handshake on this client socket
-    pub fn new(socket: S, mechanisms: VecDeque<AuthMechanism>, server_guid: Option<Guid>) -> Self {
+    pub fn new(
+        socket: Split<R, W>,
+        mechanisms: VecDeque<AuthMechanism>,
+        server_guid: Option<Guid>,
+    ) -> Self {
         Self {
             socket,
             recv_buffer: Vec::new(),
@@ -933,7 +949,7 @@ impl<S: Socket> HandshakeCommon<S> {
         let mut send_buffer = Vec::<u8>::from(command);
         while !send_buffer.is_empty() {
             let written = poll_fn(|cx| {
-                self.socket.poll_sendmsg(
+                self.socket.write_mut().poll_sendmsg(
                     cx,
                     &send_buffer,
                     #[cfg(unix)]
@@ -962,7 +978,7 @@ impl<S: Socket> HandshakeCommon<S> {
             }
 
             let mut buf = [0; 64];
-            let res = poll_fn(|cx| self.socket.poll_recvmsg(cx, &mut buf)).await?;
+            let res = poll_fn(|cx| self.socket.read_mut().poll_recvmsg(cx, &mut buf)).await?;
             let read = {
                 #[cfg(unix)]
                 {
@@ -1016,7 +1032,7 @@ mod tests {
 
     use super::*;
 
-    use crate::Guid;
+    use crate::{Guid, Socket};
 
     fn create_async_socket_pair() -> (impl AsyncWrite + Socket, impl AsyncWrite + Socket) {
         // Tokio needs us to call the sync function from async context. :shrug:
@@ -1041,9 +1057,9 @@ mod tests {
     fn handshake() {
         let (p0, p1) = create_async_socket_pair();
 
-        let client = ClientHandshake::new(p0, None);
+        let client = ClientHandshake::new(p0.split(), None);
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             None,
@@ -1067,7 +1083,7 @@ mod tests {
     fn pipelined_handshake() {
         let (mut p0, p1) = create_async_socket_pair();
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             None,
@@ -1096,7 +1112,7 @@ mod tests {
     fn separate_external_data() {
         let (mut p0, p1) = create_async_socket_pair();
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             None,
@@ -1123,7 +1139,7 @@ mod tests {
     fn missing_external_data() {
         let (mut p0, p1) = create_async_socket_pair();
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             None,
@@ -1141,7 +1157,7 @@ mod tests {
     fn anonymous_handshake() {
         let (mut p0, p1) = create_async_socket_pair();
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             Some(vec![AuthMechanism::Anonymous].into()),
@@ -1159,7 +1175,7 @@ mod tests {
     fn separate_anonymous_data() {
         let (mut p0, p1) = create_async_socket_pair();
         let server = ServerHandshake::new(
-            p1,
+            p1.split(),
             Guid::generate(),
             Some(Uid::effective().into()),
             Some(vec![AuthMechanism::Anonymous].into()),

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1286,7 +1286,7 @@ impl Connection {
     ///
     /// After this call, all reading and writing operations will fail.
     pub async fn close(self) -> Result<()> {
-        self.inner.raw_conn.close()
+        poll_fn(|cx| self.inner.raw_conn.close(cx)).await
     }
 
     pub(crate) fn init_socket_reader(&self) {

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1256,23 +1256,7 @@ impl Connection {
     ///
     /// Currently `unix_group_ids` and `linux_security_label` fields are not populated.
     pub async fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
-        let socket = self.inner.raw_conn.socket_read().await;
-
-        Ok(ConnectionCredentials {
-            process_id: socket.peer_pid()?,
-            #[cfg(unix)]
-            unix_user_id: socket.uid()?,
-            #[cfg(not(unix))]
-            unix_user_id: None,
-            // Should we beother providing all the groups of user? What's the use case?
-            unix_group_ids: None,
-            #[cfg(windows)]
-            windows_sid: socket.peer_sid(),
-            #[cfg(not(windows))]
-            windows_sid: None,
-            // TODO: Populate this field (see the field docs for pointers).
-            linux_security_label: None,
-        })
+        self.inner.raw_conn.socket_read().await.peer_credentials()
     }
 
     /// Close the connection.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1282,6 +1282,13 @@ impl Connection {
         })
     }
 
+    /// Close the connection.
+    ///
+    /// After this call, all reading and writing operations will fail.
+    pub async fn close(self) -> Result<()> {
+        self.inner.raw_conn.close()
+    }
+
     pub(crate) fn init_socket_reader(&self) {
         let inner = &self.inner;
         inner

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1343,12 +1343,16 @@ where
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        self.inner.raw_conn.lock().expect("poisoned lock").flush(cx)
+        self.inner
+            .raw_conn
+            .lock()
+            .expect("poisoned lock")
+            .try_flush(cx)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let mut raw_conn = self.inner.raw_conn.lock().expect("poisoned lock");
-        let res = raw_conn.flush(cx);
+        let res = raw_conn.try_flush(cx);
         match ready!(res) {
             Ok(_) => (),
             Err(e) => return Poll::Ready(Err(e)),

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1256,7 +1256,12 @@ impl Connection {
     ///
     /// Currently `unix_group_ids` and `linux_security_label` fields are not populated.
     pub async fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
-        self.inner.raw_conn.socket_read().await.peer_credentials()
+        self.inner
+            .raw_conn
+            .socket_read()
+            .await
+            .peer_credentials()
+            .await
     }
 
     /// Close the connection.

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -1,5 +1,5 @@
 use crate::async_lock::{Mutex, MutexGuard};
-use std::{future::poll_fn, ops::Deref};
+use std::ops::Deref;
 
 use event_listener::{Event, EventListener};
 
@@ -182,8 +182,12 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
     /// After this call, all reading and writing operations will fail.
     pub async fn close(&self) -> crate::Result<()> {
         self.activity_event.notify(usize::MAX);
-        let mut write = self.write_socket.lock().await;
-        poll_fn(|cx| write.close(cx).map_err(|e| e.into())).await
+        self.write_socket
+            .lock()
+            .await
+            .close()
+            .await
+            .map_err(Into::into)
     }
 
     /// Access the underlying read half of the socket.

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -84,7 +84,7 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
     /// If the socket is in non-blocking mode, it may read a partial message. In such case it
     /// will buffer it internally and try to complete it the next time you call
     /// `try_receive_message`.
-    pub async fn try_receive_message(&self) -> crate::Result<Message> {
+    pub async fn receive_message(&self) -> crate::Result<Message> {
         self.activity_event.notify(usize::MAX);
         let mut inbound = self.inbound.lock().await;
         let mut bytes = inbound
@@ -261,7 +261,7 @@ mod tests {
 
         conn0.send_message(&msg).await.unwrap();
 
-        let ret = conn1.try_receive_message().await.unwrap();
+        let ret = conn1.receive_message().await.unwrap();
         assert_eq!(ret.to_string(), "Method call Test");
     }
 }

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -220,12 +220,12 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
     /// Close the connection.
     ///
     /// After this call, all reading and writing operations will fail.
-    pub fn close(&self) -> crate::Result<()> {
+    pub fn close(&self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         self.activity_event.notify(usize::MAX);
         self.write_socket
             .lock()
             .expect("lock poisoned")
-            .close()
+            .close(cx)
             .map_err(|e| e.into())
     }
 

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -63,15 +63,13 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
         while pos < data.len() {
             #[cfg(unix)]
             let fds = if pos == 0 { msg.fds() } else { vec![] };
-            pos += poll_fn(|cx| {
-                write.poll_sendmsg(
-                    cx,
+            pos += write
+                .sendmsg(
                     &data[pos..],
                     #[cfg(unix)]
                     &fds,
                 )
-            })
-            .await?;
+                .await?;
         }
         Ok(())
     }

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::VecDeque,
-    io,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -65,7 +64,7 @@ impl<S: Socket> Connection<S> {
     /// outgoing buffer into the socket, until an error is encountered.
     ///
     /// This method will thus only block if the socket is in blocking mode.
-    pub fn try_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    pub fn try_flush(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         self.event.notify(usize::MAX);
         while let Some(msg) = self.out_msgs.front() {
             loop {
@@ -212,14 +211,6 @@ impl<S: Socket> Connection<S> {
 
     pub(crate) fn monitor_activity(&self) -> EventListener {
         self.event.listen()
-    }
-}
-
-impl Connection<Box<dyn Socket>> {
-    /// Same as `try_flush` above, except it wraps the method for use in [`std::future::Future`]
-    /// impls.
-    pub(crate) fn flush(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
-        self.try_flush(cx).map_err(Into::into)
     }
 }
 

--- a/zbus/src/connection/raw/connection.rs
+++ b/zbus/src/connection/raw/connection.rs
@@ -104,7 +104,7 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
             // Given that MIN_MESSAGE_SIZE is 16, this codepath is actually extremely unlikely
             // to be taken more than once
             while pos < MIN_MESSAGE_SIZE {
-                let res = poll_fn(|cx| read.poll_recvmsg(cx, &mut bytes[pos..])).await?;
+                let res = read.recvmsg(&mut bytes[pos..]).await?;
                 let len = {
                     #[cfg(unix)]
                     {
@@ -144,7 +144,7 @@ impl<R: ReadHalf, W: WriteHalf> Connection<R, W> {
 
         // Now we have an incomplete message; read the rest
         while pos < total_len {
-            let res = poll_fn(|cx| read.poll_recvmsg(cx, &mut bytes[pos..])).await?;
+            let res = read.recvmsg(&mut bytes[pos..]).await?;
             let read = {
                 #[cfg(unix)]
                 {

--- a/zbus/src/connection/raw/mod.rs
+++ b/zbus/src/connection/raw/mod.rs
@@ -1,5 +1,4 @@
 mod connection;
-mod socket;
+pub mod socket;
 
 pub use connection::Connection;
-pub use socket::Socket;

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use futures_util::future::poll_fn;
 use tracing::{debug, instrument, trace};
 
 use crate::{async_lock::Mutex, connection::MsgBroadcaster, Executor, OwnedMatchRule, Task};
@@ -33,11 +32,7 @@ impl SocketReader {
     async fn receive_msg(self) {
         loop {
             trace!("Waiting for message on the socket..");
-            let msg = {
-                poll_fn(|cx| self.raw_conn.try_receive_message(cx))
-                    .await
-                    .map(Arc::new)
-            };
+            let msg = self.raw_conn.try_receive_message().await.map(Arc::new);
             match &msg {
                 Ok(msg) => trace!("Message received on the socket: {:?}", msg),
                 Err(e) => trace!("Error reading from the socket: {:?}", e),

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -5,17 +5,20 @@ use tracing::{debug, instrument, trace};
 
 use crate::{async_lock::Mutex, connection::MsgBroadcaster, Executor, OwnedMatchRule, Task};
 
-use super::raw::{Connection as RawConnection, Socket};
+use super::raw::{
+    socket::{ReadHalf, WriteHalf},
+    Connection as RawConnection,
+};
 
 #[derive(Debug)]
 pub(crate) struct SocketReader {
-    raw_conn: Arc<RawConnection<Box<dyn Socket>>>,
+    raw_conn: Arc<RawConnection<Box<dyn ReadHalf>, Box<dyn WriteHalf>>>,
     senders: Arc<Mutex<HashMap<Option<OwnedMatchRule>, MsgBroadcaster>>>,
 }
 
 impl SocketReader {
     pub fn new(
-        raw_conn: Arc<RawConnection<Box<dyn Socket>>>,
+        raw_conn: Arc<RawConnection<Box<dyn ReadHalf>, Box<dyn WriteHalf>>>,
         senders: Arc<Mutex<HashMap<Option<OwnedMatchRule>, MsgBroadcaster>>>,
     ) -> Self {
         Self { raw_conn, senders }

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -32,7 +32,7 @@ impl SocketReader {
     async fn receive_msg(self) {
         loop {
             trace!("Waiting for message on the socket..");
-            let msg = self.raw_conn.try_receive_message().await.map(Arc::new);
+            let msg = self.raw_conn.receive_message().await.map(Arc::new);
             match &msg {
                 Ok(msg) => trace!("Message received on the socket: {:?}", msg),
                 Err(e) => trace!("Error reading from the socket: {:?}", e),


### PR DESCRIPTION
The main change in this PR, is to rework `Socket` trait to be more high-level and provide async API. Dropping of `futures::Sink` made way for this but there are also other reasons we are probably better off without it (see the relevant commit log) until and unless this trait is improved upstream.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
