### PR TITLE
Allow ser/de of `Option<T>` as array

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -18,6 +18,8 @@ uuid = ["zvariant/uuid"]
 url = ["zvariant/url"]
 time = ["zvariant/time"]
 chrono = ["zvariant/chrono"]
+# Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
+option-as-array = ["zvariant/option-as-array"]
 windows-gdbus = []
 async-io = [
   "dep:async-io",

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -14,9 +14,11 @@ readme = "README.md"
 
 [features]
 default = []
-# Also allow disabling D-Bus support
+# FIXME: Also allow disabling D-Bus support
 gvariant = []
 ostree-tests = ["gvariant"]
+# Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
+option-as-array = []
 
 [dependencies]
 byteorder = "1.4.3"

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -163,6 +163,9 @@ accomplish. However, community contribution can change that. 😊
 | gvariant | Enable [GVariant] format support |
 | arrayvec | Implement `Type` for [`arrayvec::ArrayVec`] and [`arrayvec::ArrayString`] |
 | enumflags2 | Implement `Type` for [`enumflags2::BitFlags`]`<F>` |
+| option-as-array | Enable `Option<T>` (de)serialization using array encoding |
+
+`gvariant` features conflicts with `option-as-array` and hence should not be enabled together.
 
 [dwf]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-marshaling
 [GVariant]: https://developer.gnome.org/documentation/specifications/gvariant-specification-1.0.html

--- a/zvariant/src/container_depths.rs
+++ b/zvariant/src/container_depths.rs
@@ -47,13 +47,13 @@ impl ContainerDepths {
         self.check()
     }
 
-    #[cfg(feature = "gvariant")]
+    #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
     pub fn inc_maybe(mut self) -> Result<Self> {
         self.maybe += 1;
         self.check()
     }
 
-    #[cfg(feature = "gvariant")]
+    #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
     pub fn dec_maybe(mut self) -> Self {
         self.maybe -= 1;
         self

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -192,14 +192,33 @@ where
     }
 
     fn serialize_none(self) -> Result<()> {
-        unreachable!("Option<T> can not be encoded in D-Bus format");
+        #[cfg(feature = "option-as-array")]
+        {
+            let seq = self.serialize_seq(Some(0))?;
+            seq.end()
+        }
+
+        #[cfg(not(feature = "option-as-array"))]
+        unreachable!(
+            "Can only encode Option<T> in D-Bus format if `option-as-array` feature is enabled",
+        );
     }
 
-    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, #[allow(unused)] value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unreachable!("Option<T> can not be encoded in D-Bus format");
+        #[cfg(feature = "option-as-array")]
+        {
+            let mut seq = self.serialize_seq(Some(1))?;
+            seq.serialize_element(value)?;
+            seq.end()
+        }
+
+        #[cfg(not(feature = "option-as-array"))]
+        unreachable!(
+            "Can only encode Option<T> in D-Bus format if `option-as-array` feature is enabled",
+        );
     }
 
     fn serialize_unit(self) -> Result<()> {

--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -185,6 +185,15 @@ where
         visitor.visit_borrowed_str(s)
     }
 
+    #[cfg(feature = "option-as-array")]
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("`option-as-array` and `gvariant` features are incompatible. Don't enable both.");
+    }
+
+    #[cfg(not(feature = "option-as-array"))]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -55,6 +55,7 @@ where
         }))
     }
 
+    #[cfg(not(feature = "option-as-array"))]
     fn serialize_maybe<T>(&mut self, value: Option<&T>) -> Result<()>
     where
         T: ?Sized + Serialize,
@@ -199,15 +200,30 @@ where
         seq.end()
     }
 
+    #[cfg(not(feature = "option-as-array"))]
     fn serialize_none(self) -> Result<()> {
         self.serialize_maybe::<()>(None)
     }
 
+    #[cfg(feature = "option-as-array")]
+    fn serialize_none(self) -> Result<()> {
+        panic!("`option-as-array` and `gvariant` features are incompatible. Don't enable both.");
+    }
+
+    #[cfg(not(feature = "option-as-array"))]
     fn serialize_some<T>(self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
         self.serialize_maybe(Some(value))
+    }
+
+    #[cfg(feature = "option-as-array")]
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        panic!("`option-as-array` and `gvariant` features are incompatible. Don't enable both.");
     }
 
     fn serialize_unit(self) -> Result<()> {

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -121,12 +121,28 @@ where
     }
 }
 
