### PR TITLE
Bump most dependencies

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -79,7 +79,7 @@ tokio = { version = "1.21.2", optional = true, features = [
 ] }
 tracing = "0.1.37"
 vsock = { version = "0.3.0", optional = true }
-tokio-vsock = { version = "0.3.3", optional = true }
+tokio-vsock = { version = "0.4", optional = true }
 xdg-home = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -99,9 +99,10 @@ winapi = { version = "0.3", features = [
 uds_windows = "1.0.2"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.26.0", default-features = false, features = [
+nix = { version = "0.27", default-features = false, features = [
   "socket",
   "uio",
+  "user",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 serde = { version = "1.0", features = ["derive"] }
 zvariant = { path = "../zvariant", version = "4.0.0", default-features = false }
 zbus_names = { path = "../zbus_names", version = "3.0" }
-quick-xml = { version = "0.27.1", features = ["serialize", "overlapped-lists"] }
+quick-xml = { version = "0.30", features = ["serialize", "overlapped-lists"] }
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -42,7 +42,7 @@ serde_repr = "0.1.9"
 # If you want to avoid compiling glib even when compiling tests or examples, comment out the glib
 # dev-dependency. Dev-dependencies can't be made optional, and hence can't be disabled with a
 # feature so you have to do it manually. Also, don't enable the gvariant default feature.
-glib = "0.17.9"
+glib = "0.18"
 rand = "0.8.5"
 criterion = "0.5"
 

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -44,7 +44,7 @@ serde_repr = "0.1.9"
 # feature so you have to do it manually. Also, don't enable the gvariant default feature.
 glib = "0.17.9"
 rand = "0.8.5"
-criterion = "0.4"
+criterion = "0.5"
 
 [lib]
 bench = false


### PR DESCRIPTION
Only syn and event-listener are still outdated, as they required quite some more work to fix. Plus syn is already handled in #404.