### PR TITLE
🚸 Message constructor to return a builder instance

### DIFF
--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -471,7 +471,11 @@ impl Connection {
     where
         B: serde::ser::Serialize + zvariant::DynamicType,
     {
-        let m = Message::method_reply(self.unique_name(), call, body)?;
+        let mut b = Message::method_reply(call)?;
+        if let Some(sender) = self.unique_name() {
+            b = b.sender(sender)?;
+        }
+        let m = b.build(body)?;
         self.send_message(m).await
     }
 

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     async_lock::Mutex,
     blocking,
     fdo::{self, ConnectionCredentials, RequestNameFlags, RequestNameReply},
-    message::{self, Flags, Message, Type},
+    message::{Flags, Message, Type},
     proxy::CacheProperties,
     DBusError, Error, Executor, Guid, MatchRule, MessageStream, ObjectServer, OwnedMatchRule,
     Result, Task,
@@ -397,7 +397,7 @@ impl Connection {
         M::Error: Into<Error>,
         B: serde::ser::Serialize + zvariant::DynamicType,
     {
-        let mut builder = message::Builder::method_call(path, method_name)?;
+        let mut builder = Message::method(path, method_name)?;
         if let Some(sender) = self.unique_name() {
             builder = builder.sender(sender)?
         }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -449,14 +449,14 @@ impl Connection {
         M::Error: Into<Error>,
         B: serde::ser::Serialize + zvariant::DynamicType,
     {
-        let m = Message::signal(
-            self.unique_name(),
-            destination,
-            path,
-            interface,
-            signal_name,
-            body,
-        )?;
+        let mut b = Message::signal(path, interface, signal_name)?;
+        if let Some(sender) = self.unique_name() {
+            b = b.sender(sender)?;
+        }
+        if let Some(destination) = destination {
+            b = b.destination(destination)?;
+        }
+        let m = b.build(body)?;
 
         self.send_message(m).await.map(|_| ())
     }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -496,7 +496,11 @@ impl Connection {
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {
-        let m = Message::method_error(self.unique_name(), call, error_name, body)?;
+        let mut b = Message::method_error(call, error_name)?;
+        if let Some(sender) = self.unique_name() {
+            b = b.sender(sender)?;
+        }
+        let m = b.build(body)?;
         self.send_message(m).await
     }
 

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -1014,13 +1014,10 @@ mod tests {
             .build(&())
             .unwrap();
         m.set_serial_num(1.try_into().unwrap()).unwrap();
-        let m = Message::method_error(
-            None::<()>,
-            &m,
-            "org.freedesktop.DBus.Error.TimedOut",
-            &("so long"),
-        )
-        .unwrap();
+        let m = Message::method_error(&m, "org.freedesktop.DBus.Error.TimedOut")
+            .unwrap()
+            .build(&("so long"))
+            .unwrap();
         let e: Error = m.into();
         let e: fdo::Error = e.try_into().unwrap();
         assert_eq!(e, fdo::Error::TimedOut("so long".to_string()),);

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -1007,7 +1007,12 @@ mod tests {
 
     #[test]
     fn error_from_zerror() {
-        let mut m = Message::method(Some(":1.2"), None::<()>, "/", None::<()>, "foo", &()).unwrap();
+        let mut m = Message::method("/", "foo")
+            .unwrap()
+            .destination(":1.2")
+            .unwrap()
+            .build(&())
+            .unwrap();
         m.set_serial_num(1.try_into().unwrap()).unwrap();
         let m = Message::method_error(
             None::<()>,

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -231,15 +231,14 @@ mod tests {
 
     #[test]
     fn msg() {
-        let mut m = Message::method(
-            None::<()>,
-            Some("org.freedesktop.DBus"),
-            "/org/freedesktop/DBus",
-            Some("org.freedesktop.DBus.Peer"),
-            "GetMachineId",
-            &(),
-        )
-        .unwrap();
+        let mut m = Message::method("/org/freedesktop/DBus", "GetMachineId")
+            .unwrap()
+            .destination("org.freedesktop.DBus")
+            .unwrap()
+            .interface("org.freedesktop.DBus.Peer")
+            .unwrap()
+            .build(&())
+            .unwrap();
         let hdr = m.header();
         assert_eq!(hdr.path().unwrap(), "/org/freedesktop/DBus");
         assert_eq!(hdr.interface().unwrap(), "org.freedesktop.DBus.Peer");
@@ -576,16 +575,15 @@ mod tests {
 
         // Send a message as client before service starts to process messages
         let client_conn = blocking::Connection::session().unwrap();
-        let destination = conn.unique_name().map(UniqueName::<'_>::from);
-        let msg = Message::method(
-            None::<()>,
-            destination,
-            "/org/freedesktop/Issue68",
-            Some("org.freedesktop.Issue68"),
-            "Ping",
-            &(),
-        )
-        .unwrap();
+        let destination = conn.unique_name().map(UniqueName::<'_>::from).unwrap();
+        let msg = Message::method("/org/freedesktop/Issue68", "Ping")
+            .unwrap()
+            .destination(destination)
+            .unwrap()
+            .interface("org.freedesktop.Issue68")
+            .unwrap()
+            .build(&())
+            .unwrap();
         let serial = client_conn.send_message(msg).unwrap();
 
         crate::blocking::fdo::DBusProxy::new(&conn)
@@ -726,16 +724,13 @@ mod tests {
         // when we send a message.
         std::thread::sleep(std::time::Duration::from_millis(100));
 
-        let destination = conn.unique_name().map(UniqueName::<'_>::from);
-        let msg = Message::method(
-            None::<()>,
-            destination,
-            "/does/not/matter",
-            None::<()>,
-            "ZBusIssue122",
-            &(),
-        )
-        .unwrap();
+        let destination = conn.unique_name().map(UniqueName::<'_>::from).unwrap();
+        let msg = Message::method("/does/not/matter", "ZBusIssue122")
+            .unwrap()
+            .destination(destination)
+            .unwrap()
+            .build(&())
+            .unwrap();
         conn.send_message(msg).unwrap();
 
         child.join().unwrap();

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -76,6 +76,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Create a message of type [`Type::MethodReturn`].
+    #[deprecated(since = "4.0.0", note = "Please use `Message::method_reply` instead")]
     pub fn method_return(reply_to: &Header<'_>) -> Result<Self> {
         Self::new(Type::MethodReturn).reply_to(reply_to)
     }

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -59,6 +59,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Create a message of type [`Type::Signal`].
+    #[deprecated(since = "4.0.0", note = "Please use `Message::signal` instead")]
     pub fn signal<'p: 'a, 'i: 'a, 'm: 'a, P, I, M>(path: P, interface: I, name: M) -> Result<Self>
     where
         P: TryInto<ObjectPath<'p>>,
@@ -350,14 +351,14 @@ impl<'m> From<Header<'m>> for Builder<'m> {
 
 #[cfg(test)]
 mod tests {
-    use super::Builder;
+    use super::Message;
     use crate::Error;
     use test_log::test;
 
     #[test]
     fn test_raw() -> Result<(), Error> {
         let raw_body: &[u8] = &[16, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0];
-        let message_builder = Builder::signal("/", "test.test", "test")?;
+        let message_builder = Message::signal("/", "test.test", "test")?;
         let message = unsafe {
             message_builder.build_raw_body(
                 raw_body,

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -82,6 +82,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Create a message of type [`Type::Error`].
+    #[deprecated(since = "4.0.0", note = "Please use `Message::method_error` instead")]
     pub fn error<'e: 'a, E>(reply_to: &Header<'_>, name: E) -> Result<Self>
     where
         E: TryInto<ErrorName<'e>>,

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -47,6 +47,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Create a message of type [`Type::MethodCall`].
+    #[deprecated(since = "4.0.0", note = "Please use `Message::method` instead")]
     pub fn method_call<'p: 'a, 'm: 'a, P, M>(path: P, method_name: M) -> Result<Self>
     where
         P: TryInto<ObjectPath<'p>>,

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -125,7 +125,7 @@ impl Message {
         Builder::method_return(&call.header())
     }
 
-    /// Create a builder for message of type [`Type::MethodError`].
+    /// Create a builder for message of type [`Type::Error`].
     pub fn method_error<'b, 'e: 'b, E>(call: &Self, name: E) -> Result<Builder<'b>>
     where
         E: TryInto<ErrorName<'e>>,

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -124,6 +124,7 @@ impl Message {
 
     /// Create a builder for message of type [`Type::MethodReturn`].
     pub fn method_reply(call: &Self) -> Result<Builder<'_>> {
+        #[allow(deprecated)]
         Builder::method_return(&call.header())
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -118,6 +118,7 @@ impl Message {
         I::Error: Into<Error>,
         M::Error: Into<Error>,
     {
+        #[allow(deprecated)]
         Builder::signal(path, iface, signal_name)
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -93,8 +93,6 @@ assert_impl_all!(Message: Send, Sync, Unpin);
 // TODO: Handle non-native byte order: https://github.com/dbus2/zbus/issues/19
 impl Message {
     /// Create a builder for message of type [`Type::MethodCall`].
-    ///
-    /// [`Type::MethodCall`]: enum.Type.html#variant.MethodCall
     pub fn method<'b, 'p: 'b, 'm: 'b, P, M>(path: P, method_name: M) -> Result<Builder<'b>>
     where
         P: TryInto<ObjectPath<'p>>,
@@ -106,8 +104,6 @@ impl Message {
     }
 
     /// Create a builder for message of type [`Type::Signal`].
-    ///
-    /// [`Type::Signal`]: enum.Type.html#variant.Signal
     pub fn signal<'b, 'p: 'b, 'i: 'b, 'm: 'b, P, I, M>(
         path: P,
         iface: I,
@@ -125,15 +121,11 @@ impl Message {
     }
 
     /// Create a builder for message of type [`Type::MethodReturn`].
-    ///
-    /// [`Type::MethodReturn`]: enum.Type.html#variant.MethodReturn
     pub fn method_reply(call: &Self) -> Result<Builder<'_>> {
         Builder::method_return(&call.header())
     }
 
     /// Create a builder for message of type [`Type::MethodError`].
-    ///
-    /// [`Type::MethodError`]: enum.Type.html#variant.MethodError
     pub fn method_error<'b, 'e: 'b, E>(call: &Self, name: E) -> Result<Builder<'b>>
     where
         E: TryInto<ErrorName<'e>>,

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -100,6 +100,7 @@ impl Message {
         P::Error: Into<Error>,
         M::Error: Into<Error>,
     {
+        #[allow(deprecated)]
         Builder::method_call(path, method_name)
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -134,6 +134,7 @@ impl Message {
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {
+        #[allow(deprecated)]
         Builder::error(&call.header(), name)
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use static_assertions::assert_impl_all;
-use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
+use zbus_names::{ErrorName, InterfaceName, MemberName, UniqueName};
 
 #[cfg(unix)]
 use crate::OwnedFd;
@@ -108,36 +108,20 @@ impl Message {
     /// Create a message of type [`Type::Signal`].
     ///
     /// [`Type::Signal`]: enum.Type.html#variant.Signal
-    pub fn signal<'s, 'd, 'p, 'i, 'm, S, D, P, I, M, B>(
-        sender: Option<S>,
-        destination: Option<D>,
+    pub fn signal<'b, 'p: 'b, 'i: 'b, 'm: 'b, P, I, M>(
         path: P,
         iface: I,
         signal_name: M,
-        body: &B,
-    ) -> Result<Self>
+    ) -> Result<Builder<'b>>
     where
-        S: TryInto<UniqueName<'s>>,
-        D: TryInto<BusName<'d>>,
         P: TryInto<ObjectPath<'p>>,
         I: TryInto<InterfaceName<'i>>,
         M: TryInto<MemberName<'m>>,
-        S::Error: Into<Error>,
-        D::Error: Into<Error>,
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + DynamicType,
     {
-        let mut b = Builder::signal(path, iface, signal_name)?;
-
-        if let Some(sender) = sender {
-            b = b.sender(sender)?;
-        }
-        if let Some(destination) = destination {
-            b = b.destination(destination)?;
-        }
-        b.build(body)
+        Builder::signal(path, iface, signal_name)
     }
 
     /// Create a message of type [`Type::MethodReturn`].

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -15,9 +15,9 @@ use tracing::{debug, instrument};
 use zbus::{
     block_on,
     fdo::{ObjectManager, ObjectManagerProxy},
-    message::{self, Builder},
+    message,
     object_server::ResponseDispatchNotifier,
-    DBusError, Error, MessageStream,
+    DBusError, Error, Message, MessageStream,
 };
 use zvariant::{DeserializeDict, Optional, OwnedValue, SerializeDict, Str, Type, Value};
 
@@ -437,7 +437,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     // Use low-level API for `TestResponseNotify` because we need to ensure that the signal is
     // always received after the response.
     let mut stream = MessageStream::from(&conn);
-    let method = Builder::method_call("/org/freedesktop/MyService", "TestResponseNotify")?
+    let method = Message::method("/org/freedesktop/MyService", "TestResponseNotify")?
         .interface("org.freedesktop.MyIface")?
         .destination("org.freedesktop.MyService")?
         .build(&())?;

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -258,7 +258,7 @@ fn test_interface() {
 mod signal_from_message {
     use super::*;
     use std::sync::Arc;
-    use zbus::message::Builder;
+    use zbus::message::Message;
 
     #[dbus_proxy(
         interface = "org.freedesktop.zbus_macros.Test",
@@ -276,7 +276,7 @@ mod signal_from_message {
     #[test]
     fn signal_u8() {
         let message = Arc::new(
-            Builder::signal(
+            Message::signal(
                 "/org/freedesktop/zbus_macros/test",
                 "org.freedesktop.zbus_macros.Test",
                 "SignalU8",
@@ -299,7 +299,7 @@ mod signal_from_message {
     #[test]
     fn signal_string() {
         let message = Arc::new(
-            Builder::signal(
+            Message::signal(
                 "/org/freedesktop/zbus_macros/test",
                 "org.freedesktop.zbus_macros.Test",
                 "SignalString",
@@ -322,7 +322,7 @@ mod signal_from_message {
     #[test]
     fn wrong_data() {
         let message = Arc::new(
-            Builder::signal(
+            Message::signal(
                 "/org/freedesktop/zbus_macros/test",
                 "org.freedesktop.zbus_macros.Test",
                 "SignalU8",

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -244,15 +244,10 @@ fn test_interface() {
             // check compilation
             let c = zbus::Connection::session().await.unwrap();
             let s = c.object_server();
-            let m = zbus::message::Message::method(
-                None::<()>,
-                None::<()>,
-                "/",
-                None::<()>,
-                "StrU32",
-                &(42,),
-            )
-            .unwrap();
+            let m = zbus::message::Message::method("/", "StrU32")
+                .unwrap()
+                .build(&(42,))
+                .unwrap();
             let _ = t.call(&s, &c, &m, "StrU32".try_into().unwrap());
             let ctxt = SignalContext::new(&c, "/does/not/matter").unwrap();
             block_on(Test::<u32>::signal(&ctxt, 23, "ergo sum")).unwrap();


### PR DESCRIPTION
Not only this makes sense anyway, it also makes the method much simpler as we can drop the optional arguments and therefore also the need for user to have to specify the concrete types for these arguments even when they just want to pass `None`.
