### PR TITLE
💥 zb: Optional interface on fdo::PropertiesProxy::get_all

### DIFF
--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -93,7 +93,7 @@ macro_rules! gen_properties_proxy {
             /// Get all properties.
             async fn get_all(
                 &self,
-                interface_name: InterfaceName<'_>,
+                interface_name: Optional<InterfaceName<'_>>,
             ) -> Result<HashMap<String, OwnedValue>>;
 
             #[dbus_proxy(signal)]


### PR DESCRIPTION
According to the spec:

> An empty string may be provided for the interface name; in this case, if
> there are multiple properties on an object with the same name, the
> results are undefined (picking one by according to an arbitrary
> deterministic rule, or returning an error, are the reasonable
> possibilities).

Fixes #302.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
