### PR TITLE
Add cancellation token

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -57,6 +57,7 @@ async-trait = "0.1.58"
 async-fs = { version = "1.6.0", optional = true }
 # FIXME: We should only enable process feature for Mac OS. See comment on async-process below for why we can't.
 tokio = { version = "1.21.2", optional = true, features = ["rt", "net", "time", "fs", "io-util", "process", "sync", "tracing"] }
+tokio-util = "0.7.9"
 tracing = "0.1.37"
 vsock = { version = "0.3.0", optional = true }
 tokio-vsock = { version = "0.3.3", optional = true }


### PR DESCRIPTION
There were requests to support graceful shutdown #309 and awaitable connections #307. This change attacks both by adding an option to supply a cancellation token.

Once the token is cancelled, the `socket reader` task is stopped. From what I understand, that in turn lets the object server consume all outstanding messages and once that is done, the dbus interfaces are deregistered.