### PR TITLE
Revert "👷 CI: Use large runners for faster actions"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   book:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     permissions:
       contents: write # To push a branch
       pull-requests: write # To create a PR from that branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   MSRV:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       MSRV: 1.66.0
@@ -31,7 +31,7 @@ jobs:
         # cargo check --all-features
 
   lint:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
@@ -49,7 +49,7 @@ jobs:
         run: cargo clippy -- -D warnings -D clippy::large_futures
 
   linux_test:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     needs: lint
     env:
       RUSTFLAGS: -D warnings
@@ -82,7 +82,7 @@ jobs:
           dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --doc --no-default-features connection::Connection::executor
 
   windows_test:
-    runs-on: windows-large
+    runs-on: windows-latest
     needs: lint
     env:
       RUSTFLAGS: -D warnings
@@ -203,7 +203,7 @@ jobs:
           cargo test --features zbus/windows-gdbus
 
   cross_check:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
     steps:
@@ -220,7 +220,7 @@ jobs:
           cargo check --target x86_64-unknown-netbsd
 
   zvariant_fuzz:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
@@ -237,7 +237,7 @@ jobs:
           cargo fuzz run --fuzz-dir zvariant/fuzz gvariant -- -max_total_time=30 -max_len=100M
 
   doc_build:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -D warnings
     steps:


### PR DESCRIPTION
This reverts commit 7e486f5817c76cd98a7b89565662f89f7d5cf24b.

The cost is very high. Let's just stick to the default runners for now.