-#[cfg(feature = "gvariant")]
+#[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
 impl<'v, V> From<Option<V>> for Value<'v>
 where
     Option<V>: Into<Maybe<'v>>,
 {
     fn from(v: Option<V>) -> Value<'v> {
         Value::Maybe(v.into())
+    }
+}
+
+#[cfg(feature = "option-as-array")]
+impl<'v, V> From<Option<V>> for Value<'v>
+where
+    V: Into<Value<'v>> + Type,
+{
+    fn from(v: Option<V>) -> Value<'v> {
+        let mut array = Array::new(V::signature());
+        if let Some(v) = v {
+            // We got the signature from the `Type` impl, so this should never panic.
+            array.append(v.into()).expect("signature mismatch");
+        }
+
+        array.into()
     }
 }

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -167,11 +167,6 @@ where
     }
 }
 
-// This would be great but somehow it conflicts with some blanket generic implementations from
-// core:
-//
-// impl<'a, T> TryFrom<Maybe<'a>> for Option<T>
-
 impl<'a> Serialize for Maybe<'a> {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -218,7 +218,7 @@ deref_impl!(T, <T: ?Sized + Type> Type for RwLock<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Box<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Rc<T>);
 
-#[cfg(feature = "gvariant")]
+#[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
 impl<T> Type for Option<T>
 where
     T: Type,
@@ -226,6 +226,17 @@ where
     #[inline]
     fn signature() -> Signature<'static> {
         Signature::from_string_unchecked(format!("m{}", T::signature()))
+    }
+}
+
+#[cfg(feature = "option-as-array")]
+impl<T> Type for Option<T>
+where
+    T: Type,
+{
+    #[inline]
+    fn signature() -> Signature<'static> {
+        Signature::from_string_unchecked(format!("a{}", T::signature()))
     }
 }
 

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -972,8 +972,16 @@ mod tests {
             "((true,), (true, false), (true, true, false))"
         );
 
-        #[cfg(feature = "gvariant")]
+        #[cfg(any(feature = "gvariant", feature = "option-as-array"))]
         {
+            #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
+            let s = "((@mn 0, @mmn 0, @mmmn 0), \
+                (@mn nothing, @mmn just nothing, @mmmn just just nothing), \
+                (@mmn nothing, @mmmn just nothing))";
+            #[cfg(feature = "option-as-array")]
+            let s = "(([int16 0], [[int16 0]], [[[int16 0]]]), \
+                (@an [], [@an []], [[@an []]]), \
+                (@aan [], [@aan []]))";
             assert_eq!(
                 Value::new((
                     (Some(0_i16), Some(Some(0_i16)), Some(Some(Some(0_i16))),),
@@ -981,9 +989,7 @@ mod tests {
                     (None::<Option<i16>>, Some(None::<Option<i16>>)),
                 ))
                 .to_string(),
-                "((@mn 0, @mmn 0, @mmmn 0), \
-                (@mn nothing, @mmn just nothing, @mmmn just just nothing), \
-                (@mmn nothing, @mmmn just nothing))"
+                s,
             );
 
             #[cfg(unix)]
@@ -992,6 +998,16 @@ mod tests {
                 "[handle 0, -100]"
             );
 
+            #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
+            let s = "(@mb nothing, @mb nothing, \
+                @ma{sv} {\"size\": <(800, 600)>}, \
+                [<1>, <{\"dimension\": <([2.4, 1.], \
+                @mmn 200, <(byte 0x03, \"Hello!\")>)>}>], \
+                7777, objectpath \"/\", 8888)";
+            #[cfg(feature = "option-as-array")]
+            let s = "(@ab [], @ab [], [{\"size\": <(800, 600)>}], \
+                [<1>, <{\"dimension\": <([2.4, 1.], [[int16 200]], \
+                <(byte 0x03, \"Hello!\")>)>}>], 7777, objectpath \"/\", 8888)";
             assert_eq!(
                 Value::new((
                     None::<bool>,
@@ -1021,11 +1037,7 @@ mod tests {
                     8888
                 ))
                 .to_string(),
-                "(@mb nothing, @mb nothing, \
-                @ma{sv} {\"size\": <(800, 600)>}, \
-                [<1>, <{\"dimension\": <([2.4, 1.], \
-                @mmn 200, <(byte 0x03, \"Hello!\")>)>}>], \
-                7777, objectpath \"/\", 8888)"
+                s,
             );
         }
     }


### PR DESCRIPTION
Add a non-default feature, `option-as-array` that enables this. Also, add a FAQ item to the book, explaining how people can handle nullable types.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).