### PR TITLE
⬆️  Bump MSRV to 1.66

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-      MSRV: 1.64.0
+      MSRV: 1.66.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "API for D-Bus communication"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "proc-macros for zbus"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_names"
 version = "3.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "A collection of D-Bus bus names types"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_xml"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "API to handle D-Bus introspection XML"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "D-Bus XML interface code generator"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -3,7 +3,7 @@ name = "zvariant"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -4,7 +4,7 @@ name = "zvariant_derive"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "turbocooler <turbocooler@cocaine.ninja>",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 description = "Various utilities used internally by the zvariant crate."
 repository = "https://github.com/dbus2/zbus/"


### PR DESCRIPTION
Seems one of our indirect dependencies, `toml_edit` has bumped to this and since Rust 1.66 was released more than 9 months ago, it's not that big a deal.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
