### PR TITLE
👷 CI: Enable pedantic clippy large futures warning

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Catch common mistakes and unwrap calls
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings -D clippy::large_futures
 
   linux_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've been bitten by this before (#330) so let's check for this in the CI.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).