### PR TITLE
remove dbus prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ A simple service that politely greets whoever calls its `SayHello` method:
 
 ```rust,no_run
 use std::{error::Error, future::pending};
-use zbus::{connection, dbus_interface};
+use zbus::{connection, interface};
 
 struct Greeter {
     count: u64
 }
 
-#[dbus_interface(name = "org.zbus.MyGreeter1")]
+#[interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {
     // Can be `async` as well.
     fn say_hello(&mut self, name: &str) -> String {
@@ -79,9 +79,9 @@ s "Hello Maria! I have been called 1 times."
 Now let's write the client-side code for `MyGreeter` service:
 
 ```rust,no_run
-use zbus::{Connection, Result, dbus_proxy};
+use zbus::{Connection, Result, proxy};
 
-#[dbus_proxy(
+#[proxy(
     interface = "org.zbus.MyGreeter1",
     default_service = "org.zbus.MyGreeter",
     default_path = "/org/zbus/MyGreeter"
@@ -95,7 +95,7 @@ trait MyGreeter {
 async fn main() -> Result<()> {
     let connection = Connection::session().await?;
 
-    // `dbus_proxy` macro creates `MyGreeterProxy` based on `Notifications` trait.
+    // `proxy` macro creates `MyGreeterProxy` based on `Notifications` trait.
     let proxy = MyGreeterProxy::new(&connection).await?;
     let reply = proxy.say_hello("Maria").await?;
     println!("{reply}");

--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -18,26 +18,26 @@ except all its methods are blocking.
 ## Client
 
 Similar to `blocking::Connection`, you use `blocking::Proxy` type. Its constructors require
-`blocking::Connection` instead of `Connection`. Moreover, `dbus_proxy` macro generates a
+`blocking::Connection` instead of `Connection`. Moreover, `proxy` macro generates a
 `blocking::Proxy` wrapper for you as well. Let's convert the last example in the previous chapter,
 to use the blocking connection and proxy:
 
 ```rust,no_run
-use zbus::{blocking::Connection, zvariant::ObjectPath, dbus_proxy, Result};
+use zbus::{blocking::Connection, zvariant::ObjectPath, proxy, Result};
 
-#[dbus_proxy(
+#[proxy(
     default_service = "org.freedesktop.GeoClue2",
     interface = "org.freedesktop.GeoClue2.Manager",
     default_path = "/org/freedesktop/GeoClue2/Manager"
 )]
 trait Manager {
-    #[dbus_proxy(object = "Client")]
+    #[zbus(object = "Client")]
     /// The method normally returns an `ObjectPath`.
     /// With the object attribute, we can make it return a `ClientProxy` directly.
     fn get_client(&self);
 }
 
-#[dbus_proxy(
+#[proxy(
     default_service = "org.freedesktop.GeoClue2",
     interface = "org.freedesktop.GeoClue2.Client"
 )]
@@ -45,21 +45,21 @@ trait Client {
     fn start(&self) -> Result<()>;
     fn stop(&self) -> Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_desktop_id(&mut self, id: &str) -> Result<()>;
 
-    #[dbus_proxy(signal)]
+    #[zbus(signal)]
     fn location_updated(&self, old: ObjectPath<'_>, new: ObjectPath<'_>) -> Result<()>;
 }
 
-#[dbus_proxy(
+#[proxy(
     default_service = "org.freedesktop.GeoClue2",
     interface = "org.freedesktop.GeoClue2.Location"
 )]
 trait Location {
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn latitude(&self) -> Result<f64>;
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn longitude(&self) -> Result<f64>;
 }
 let conn = Connection::system().unwrap();
@@ -88,7 +88,7 @@ println!(
 );
 ```
 
-As you can see, nothing changed in the `dbus_proxy` usage here and the rest largely remained the
+As you can see, nothing changed in the `proxy` usage here and the rest largely remained the
 same as well. One difference that's not obvious is that the blocking API for receiving signals,
 implement [`std::iter::Iterator`] trait instead of [`futures::stream::Stream`].
 
@@ -97,15 +97,15 @@ implement [`std::iter::Iterator`] trait instead of [`futures::stream::Stream`].
 That's almost the same as receiving signals:
 
 ```rust,no_run
-# use zbus::{blocking::Connection, dbus_proxy, Result};
+# use zbus::{blocking::Connection, proxy, Result};
 #
-#[dbus_proxy(
+#[proxy(
     interface = "org.freedesktop.systemd1.Manager",
     default_service = "org.freedesktop.systemd1",
     default_path = "/org/freedesktop/systemd1"
 )]
 trait SystemdManager {
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn log_level(&self) -> zbus::Result<String>;
 }
 
@@ -124,7 +124,7 @@ fn main() -> Result<()> {
 
 Similarly here, you'd use [`blocking::ObjectServer`] that is associated with every
 [`blocking::Connection`] instance. While there is no blocking version of `Interface`,
-`dbus_interface` allows you to write non-async methods.
+`interface` allows you to write non-async methods.
 
 **Note:** Even though you can write non-async methods, these methods are still called from an async
 context. Therefore, you can not use blocking API in the method implementation directly. See note at
@@ -132,7 +132,7 @@ the beginning of this chapter for details on why and a possible workaround.
 
 ```rust,no_run
 # use std::error::Error;
-# use zbus::{blocking::connection, dbus_interface, fdo, SignalContext};
+# use zbus::{blocking::connection, interface, fdo, SignalContext};
 #
 use event_listener::Event;
 
@@ -141,7 +141,7 @@ struct Greeter {
     done: Event,
 }
 
-#[dbus_interface(name = "org.zbus.MyGreeter1")]
+#[interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {
     fn say_hello(&self, name: &str) -> String {
         format!("Hello {}!", name)
@@ -160,7 +160,7 @@ impl Greeter {
     }
 
     /// A "GreeterName" property.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn greeter_name(&self) -> &str {
         &self.name
     }
@@ -170,13 +170,13 @@ impl Greeter {
     /// Additionally, a `greeter_name_changed` method has been generated for you if you need to
     /// notify listeners that "GreeterName" was updated. It will be automatically called when
     /// using this setter.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_greeter_name(&mut self, name: String) {
         self.name = name;
     }
 
     /// A signal; the implementation is provided by the macro.
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn greeted_everyone(ctxt: &SignalContext<'_>) -> zbus::Result<()>;
 }
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -12,7 +12,7 @@ the `signature` attribute. Here is a simple example:
 
 ```rust,noplayground
 use zbus::{
-    dbus_proxy, dbus_interface, fdo::Result,
+    proxy, interface, fdo::Result,
     zvariant::{DeserializeDict, SerializeDict, Type},
 };
 
@@ -26,7 +26,7 @@ pub struct Dictionary {
     optional_field: Option<String>,
 }
 
-#[dbus_proxy(
+#[proxy(
     interface = "org.zbus.DictionaryGiver",
     default_path = "/org/zbus/DictionaryGiver",
     default_service = "org.zbus.DictionaryGiver",
@@ -37,7 +37,7 @@ trait DictionaryGiver {
 
 struct DictionaryGiverInterface;
 
-#[dbus_interface(interface = "org.zbus.DictionaryGiver")]
+#[interface(interface = "org.zbus.DictionaryGiver")]
 impl DictionaryGiverInterface {
     fn give_me(&self) -> Result<Dictionary> {
         Ok(Dictionary {
@@ -73,7 +73,7 @@ see [the corresponding tokio issue on GitHub][tctiog].
 
 There are typically two reasons this can happen with zbus:
 
-### 1. A `dbus_interface` method that takes a `&mut self` argument is taking too long
+### 1. A `interface` method that takes a `&mut self` argument is taking too long
 
 Simply put, this is because of one of the primary rules of Rust: while a mutable reference to a
 resource exists, no other references to that same resource can exist at the same time. This means
@@ -98,7 +98,7 @@ update accordingly.
 
 However, you can disabling caching for specific properties:
 
-- Add the `#[dbus_proxy(property(emits_changed_signal = "false"))]` annotation to the property
+- Add the `#[zbus(property(emits_changed_signal = "false"))]` annotation to the property
 for which you desire to disable caching on.
 
 - Use `proxy::Builder` to build your proxy instance and use `proxy::Builder::uncached_properties` method
@@ -108,7 +108,7 @@ to list all properties you wish to disable caching for.
 method.
 
 For more information about all the possible values for `emits_changed_signal` refer
- to [`dbus_proxy`](https://docs.rs/zbus/latest/zbus/attr.dbus_proxy.html) documentation.
+ to [`proxy`](https://docs.rs/zbus/latest/zbus/attr.proxy.html) documentation.
 
 ## How do I use `Option<T>`` with zbus?
 
@@ -137,7 +137,7 @@ all types. However, it does come with some caveats and limitations:
     nullable type, this can be confusing for users of generic tools like [`d-feet`]. It is therefore
     highly recommended that service authors document each use of `Option<T>` in their D-Bus
     interface documentation.
-  2. Currently it is not possible to use `Option<T>` for `dbus_interface` and `dbus_proxy` property
+  2. Currently it is not possible to use `Option<T>` for `interface` and `proxy` property
     methods.
   3. Both the sender and receiver must agree on use of this encoding. If the sender sends `T`, the
     receiver will not be able to decode it successfully as `Option<T>` and vice versa.

--- a/book/src/server.md
+++ b/book/src/server.md
@@ -99,7 +99,7 @@ need, but it is also easy to get it wrong. Fortunately, zbus has a simpler solut
 
 ## Using the `ObjectServer`
 
-One can write an `impl` block with a set of methods and let the `dbus_interface` procedural macro
+One can write an `impl` block with a set of methods and let the `interface` procedural macro
 write the D-Bus message handling details. It will dispatch the incoming method calls to their
 respective handlers, as well as replying to introspection requests.
 
@@ -108,12 +108,12 @@ respective handlers, as well as replying to introspection requests.
 Let see how to use it for `MyGreeter` interface:
 
 ```rust,no_run
-# use zbus::{Connection, dbus_interface, Result};
+# use zbus::{Connection, interface, Result};
 #
 
 struct Greeter;
 
-#[dbus_interface(name = "org.zbus.MyGreeter1")]
+#[interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {
     async fn say_hello(&self, name: &str) -> String {
         format!("Hello {}!", name)
@@ -150,12 +150,12 @@ after taking their name. This is why it's typically better to make use of `conne
 setting up your interfaces and requesting names, and not have to care about this:
 
 ```rust,no_run
-# use zbus::{connection, dbus_interface, Result};
+# use zbus::{connection, interface, Result};
 #
 #
 # struct Greeter;
 #
-# #[dbus_interface(name = "org.zbus.MyGreeter1")]
+# #[interface(name = "org.zbus.MyGreeter1")]
 # impl Greeter {
 #     async fn say_hello(&self, name: &str) -> String {
 #         format!("Hello {}!", name)
@@ -207,7 +207,7 @@ synchronize with the interface handlers from outside, thanks to the `event_liste
 (this is just one of the many ways).
 
 ```rust,no_run
-# use zbus::{object_server::SignalContext, connection::Builder, dbus_interface, fdo, Result};
+# use zbus::{object_server::SignalContext, connection::Builder, interface, fdo, Result};
 #
 use event_listener::Event;
 
@@ -216,7 +216,7 @@ struct Greeter {
     done: Event,
 }
 
-#[dbus_interface(name = "org.zbus.MyGreeter1")]
+#[interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {
     async fn say_hello(&self, name: &str) -> String {
         format!("Hello {}!", name)
@@ -235,7 +235,7 @@ impl Greeter {
     }
 
     /// A "GreeterName" property.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn greeter_name(&self) -> &str {
         &self.name
     }
@@ -245,13 +245,13 @@ impl Greeter {
     /// Additionally, a `greeter_name_changed` method has been generated for you if you need to
     /// notify listeners that "GreeterName" was updated. It will be automatically called when
     /// using this setter.
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn set_greeter_name(&mut self, name: String) {
         self.name = name;
     }
 
     /// A signal; the implementation is provided by the macro.
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn greeted_everyone(ctxt: &SignalContext<'_>) -> Result<()>;
 }
 
@@ -307,34 +307,34 @@ you'll want to use `zbus::fdo::Error::UnknownProperty` variant.
 
 As you might have noticed in the previous example, the signal methods don't take a `&self` argument
 but a `SignalContext` reference. This allows to emit signals whether from inside or outside of the
-`dbus_interface` methods' context. To make things simpler, `dbus_interface` methods can receive a
+`interface` methods' context. To make things simpler, `interface` methods can receive a
 `SignalContext` passed to them using the special `zbus(signal_context)` attribute, as demonstrated
 in the previous example.
 
-Please refer to [`dbus_interface` documentation][didoc] for more examples and list of other special
+Please refer to [`interface` documentation][didoc] for more examples and list of other special
 attributes you can make use of.
 
 ### Notifying property changes
 
-For each property declared through the `dbus_interface` macro, a `<property_name>_changed` method is
+For each property declared through the `interface` macro, a `<property_name>_changed` method is
 generated that emits the necessary property change signal. Here is how to use it with the previous
 example code:
 
 ```rust,no_run
-# use zbus::dbus_interface;
+# use zbus::interface;
 #
 # struct Greeter {
 #     name: String
 # }
 #
-# #[dbus_interface(name = "org.zbus.MyGreeter1")]
+# #[interface(name = "org.zbus.MyGreeter1")]
 # impl Greeter {
-#     #[dbus_interface(property)]
+#     #[zbus(property)]
 #     async fn greeter_name(&self) -> &str {
 #         &self.name
 #     }
 #
-#     #[dbus_interface(property)]
+#     #[zbus(property)]
 #     async fn set_greeter_name(&mut self, name: String) {
 #         self.name = name;
 #     }
@@ -354,4 +354,4 @@ iface.greeter_name_changed(iface_ref.signal_context()).await?;
 ```
 
 [D-Bus concepts]: concepts.html#bus-name--service-name
-[didoc]: https://docs.rs/zbus/latest/zbus/attr.dbus_interface.html
+[didoc]: https://docs.rs/zbus/latest/zbus/attr.interface.html

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -26,13 +26,13 @@ A simple service that politely greets whoever calls its `SayHello` method:
 
 ```rust,no_run
 use std::{error::Error, future::pending};
-use zbus::{connection, dbus_interface};
+use zbus::{connection, interface};
 
 struct Greeter {
     count: u64
 }
 
-#[dbus_interface(name = "org.zbus.MyGreeter1")]
+#[interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {
     // Can be `async` as well.
     fn say_hello(&mut self, name: &str) -> String {
@@ -70,9 +70,9 @@ s "Hello Maria! I have been called 1 times."
 Now let's write the client-side code for `MyGreeter` service:
 
 ```rust,no_run
-use zbus::{Connection, Result, dbus_proxy};
+use zbus::{Connection, Result, proxy};
 
-#[dbus_proxy(
+#[proxy(
     interface = "org.zbus.MyGreeter1",
     default_service = "org.zbus.MyGreeter",
     default_path = "/org/zbus/MyGreeter"
@@ -86,7 +86,7 @@ trait MyGreeter {
 async fn main() -> Result<()> {
     let connection = Connection::session().await?;
 
-    // `dbus_proxy` macro creates `MyGreaterProxy` based on `Notifications` trait.
+    // `proxy` macro creates `MyGreaterProxy` based on `Notifications` trait.
     let proxy = MyGreeterProxy::new(&connection).await?;
     let reply = proxy.say_hello("Maria").await?;
     println!("{reply}");

--- a/zbus/examples/watch-systemd-jobs.rs
+++ b/zbus/examples/watch-systemd-jobs.rs
@@ -6,21 +6,21 @@
 
 use async_std::stream::StreamExt;
 use zbus::Connection;
-use zbus_macros::dbus_proxy;
+use zbus_macros::proxy;
 use zvariant::OwnedObjectPath;
 
 fn main() {
     async_io::block_on(watch_systemd_jobs()).expect("Error listening to signal");
 }
 
-#[dbus_proxy(
+#[proxy(
     default_service = "org.freedesktop.systemd1",
     default_path = "/org/freedesktop/systemd1",
     interface = "org.freedesktop.systemd1.Manager"
 )]
 trait Systemd1Manager {
     // Defines signature for D-Bus signal named `JobNew`
-    #[dbus_proxy(signal)]
+    #[zbus(signal)]
     fn job_new(&self, id: u32, job: OwnedObjectPath, unit: String) -> zbus::Result<()>;
 }
 

--- a/zbus/src/blocking/fdo.rs
+++ b/zbus/src/blocking/fdo.rs
@@ -12,12 +12,11 @@ use zbus_names::{
 use zvariant::{ObjectPath, Optional, OwnedValue, Value};
 
 use crate::{
-    dbus_proxy,
     fdo::{
         ConnectionCredentials, ManagedObjects, ReleaseNameReply, RequestNameFlags,
         RequestNameReply, Result,
     },
-    OwnedGuid,
+    proxy, OwnedGuid,
 };
 
 gen_introspectable_proxy!(false, true);

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Since methods provided by these types run their own little runtime (`block_on`), you must not
 //! use them in async contexts because of the infamous [async sandwich footgun][asf]. This is
-//! an especially important fact to keep in mind for [`crate::dbus_interface`]. While
+//! an especially important fact to keep in mind for [`crate::interface`]. While
 //! `dbus_interface` allows non-async methods for convenience, these methods are called from an
 //! async context. The [`blocking` crate] provides an easy way around this problem though.
 //!

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -41,13 +41,13 @@ where
     /// ```no_run
     /// # use std::error::Error;
     /// # use async_io::block_on;
-    /// # use zbus::{blocking::Connection, dbus_interface};
+    /// # use zbus::{blocking::Connection, interface};
     ///
     /// struct MyIface(u32);
     ///
-    /// #[dbus_interface(name = "org.myiface.MyIface")]
+    /// #[interface(name = "org.myiface.MyIface")]
     /// impl MyIface {
-    ///    #[dbus_interface(property)]
+    ///    #[zbus(property)]
     ///    fn count(&self) -> u32 {
     ///        self.0
     ///    }
@@ -84,7 +84,7 @@ where
 ///
 /// ```no_run
 /// # use std::error::Error;
-/// use zbus::{blocking::Connection, dbus_interface};
+/// use zbus::{blocking::Connection, interface};
 /// use event_listener::Event;
 ///
 /// struct Example {
@@ -99,14 +99,14 @@ where
 ///     }
 /// }
 ///
-/// #[dbus_interface(name = "org.myiface.Example")]
+/// #[interface(name = "org.myiface.Example")]
 /// impl Example {
 ///     // This will be the "Quit" D-Bus method.
 ///     fn quit(&mut self) {
 ///         self.quit_event.notify(1);
 ///     }
 ///
-///     // See `dbus_interface` documentation to learn
+///     // See `interface` documentation to learn
 ///     // how to expose properties & signals as well.
 /// }
 ///
@@ -189,13 +189,13 @@ impl ObjectServer {
     /// # use zbus::{
     /// #    SignalContext,
     /// #    blocking::Connection,
-    /// #    dbus_interface,
+    /// #    interface,
     /// # };
     /// #
     /// struct MyIface;
-    /// #[dbus_interface(name = "org.myiface.MyIface")]
+    /// #[interface(name = "org.myiface.MyIface")]
     /// impl MyIface {
-    ///     #[dbus_interface(signal)]
+    ///     #[zbus(signal)]
     ///     async fn emit_signal(ctxt: &SignalContext<'_>) -> zbus::Result<()>;
     /// }
     ///

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -47,14 +47,14 @@ pub use builder::Builder;
 ///
 /// # Note
 ///
-/// It is recommended to use the [`dbus_proxy`] macro, which provides a more convenient and
+/// It is recommended to use the [`proxy`] macro, which provides a more convenient and
 /// type-safe *façade* `Proxy` derived from a Rust trait.
 ///
 /// ## Current limitations:
 ///
 /// At the moment, `Proxy` doesn't prevent [auto-launching][al].
 ///
-/// [`dbus_proxy`]: attr.dbus_proxy.html
+/// [`proxy`]: attr.proxy.html
 /// [al]: https://github.com/dbus2/zbus/issues/54
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Debug)]

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -90,7 +90,7 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 ///
 /// For higher-level message handling (typed functions, introspection, documentation reasons etc),
 /// it is recommended to wrap the low-level D-Bus messages into Rust functions with the
-/// [`dbus_proxy`] and [`dbus_interface`] macros instead of doing it directly on a `Connection`.
+/// [`proxy`] and [`interface`] macros instead of doing it directly on a `Connection`.
 ///
 /// Typically, a connection is made to the session bus with [`Connection::session`], or to the
 /// system bus with [`Connection::system`]. Then the connection is used with [`crate::Proxy`]
@@ -113,8 +113,8 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 ///
 /// [method calls]: struct.Connection.html#method.call_method
 /// [signals]: struct.Connection.html#method.emit_signal
-/// [`dbus_proxy`]: attr.dbus_proxy.html
-/// [`dbus_interface`]: attr.dbus_interface.html
+/// [`proxy`]: attr.proxy.html
+/// [`interface`]: attr.interface.html
 /// [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
 /// [`set_max_queued`]: struct.Connection.html#method.set_max_queued
 ///
@@ -848,7 +848,7 @@ impl Connection {
     ///
     /// # struct SomeIface;
     /// #
-    /// # #[zbus::dbus_interface]
+    /// # #[zbus::interface]
     /// # impl SomeIface {
     /// # }
     /// #
@@ -1604,7 +1604,7 @@ mod tests {
         #[derive(Default)]
         struct MyInterface {}
 
-        #[crate::dbus_interface(name = "dev.peelz.FooBar.Baz")]
+        #[crate::interface(name = "dev.peelz.FooBar.Baz")]
         impl MyInterface {
             fn do_thing(&self) {}
         }

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -17,15 +17,15 @@ use zvariant::{
 };
 
 use crate::{
-    dbus_interface, dbus_proxy, message::Header, object_server::SignalContext, DBusError,
-    ObjectServer, OwnedGuid,
+    interface, message::Header, object_server::SignalContext, proxy, DBusError, ObjectServer,
+    OwnedGuid,
 };
 
 #[rustfmt::skip]
 macro_rules! gen_introspectable_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus.Introspectable` interface.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.Introspectable",
             default_path = "/",
             gen_async = $gen_async,
@@ -47,7 +47,7 @@ assert_impl_all!(IntrospectableProxy<'_>: Send, Sync, Unpin);
 /// [ObjectServer](crate::ObjectServer).
 pub(crate) struct Introspectable;
 
-#[dbus_interface(name = "org.freedesktop.DBus.Introspectable")]
+#[interface(name = "org.freedesktop.DBus.Introspectable")]
 impl Introspectable {
     async fn introspect(
         &self,
@@ -69,7 +69,7 @@ impl Introspectable {
 macro_rules! gen_properties_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus.Properties` interface.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.Properties",
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
@@ -96,7 +96,7 @@ macro_rules! gen_properties_proxy {
                 interface_name: Optional<InterfaceName<'_>>,
             ) -> Result<HashMap<String, OwnedValue>>;
 
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             async fn properties_changed(
                 &self,
                 interface_name: InterfaceName<'_>,
@@ -117,7 +117,7 @@ pub struct Properties;
 
 assert_impl_all!(Properties: Send, Sync, Unpin);
 
-#[dbus_interface(name = "org.freedesktop.DBus.Properties")]
+#[interface(name = "org.freedesktop.DBus.Properties")]
 impl Properties {
     async fn get(
         &self,
@@ -207,7 +207,7 @@ impl Properties {
     }
 
     /// Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     #[rustfmt::skip]
     pub async fn properties_changed(
         ctxt: &SignalContext<'_>,
@@ -229,7 +229,7 @@ macro_rules! gen_object_manager_proxy {
         /// **NB:** Changes to properties on existing interfaces are not reported using this interface.
         /// Please use [`PropertiesProxy::receive_properties_changed`] to monitor changes to properties on
         /// objects.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.ObjectManager",
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
@@ -248,7 +248,7 @@ macro_rules! gen_object_manager_proxy {
             /// This signal is emitted when either a new object is added or when an existing object gains
             /// one or more interfaces. The `interfaces_and_properties` argument contains a map with the
             /// interfaces and properties (if any) that have been added to the given object path.
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn interfaces_added(
                 &self,
                 object_path: ObjectPath<'_>,
@@ -257,7 +257,7 @@ macro_rules! gen_object_manager_proxy {
 
             /// This signal is emitted whenever an object is removed or it loses one or more interfaces.
             /// The `interfaces` parameters contains a list of the interfaces that were removed.
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn interfaces_removed(
                 &self,
                 object_path: ObjectPath<'_>,
@@ -287,7 +287,7 @@ assert_impl_all!(ObjectManagerProxy<'_>: Send, Sync, Unpin);
 #[derive(Debug, Clone)]
 pub struct ObjectManager;
 
-#[dbus_interface(name = "org.freedesktop.DBus.ObjectManager")]
+#[interface(name = "org.freedesktop.DBus.ObjectManager")]
 impl ObjectManager {
     async fn get_managed_objects(
         &self,
@@ -307,7 +307,7 @@ impl ObjectManager {
     /// This signal is emitted when either a new object is added or when an existing object gains
     /// one or more interfaces. The `interfaces_and_properties` argument contains a map with the
     /// interfaces and properties (if any) that have been added to the given object path.
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn interfaces_added(
         ctxt: &SignalContext<'_>,
         object_path: &ObjectPath<'_>,
@@ -316,7 +316,7 @@ impl ObjectManager {
 
     /// This signal is emitted whenever an object is removed or it loses one or more interfaces.
     /// The `interfaces` parameters contains a list of the interfaces that were removed.
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn interfaces_removed(
         ctxt: &SignalContext<'_>,
         object_path: &ObjectPath<'_>,
@@ -328,7 +328,7 @@ impl ObjectManager {
 macro_rules! gen_peer_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus.Peer` interface.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.Peer",
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
@@ -356,7 +356,7 @@ pub(crate) struct Peer;
 /// Server-side implementation for the `org.freedesktop.DBus.Peer` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer](crate::ObjectServer).
-#[dbus_interface(name = "org.freedesktop.DBus.Peer")]
+#[interface(name = "org.freedesktop.DBus.Peer")]
 impl Peer {
     fn ping(&self) {}
 
@@ -384,7 +384,7 @@ impl Peer {
 macro_rules! gen_monitoring_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus.Monitoring` interface.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.Monitoring",
             default_service = "org.freedesktop.DBus",
             default_path = "/org/freedesktop/DBus",
@@ -428,7 +428,7 @@ assert_impl_all!(MonitoringProxy<'_>: Send, Sync, Unpin);
 macro_rules! gen_stats_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus.Debug.Stats` interface.
-        #[dbus_proxy(
+        #[proxy(
             interface = "org.freedesktop.DBus.Debug.Stats",
             default_service = "org.freedesktop.DBus",
             default_path = "/org/freedesktop/DBus",
@@ -695,7 +695,7 @@ impl ConnectionCredentials {
 macro_rules! gen_dbus_proxy {
     ($gen_async:literal, $gen_blocking:literal) => {
         /// Proxy for the `org.freedesktop.DBus` interface.
-        #[dbus_proxy(
+        #[proxy(
             default_service = "org.freedesktop.DBus",
             default_path = "/org/freedesktop/DBus",
             interface = "org.freedesktop.DBus",
@@ -704,7 +704,7 @@ macro_rules! gen_dbus_proxy {
         )]
         trait DBus {
             /// Adds a match rule to match messages going through the message bus
-            #[dbus_proxy(name = "AddMatch")]
+            #[zbus(name = "AddMatch")]
             fn add_match_rule(&self, rule: crate::MatchRule<'_>) -> Result<()>;
 
             /// Returns auditing data used by Solaris ADT, in an unspecified binary format.
@@ -717,14 +717,14 @@ macro_rules! gen_dbus_proxy {
             ) -> Result<ConnectionCredentials>;
 
             /// Returns the security context used by SELinux, in an unspecified format.
-            #[dbus_proxy(name = "GetConnectionSELinuxSecurityContext")]
+            #[zbus(name = "GetConnectionSELinuxSecurityContext")]
             fn get_connection_selinux_security_context(
                 &self,
                 bus_name: BusName<'_>,
             ) -> Result<Vec<u8>>;
 
             /// Returns the Unix process ID of the process connected to the server.
-            #[dbus_proxy(name = "GetConnectionUnixProcessID")]
+            #[zbus(name = "GetConnectionUnixProcessID")]
             fn get_connection_unix_process_id(&self, bus_name: BusName<'_>) -> Result<u32>;
 
             /// Returns the Unix user ID of the process connected to the server.
@@ -758,7 +758,7 @@ macro_rules! gen_dbus_proxy {
             fn reload_config(&self) -> Result<()>;
 
             /// Removes the first rule that matches.
-            #[dbus_proxy(name = "RemoveMatch")]
+            #[zbus(name = "RemoveMatch")]
             fn remove_match_rule(&self, rule: crate::MatchRule<'_>) -> Result<()>;
 
             /// Ask the message bus to assign the given name to the method caller.
@@ -779,7 +779,7 @@ macro_rules! gen_dbus_proxy {
             /// This signal indicates that the owner of a name has
             /// changed. It's also the signal to use to detect the appearance
             /// of new names on the bus.
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn name_owner_changed(
                 &self,
                 name: BusName<'_>,
@@ -788,16 +788,16 @@ macro_rules! gen_dbus_proxy {
             );
 
             /// This signal is sent to a specific application when it loses ownership of a name.
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn name_lost(&self, name: BusName<'_>);
 
             /// This signal is sent to a specific application when it gains ownership of a name.
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn name_acquired(&self, name: BusName<'_>);
 
             /// This property lists abstract “features” provided by the message bus, and can be used by
             /// clients to detect the capabilities of the message bus with which they are communicating.
-            #[dbus_proxy(property)]
+            #[zbus(property)]
             fn features(&self) -> Result<Vec<String>>;
 
             /// This property lists interfaces provided by the `/org/freedesktop/DBus` object, and can be
@@ -812,7 +812,7 @@ macro_rules! gen_dbus_proxy {
             /// `org.freedesktop.DBus` was successful. The standard `org.freedesktop.DBus.Peer` and
             /// `org.freedesktop.DBus.Introspectable` interfaces are not included in the value of this
             /// property either, because they do not indicate features of the message bus implementation.
-            #[dbus_proxy(property)]
+            #[zbus(property)]
             fn interfaces(&self) -> Result<Vec<OwnedInterfaceName>>;
         }
     };
@@ -1115,9 +1115,9 @@ mod tests {
 
         // Now create the service side.
         struct TestObj;
-        #[super::dbus_interface(name = "org.zbus.TestObj")]
+        #[super::interface(name = "org.zbus.TestObj")]
         impl TestObj {
-            #[dbus_interface(property)]
+            #[zbus(property)]
             fn test(&self) -> String {
                 "test".into()
             }

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -823,11 +823,11 @@ assert_impl_all!(DBusProxy<'_>: Send, Sync, Unpin);
 
 /// Errors from <https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/dbus/dbus-protocol.h>
 #[derive(Clone, Debug, DBusError, PartialEq)]
-#[dbus_error(prefix = "org.freedesktop.DBus.Error", impl_display = true)]
+#[zbus(prefix = "org.freedesktop.DBus.Error", impl_display = true)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Error {
     /// Unknown or fall-through ZBus error.
-    #[dbus_error(zbus_error)]
+    #[zbus(error)]
     ZBus(zbus::Error),
 
     /// A generic error; "something went wrong" - see the error message for more.
@@ -913,51 +913,51 @@ pub enum Error {
     MatchRuleInvalid(String),
 
     /// While starting a new process, the exec() call failed.
-    #[dbus_error(name = "Spawn.ExecFailed")]
+    #[zbus(name = "Spawn.ExecFailed")]
     SpawnExecFailed(String),
 
     /// While starting a new process, the fork() call failed.
-    #[dbus_error(name = "Spawn.ForkFailed")]
+    #[zbus(name = "Spawn.ForkFailed")]
     SpawnForkFailed(String),
 
     /// While starting a new process, the child exited with a status code.
-    #[dbus_error(name = "Spawn.ChildExited")]
+    #[zbus(name = "Spawn.ChildExited")]
     SpawnChildExited(String),
 
     /// While starting a new process, the child exited on a signal.
-    #[dbus_error(name = "Spawn.ChildSignaled")]
+    #[zbus(name = "Spawn.ChildSignaled")]
     SpawnChildSignaled(String),
 
     /// While starting a new process, something went wrong.
-    #[dbus_error(name = "Spawn.Failed")]
+    #[zbus(name = "Spawn.Failed")]
     SpawnFailed(String),
 
     /// We failed to setup the environment correctly.
-    #[dbus_error(name = "Spawn.FailedToSetup")]
+    #[zbus(name = "Spawn.FailedToSetup")]
     SpawnFailedToSetup(String),
 
     /// We failed to setup the config parser correctly.
-    #[dbus_error(name = "Spawn.ConfigInvalid")]
+    #[zbus(name = "Spawn.ConfigInvalid")]
     SpawnConfigInvalid(String),
 
     /// Bus name was not valid.
-    #[dbus_error(name = "Spawn.ServiceNotValid")]
+    #[zbus(name = "Spawn.ServiceNotValid")]
     SpawnServiceNotValid(String),
 
     /// Service file not found in system-services directory.
-    #[dbus_error(name = "Spawn.ServiceNotFound")]
+    #[zbus(name = "Spawn.ServiceNotFound")]
     SpawnServiceNotFound(String),
 
     /// Permissions are incorrect on the setuid helper.
-    #[dbus_error(name = "Spawn.PermissionsInvalid")]
+    #[zbus(name = "Spawn.PermissionsInvalid")]
     SpawnPermissionsInvalid(String),
 
     /// Service file invalid (Name, User or Exec missing).
-    #[dbus_error(name = "Spawn.FileInvalid")]
+    #[zbus(name = "Spawn.FileInvalid")]
     SpawnFileInvalid(String),
 
     /// There was not enough memory to complete the operation.
-    #[dbus_error(name = "Spawn.NoMemory")]
+    #[zbus(name = "Spawn.NoMemory")]
     SpawnNoMemory(String),
 
     /// Tried to get a UNIX process ID and it wasn't available.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -122,13 +122,13 @@ where
     /// ```no_run
     /// # use std::error::Error;
     /// # use async_io::block_on;
-    /// # use zbus::{Connection, dbus_interface};
+    /// # use zbus::{Connection, interface};
     ///
     /// struct MyIface(u32);
     ///
-    /// #[dbus_interface(name = "org.myiface.MyIface")]
+    /// #[interface(name = "org.myiface.MyIface")]
     /// impl MyIface {
-    ///    #[dbus_interface(property)]
+    ///    #[zbus(property)]
     ///    async fn count(&self) -> u32 {
     ///        self.0
     ///    }
@@ -433,7 +433,7 @@ impl Node {
 ///
 /// ```no_run
 /// # use std::error::Error;
-/// use zbus::{Connection, dbus_interface};
+/// use zbus::{Connection, interface};
 /// use event_listener::Event;
 /// # use async_io::block_on;
 ///
@@ -449,14 +449,14 @@ impl Node {
 ///     }
 /// }
 ///
-/// #[dbus_interface(name = "org.myiface.Example")]
+/// #[interface(name = "org.myiface.Example")]
 /// impl Example {
 ///     // This will be the "Quit" D-Bus method.
 ///     async fn quit(&mut self) {
 ///         self.quit_event.notify(1);
 ///     }
 ///
-///     // See `dbus_interface` documentation to learn
+///     // See `interface` documentation to learn
 ///     // how to expose properties & signals as well.
 /// }
 ///
@@ -636,14 +636,14 @@ impl ObjectServer {
     ///
     /// ```no_run
     /// # use std::error::Error;
-    /// # use zbus::{Connection, dbus_interface};
+    /// # use zbus::{Connection, interface};
     /// # use async_io::block_on;
     /// #
     /// struct MyIface(u32);
     ///
-    /// #[dbus_interface(name = "org.myiface.MyIface")]
+    /// #[interface(name = "org.myiface.MyIface")]
     /// impl MyIface {
-    ///      #[dbus_interface(property)]
+    ///      #[zbus(property)]
     ///      async fn count(&self) -> u32 {
     ///          self.0
     ///      }
@@ -816,7 +816,7 @@ impl From<crate::blocking::ObjectServer> for ObjectServer {
 
 /// A response wrapper that notifies after response has been sent.
 ///
-/// Sometimes in [`dbus_interface`] method implemenations we need to do some other work after the
+/// Sometimes in [`interface`] method implemenations we need to do some other work after the
 /// response has been sent off. This wrapper type allows us to do that. Instead of returning your
 /// intended response type directly, wrap it in this type and return it from your method. The
 /// returned `EventListener` from `new` method will be notified when the response has been sent.
@@ -830,7 +830,7 @@ impl From<crate::blocking::ObjectServer> for ObjectServer {
 /// The notification indicates that the response has been sent off, not that destination peer has
 /// received it. That can only be guaranteed for a peer-to-peer connection.
 ///
-/// [`dbus_interface`]: crate::dbus_interface
+/// [`interface`]: crate::interface
 #[derive(Debug)]
 pub struct ResponseDispatchNotifier<R> {
     response: R,

--- a/zbus/src/object_server/signal_context.rs
+++ b/zbus/src/object_server/signal_context.rs
@@ -6,7 +6,7 @@ use crate::{zvariant::ObjectPath, Connection, Error, Result};
 ///
 /// For signal emission using the high-level API, you'll need instances of this type.
 ///
-/// See [`crate::InterfaceRef::signal_context`] and [`crate::dbus_interface`]
+/// See [`crate::InterfaceRef::signal_context`] and [`crate::interface`]
 /// documentation for details and examples of this type in use.
 #[derive(Clone, Debug)]
 pub struct SignalContext<'s> {

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -60,11 +60,11 @@ pub use builder::{Builder, CacheProperties, ProxyDefault};
 ///
 /// # Note
 ///
-/// It is recommended to use the [`dbus_proxy`] macro, which provides a more convenient and
+/// It is recommended to use the [`proxy`] macro, which provides a more convenient and
 /// type-safe *façade* `Proxy` derived from a Rust trait.
 ///
 /// [`futures` crate]: https://crates.io/crates/futures
-/// [`dbus_proxy`]: attr.dbus_proxy.html
+/// [`proxy`]: attr.proxy.html
 #[derive(Clone, Debug)]
 pub struct Proxy<'a> {
     pub(crate) inner: Arc<ProxyInner<'a>>,
@@ -1343,8 +1343,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        connection, dbus_interface, dbus_proxy, object_server::SignalContext, utils::block_on,
-        AsyncDrop,
+        connection, interface, object_server::SignalContext, proxy, utils::block_on, AsyncDrop,
     };
     use futures_util::StreamExt;
     use ntest::timeout;
@@ -1432,22 +1431,22 @@ mod tests {
     /// signal listener is created against another signal. Previously, this second
     /// call to add the match rule never resolved and resulted in a deadlock.
     async fn test_signal_stream_deadlock() -> Result<()> {
-        #[dbus_proxy(
+        #[proxy(
             gen_blocking = false,
             default_path = "/org/zbus/Test",
             default_service = "org.zbus.Test.MR501",
             interface = "org.zbus.Test"
         )]
         trait Test {
-            #[dbus_proxy(signal)]
+            #[zbus(signal)]
             fn my_signal(&self, msg: &str) -> Result<()>;
         }
 
         struct TestIface;
 
-        #[dbus_interface(name = "org.zbus.Test")]
+        #[interface(name = "org.zbus.Test")]
         impl TestIface {
-            #[dbus_interface(signal)]
+            #[zbus(signal)]
             async fn my_signal(context: &SignalContext<'_>, msg: &'static str) -> Result<()>;
         }
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -189,10 +189,10 @@ impl MyIfaceImpl {
 
 /// Custom D-Bus error type.
 #[derive(Debug, DBusError)]
-#[dbus_error(prefix = "org.freedesktop.MyIface.Error")]
+#[zbus(prefix = "org.freedesktop.MyIface.Error")]
 enum MyIfaceError {
     SomethingWentWrong(String),
-    #[dbus_error(zbus_error)]
+    #[zbus(error)]
     ZBus(zbus::Error),
 }
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -22,9 +22,10 @@ use zbus::{
 use zvariant::{DeserializeDict, Optional, OwnedValue, SerializeDict, Str, Type, Value};
 
 use zbus::{
-    connection, dbus_interface, dbus_proxy,
+    connection, interface,
     message::Header,
     object_server::{InterfaceRef, SignalContext},
+    proxy,
     proxy::CacheProperties,
     Connection, ObjectServer,
 };
@@ -51,7 +52,7 @@ pub struct RefType<'a> {
     field1: Str<'a>,
 }
 
-#[dbus_proxy(assume_defaults = true, gen_blocking = true)]
+#[proxy(assume_defaults = true, gen_blocking = true)]
 trait MyIface {
     fn ping(&self) -> zbus::Result<u32>;
 
@@ -79,79 +80,79 @@ trait MyIface {
     // Optional params and return values.
     fn optional_args(&self, key: Option<&str>) -> zbus::Result<Option<String>>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn count(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_count(&self, count: u32) -> zbus::Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn hash_map(&self) -> zbus::Result<HashMap<String, String>>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn address_data(&self) -> zbus::Result<IP4Adress>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_address_data(&self, addr: IP4Adress) -> zbus::Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn address_data2(&self) -> zbus::Result<IP4Adress>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn str_prop(&self) -> zbus::Result<String>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_str_prop(&self, str_prop: &str) -> zbus::Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn ref_type(&self) -> zbus::Result<RefType<'_>>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_ref_type(&self, ref_type: RefType<'_>) -> zbus::Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn fail_property(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn optional_property(&self) -> zbus::Result<Optional<u32>>;
 
-    #[dbus_proxy(no_reply)]
+    #[zbus(no_reply)]
     fn test_no_reply(&self) -> zbus::Result<()>;
 
-    #[dbus_proxy(no_autostart)]
+    #[zbus(no_autostart)]
     fn test_no_autostart(&self) -> zbus::Result<()>;
 
-    #[dbus_proxy(allow_interactive_auth)]
+    #[zbus(allow_interactive_auth)]
     fn test_interactive_auth(&self) -> zbus::Result<()>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn emits_changed_default(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_emits_changed_default(&self, count: u32) -> zbus::Result<()>;
 
-    #[dbus_proxy(property(emits_changed_signal = "true"))]
+    #[zbus(property(emits_changed_signal = "true"))]
     fn emits_changed_true(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_emits_changed_true(&self, count: u32) -> zbus::Result<()>;
 
-    #[dbus_proxy(property(emits_changed_signal = "invalidates"))]
+    #[zbus(property(emits_changed_signal = "invalidates"))]
     fn emits_changed_invalidates(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_emits_changed_invalidates(&self, count: u32) -> zbus::Result<()>;
 
-    #[dbus_proxy(property(emits_changed_signal = "const"))]
+    #[zbus(property(emits_changed_signal = "const"))]
     fn emits_changed_const(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_emits_changed_const(&self, count: u32) -> zbus::Result<()>;
 
-    #[dbus_proxy(property(emits_changed_signal = "false"))]
+    #[zbus(property(emits_changed_signal = "false"))]
     fn emits_changed_false(&self) -> zbus::Result<u32>;
 
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_emits_changed_false(&self, count: u32) -> zbus::Result<()>;
 }
 
@@ -196,7 +197,7 @@ enum MyIfaceError {
     ZBus(zbus::Error),
 }
 
-#[dbus_interface(interface = "org.freedesktop.MyIface")]
+#[interface(interface = "org.freedesktop.MyIface")]
 impl MyIfaceImpl {
     #[instrument]
     async fn ping(&mut self, #[zbus(signal_context)] ctxt: SignalContext<'_>) -> u32 {
@@ -261,7 +262,7 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(out_args("foo", "bar"))]
+    #[zbus(out_args("foo", "bar"))]
     fn test_multi_ret(&self) -> zbus::fdo::Result<(i32, String)> {
         debug!("`TestMultiRet` called.");
         Ok((42, String::from("Meaning of life")))
@@ -290,7 +291,7 @@ impl MyIfaceImpl {
         Ok(response)
     }
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn test_response_notified(ctxt: SignalContext<'_>) -> zbus::Result<()>;
 
     #[instrument]
@@ -342,7 +343,7 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_count(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`Count` setter called.");
         if val == 42 {
@@ -353,21 +354,21 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn count(&self) -> u32 {
         debug!("`Count` getter called.");
         self.count
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn hash_map(&self) -> HashMap<String, String> {
         debug!("`HashMap` getter called.");
         self.test_hashmap_return().await.unwrap()
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     async fn fail_property(&self) -> zbus::fdo::Result<u32> {
         Err(zbus::fdo::Error::UnknownProperty(
             "FailProperty".to_string(),
@@ -375,14 +376,14 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn optional_property(&self) -> Optional<u32> {
         debug!("`OptionalAsProp` getter called.");
         Some(42).into()
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn address_data(&self) -> IP4Adress {
         debug!("`AddressData` getter called.");
         IP4Adress {
@@ -392,7 +393,7 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_address_data(&self, addr: IP4Adress) {
         debug!("`AddressData` setter called with {:?}", addr);
     }
@@ -400,7 +401,7 @@ impl MyIfaceImpl {
     // On the bus, this should return the same value as address_data above. We want to test if
     // this works both ways.
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn address_data2(&self) -> HashMap<String, OwnedValue> {
         debug!("`AddressData2` getter called.");
         let mut map = HashMap::new();
@@ -414,19 +415,19 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn str_prop(&self) -> String {
         "Hello".to_string()
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_str_prop(&self, str_prop: &str) {
         debug!("`SetStrRef` called with {:?}", str_prop);
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn ref_prop(&self) -> RefType<'_> {
         RefType {
             field1: "Hello".into(),
@@ -434,7 +435,7 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_ref_prop(&self, ref_type: RefType<'_>) {
         debug!("`SetRefType` called with {:?}", ref_type);
     }
@@ -469,18 +470,18 @@ impl MyIfaceImpl {
             .contains(zbus::message::Flags::AllowInteractiveAuth));
     }
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     async fn alert_count(ctxt: &SignalContext<'_>, val: u32) -> zbus::Result<()>;
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn emits_changed_default(&self) -> u32 {
         debug!("`EmitsChangedDefault` getter called.");
         self.emits_changed_default
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_emits_changed_default(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`EmitsChangedDefault` setter called.");
         self.emits_changed_default = val;
@@ -488,14 +489,14 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property(emits_changed_signal = "true"))]
+    #[zbus(property(emits_changed_signal = "true"))]
     fn emits_changed_true(&self) -> u32 {
         debug!("`EmitsChangedTrue` getter called.");
         self.emits_changed_true
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_emits_changed_true(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`EmitsChangedTrue` setter called.");
         self.emits_changed_true = val;
@@ -503,14 +504,14 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property(emits_changed_signal = "invalidates"))]
+    #[zbus(property(emits_changed_signal = "invalidates"))]
     fn emits_changed_invalidates(&self) -> u32 {
         debug!("`EmitsChangedInvalidates` getter called.");
         self.emits_changed_invalidates
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_emits_changed_invalidates(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`EmitsChangedInvalidates` setter called.");
         self.emits_changed_invalidates = val;
@@ -518,14 +519,14 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property(emits_changed_signal = "const"))]
+    #[zbus(property(emits_changed_signal = "const"))]
     fn emits_changed_const(&self) -> u32 {
         debug!("`EmitsChangedConst` getter called.");
         self.emits_changed_const
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_emits_changed_const(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`EmitsChangedConst` setter called.");
         self.emits_changed_const = val;
@@ -533,14 +534,14 @@ impl MyIfaceImpl {
     }
 
     #[instrument]
-    #[dbus_interface(property(emits_changed_signal = "false"))]
+    #[zbus(property(emits_changed_signal = "false"))]
     fn emits_changed_false(&self) -> u32 {
         debug!("`EmitsChangedFalse` getter called.");
         self.emits_changed_false
     }
 
     #[instrument]
-    #[dbus_interface(property)]
+    #[zbus(property)]
     fn set_emits_changed_false(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`EmitsChangedFalse` setter called.");
         self.emits_changed_false = val;

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -25,7 +25,7 @@ syn = { version = "1.0.103", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.21"
 proc-macro-crate = "1.2.1"
 regex = "1.6.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.0.1" }
+zvariant_utils = { path = "../zvariant_utils", version = "=1.1.0" }
 
 [dev-dependencies]
 zbus = { path = "../zbus" }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -345,12 +345,12 @@ pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This macro makes it easy to implement the [`zbus::DBusError`] trait for your custom error type
 /// (currently only enums are supported).
 ///
-/// If a special variant marked with the `dbus_error` attribute is present, `From<zbus::Error>` is
+/// If a special variant marked with the `zbus` attribute is present, `From<zbus::Error>` is
 /// also implemented for your type. This variant can only have a single unnamed field of type
 /// [`zbus::Error`]. This implementation makes it possible for you to declare proxy methods to
 /// directly return this type, rather than [`zbus::Error`].
 ///
-/// Each variant (except for the special `dbus_error` one) can optionally have a (named or unnamed)
+/// Each variant (except for the special `zbus` one) can optionally have a (named or unnamed)
 /// `String` field (which is used as the human-readable error description).
 ///
 /// # Example
@@ -359,9 +359,9 @@ pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// use zbus_macros::DBusError;
 ///
 /// #[derive(DBusError, Debug)]
-/// #[dbus_error(prefix = "org.myservice.App")]
+/// #[zbus(prefix = "org.myservice.App")]
 /// enum Error {
-///     #[dbus_error(zbus_error)]
+///     #[zbus(error)]
 ///     ZBus(zbus::Error),
 ///     FileNotFound(String),
 ///     OutOfMemory,
@@ -372,7 +372,7 @@ pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// [`zbus::Error`]: https://docs.rs/zbus/latest/zbus/enum.Error.html
 /// [`zvariant::Type`]: https://docs.rs/zvariant/latest/zvariant/trait.Type.html
 /// [`serde::Serialize`]: https://docs.rs/serde/1.0.132/serde/trait.Serialize.html
-#[proc_macro_derive(DBusError, attributes(dbus_error))]
+#[proc_macro_derive(DBusError, attributes(zbus))]
 pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     error::expand_derive(input)

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -46,13 +46,13 @@ mod utils;
 /// * `blocking_name` - Specify the exact name of the blocking proxy type.
 ///
 /// * `assume_defaults` - whether to auto-generate values for `default_path` and `default_service`
-///   if none are specified (default: `false`). `dbus_proxy` generates a warning if neither this
+///   if none are specified (default: `false`). `proxy` generates a warning if neither this
 ///   attribute nor one of the default values are specified. Please make sure to explicitly set
 ///   either this attribute or the default values, according to your needs.
 ///
 /// Each trait method will be expanded to call to the associated D-Bus remote interface.
 ///
-/// Trait methods accept `dbus_proxy` attributes:
+/// Trait methods accept `proxy` attributes:
 ///
 /// * `name` - override the D-Bus name (pascal case form by default)
 ///
@@ -108,12 +108,12 @@ mod utils;
 ///
 /// ```no_run
 /// # use std::error::Error;
-/// use zbus_macros::dbus_proxy;
+/// use zbus_macros::proxy;
 /// use zbus::{blocking::Connection, Result, fdo, zvariant::Value};
 /// use futures_util::stream::StreamExt;
 /// use async_io::block_on;
 ///
-/// #[dbus_proxy(
+/// #[proxy(
 ///     interface = "org.test.SomeIface",
 ///     default_service = "org.test.SomeService",
 ///     default_path = "/org/test/SomeObject"
@@ -121,16 +121,16 @@ mod utils;
 /// trait SomeIface {
 ///     fn do_this(&self, with: &str, some: u32, arg: &Value<'_>) -> Result<bool>;
 ///
-///     #[dbus_proxy(property)]
+///     #[zbus(property)]
 ///     fn a_property(&self) -> fdo::Result<String>;
 ///
-///     #[dbus_proxy(property)]
+///     #[zbus(property)]
 ///     fn set_a_property(&self, a_property: &str) -> fdo::Result<()>;
 ///
-///     #[dbus_proxy(signal)]
+///     #[zbus(signal)]
 ///     fn some_signal(&self, arg1: &str, arg2: u32) -> fdo::Result<()>;
 ///
-///     #[dbus_proxy(object = "SomeOtherIface", blocking_object = "SomeOtherInterfaceBlock")]
+///     #[zbus(object = "SomeOtherIface", blocking_object = "SomeOtherInterfaceBlock")]
 ///     // The method will return a `SomeOtherIfaceProxy` or `SomeOtherIfaceProxyBlock`, depending
 ///     // on whether it is called on `SomeIfaceProxy` or `SomeIfaceProxyBlocking`, respectively.
 ///     //
@@ -140,7 +140,7 @@ mod utils;
 ///     fn some_method(&self, arg1: &str);
 /// }
 ///
-/// #[dbus_proxy(
+/// #[proxy(
 ///     interface = "org.test.SomeOtherIface",
 ///     default_service = "org.test.SomeOtherService",
 ///     blocking_name = "SomeOtherInterfaceBlock",
@@ -191,10 +191,20 @@ mod utils;
 /// [`ObjectPath`]: https://docs.rs/zvariant/latest/zvariant/struct.ObjectPath.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 #[proc_macro_attribute]
+pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as AttributeArgs);
+    let input = parse_macro_input!(item as ItemTrait);
+    proxy::expand::<proxy::ImplAttributes, proxy::MethodAttributes>(args, input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[deprecated = "Use `#[proxy(...)]` proc macro with `#[zbus(...)]` item attributes instead."]
+#[proc_macro_attribute]
 pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as AttributeArgs);
     let input = parse_macro_input!(item as ItemTrait);
-    proxy::expand(args, input)
+    proxy::expand::<proxy::old::ImplAttributes, proxy::old::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
@@ -205,7 +215,7 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// properties or signal depending on the item attributes. It will implement the [`Interface`] trait
 /// `for T` on your behalf, to handle the message dispatching and introspection support.
 ///
-/// The methods accepts the `dbus_interface` attributes:
+/// The methods accepts the `interface` attributes:
 ///
 /// * `name` - override the D-Bus name (pascal case form of the method by default)
 ///
@@ -265,14 +275,14 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```
 /// # use std::error::Error;
-/// use zbus_macros::dbus_interface;
+/// use zbus_macros::interface;
 /// use zbus::{ObjectServer, object_server::SignalContext, message::Header};
 ///
 /// struct Example {
 ///     _some_data: String,
 /// }
 ///
-/// #[dbus_interface(name = "org.myservice.Example")]
+/// #[interface(name = "org.myservice.Example")]
 /// impl Example {
 ///     // "Quit" method. A method may throw errors.
 ///     async fn quit(
@@ -296,7 +306,7 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     // "TheAnswer" property (note: the "name" attribute), with its associated getter.
 ///     // A `the_answer_changed` method has also been generated to emit the
 ///     // "PropertiesChanged" signal for this property.
-///     #[dbus_interface(property, name = "TheAnswer")]
+///     #[zbus(property, name = "TheAnswer")]
 ///     fn answer(&self) -> u32 {
 ///         2 * 3 * 7
 ///     }
@@ -304,16 +314,16 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     // "IFail" property with its associated getter.
 ///     // An `i_fail_changed` method has also been generated to emit the
 ///     // "PropertiesChanged" signal for this property.
-///     #[dbus_interface(property)]
+///     #[zbus(property)]
 ///     fn i_fail(&self) -> zbus::fdo::Result<i32> {
 ///         Err(zbus::fdo::Error::UnknownProperty("IFail".into()))
 ///     }
 ///
 ///     // "Bye" signal (note: no implementation body).
-///     #[dbus_interface(signal)]
+///     #[zbus(signal)]
 ///     async fn bye(signal_ctxt: &SignalContext<'_>, message: &str) -> zbus::Result<()>;
 ///
-///     #[dbus_interface(out_args("answer", "question"))]
+///     #[zbus(out_args("answer", "question"))]
 ///     fn meaning_of_life(&self) -> zbus::fdo::Result<(i32, String)> {
 ///         Ok((42, String::from("Meaning of life")))
 ///     }
@@ -332,10 +342,20 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// [`Interface`]: https://docs.rs/zbus/latest/zbus/object_server/trait.Interface.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 #[proc_macro_attribute]
-pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as AttributeArgs);
+pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr);
     let input = syn::parse_macro_input!(item as ItemImpl);
-    iface::expand(args, input)
+    iface::expand::<iface::TraitAttributes, iface::MethodAttributes>(args, input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[deprecated = "Use `#[interface(...)]` proc macro with `#[zbus(...)]` item attributes instead."]
+#[proc_macro_attribute]
+pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr);
+    let input = syn::parse_macro_input!(item as ItemImpl);
+    iface::expand::<iface::old::TraitAttributes, iface::old::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -110,12 +110,12 @@ fn test_proxy() {
 #[test]
 fn test_derive_error() {
     #[derive(Debug, DBusError)]
-    #[dbus_error(prefix = "org.freedesktop.zbus")]
+    #[zbus(prefix = "org.freedesktop.zbus")]
     enum Test {
-        #[dbus_error(zbus_error)]
+        #[zbus(error)]
         ZBus(zbus::Error),
         SomeExcuse,
-        #[dbus_error(name = "I.Am.Sorry.Dave")]
+        #[zbus(name = "I.Am.Sorry.Dave")]
         IAmSorryDave(String),
         LetItBe {
             desc: String,

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -4,16 +4,16 @@ use futures_util::{
 };
 use std::future::ready;
 use zbus::{block_on, fdo, object_server::SignalContext, proxy::CacheProperties};
-use zbus_macros::{dbus_interface, dbus_proxy, DBusError};
+use zbus_macros::{interface, proxy, DBusError};
 
 mod param {
-    #[zbus_macros::dbus_proxy(
+    #[zbus_macros::proxy(
         interface = "org.freedesktop.zbus_macros.ProxyParam",
         default_service = "org.freedesktop.zbus_macros",
         default_path = "/org/freedesktop/zbus_macros/test"
     )]
     trait ProxyParam {
-        #[dbus_proxy(object = "super::test::Test")]
+        #[zbus(object = "super::test::Test")]
         fn some_method<T>(&self, test: &T);
     }
 }
@@ -24,7 +24,7 @@ mod test {
         zvariant::{OwnedStructure, Structure},
     };
 
-    #[zbus_macros::dbus_proxy(
+    #[zbus_macros::proxy(
         assume_defaults = false,
         interface = "org.freedesktop.zbus_macros.Test",
         default_service = "org.freedesktop.zbus_macros"
@@ -43,22 +43,22 @@ mod test {
         /// A call returning an type that only implements DynamicDeserialize
         fn test_dyn_ret(&self) -> zbus::Result<OwnedStructure>;
 
-        #[dbus_proxy(name = "CheckRENAMING")]
+        #[zbus(name = "CheckRENAMING")]
         fn check_renaming(&self) -> zbus::Result<Vec<u8>>;
 
-        #[dbus_proxy(property)]
+        #[zbus(property)]
         fn property(&self) -> fdo::Result<Vec<String>>;
 
-        #[dbus_proxy(property(emits_changed_signal = "const"))]
+        #[zbus(property(emits_changed_signal = "const"))]
         fn a_const_property(&self) -> fdo::Result<Vec<String>>;
 
-        #[dbus_proxy(property(emits_changed_signal = "false"))]
+        #[zbus(property(emits_changed_signal = "false"))]
         fn a_live_property(&self) -> fdo::Result<Vec<String>>;
 
-        #[dbus_proxy(property)]
+        #[zbus(property)]
         fn set_property(&self, val: u16) -> fdo::Result<()>;
 
-        #[dbus_proxy(signal)]
+        #[zbus(signal)]
         fn a_signal<T>(&self, arg: u8, other: T) -> fdo::Result<()>
         where
             T: AsRef<str>;
@@ -139,7 +139,7 @@ fn test_interface() {
     #[derive(Serialize, Deserialize, Type, Value)]
     struct MyCustomPropertyType(u32);
 
-    #[dbus_interface(name = "org.freedesktop.zbus.Test")]
+    #[interface(name = "org.freedesktop.zbus.Test")]
     impl<T: 'static> Test<T>
     where
         T: serde::ser::Serialize + zbus::zvariant::Type + Send + Sync,
@@ -168,34 +168,34 @@ fn test_interface() {
             unimplemented!()
         }
 
-        #[dbus_interface(property)]
+        #[zbus(property)]
         fn my_custom_property(&self) -> MyCustomPropertyType {
             unimplemented!()
         }
 
         // Also tests that mut argument bindings work for properties
-        #[dbus_interface(property)]
+        #[zbus(property)]
         fn set_my_custom_property(&self, mut _value: MyCustomPropertyType) {
             _value = MyCustomPropertyType(42);
         }
 
         // Test that the emits_changed_signal property results in the correct annotation
-        #[dbus_interface(property(emits_changed_signal = "false"))]
+        #[zbus(property(emits_changed_signal = "false"))]
         fn my_custom_property_emits_false(&self) -> MyCustomPropertyType {
             unimplemented!()
         }
 
-        #[dbus_interface(property(emits_changed_signal = "invalidates"))]
+        #[zbus(property(emits_changed_signal = "invalidates"))]
         fn my_custom_property_emits_invalidates(&self) -> MyCustomPropertyType {
             unimplemented!()
         }
 
-        #[dbus_interface(property(emits_changed_signal = "const"))]
+        #[zbus(property(emits_changed_signal = "const"))]
         fn my_custom_property_emits_const(&self) -> MyCustomPropertyType {
             unimplemented!()
         }
 
-        #[dbus_interface(name = "CheckVEC")]
+        #[zbus(name = "CheckVEC")]
         fn check_vec(&self) -> Vec<u8> {
             unimplemented!()
         }
@@ -203,18 +203,18 @@ fn test_interface() {
         /// Testing my_prop documentation is reflected in XML.
         ///
         /// And that too.
-        #[dbus_interface(property)]
+        #[zbus(property)]
         fn my_prop(&self) -> u16 {
             unimplemented!()
         }
 
-        #[dbus_interface(property)]
+        #[zbus(property)]
         fn set_my_prop(&mut self, _val: u16) {
             unimplemented!()
         }
 
         /// Emit a signal.
-        #[dbus_interface(signal)]
+        #[zbus(signal)]
         async fn signal(ctxt: &SignalContext<'_>, arg: u8, other: &str) -> zbus::Result<()>;
     }
 
@@ -293,16 +293,16 @@ mod signal_from_message {
     use super::*;
     use zbus::message::Message;
 
-    #[dbus_proxy(
+    #[proxy(
         interface = "org.freedesktop.zbus_macros.Test",
         default_service = "org.freedesktop.zbus_macros",
         default_path = "/org/freedesktop/zbus_macros/test"
     )]
     trait Test {
-        #[dbus_proxy(signal)]
+        #[zbus(signal)]
         fn signal_u8(&self, arg: u8) -> fdo::Result<()>;
 
-        #[dbus_proxy(signal)]
+        #[zbus(signal)]
         fn signal_string(&self, arg: String) -> fdo::Result<()>;
     }
 

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0"
 syn = { version = "1.0.103", features = ["extra-traits", "full"] }
 quote = "1.0.21"
 proc-macro-crate = "1.2.1"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.0.1" }
+zvariant_utils = { path = "../zvariant_utils", version = "=1.1.0" }
 
 [dev-dependencies]
 zvariant = { path = "../zvariant", features = ["enumflags2"] }

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant_utils"
-version = "1.0.1"
+version = "1.1.0"
 authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",

--- a/zvariant_utils/src/macros.rs
+++ b/zvariant_utils/src/macros.rs
@@ -136,6 +136,23 @@ pub fn match_attribute_without_value(meta: &Meta, attr: &str) -> Result<bool> {
     }
 }
 
+/// The `AttrParse` trait is a generic interface for attribute structures.
+/// This is only implemented directly by the [`crate::def_attrs`] macro, within the `zbus_macros`
+/// crate. This macro allows the parsing of multiple variants when using the [`crate::old_new`]
+/// macro pattern, using `<T: AttrParse>` as a bounds check at compile time.
+pub trait AttrParse {
+    fn parse_meta(&mut self, meta: &::syn::Meta) -> ::syn::Result<()>;
+
+    fn parse_nested_metas<'a, I>(iter: I) -> syn::Result<Self>
+    where
+        I: ::std::iter::IntoIterator<Item = &'a ::syn::NestedMeta>,
+        Self: Sized;
+
+    fn parse(attrs: &[::syn::Attribute]) -> ::syn::Result<Self>
+    where
+        Self: Sized;
+}
+
 /// Returns an iterator over the contents of all [`MetaList`]s with the specified identifier in an
 /// array of [`Attribute`]s.
 pub fn iter_meta_lists(
@@ -395,6 +412,22 @@ macro_rules! def_attrs {
             $(pub $attr_name: $crate::def_attrs!(@attr_ty $kind)),+
         }
 
+        impl ::zvariant_utils::macros::AttrParse for $name {
+          fn parse_meta(
+              &mut self,
+              meta: &::syn::Meta
+          ) -> ::syn::Result<()> { self.parse_meta(meta) }
+
+          fn parse_nested_metas<'a, I>(iter: I) -> syn::Result<Self>
+          where
+              I: ::std::iter::IntoIterator<Item=&'a ::syn::NestedMeta>,
+              Self: Sized { Self::parse_nested_metas(iter) }
+
+          fn parse(attrs: &[::syn::Attribute]) -> ::syn::Result<Self>
+          where
+              Self: Sized { Self::parse(attrs) }
+        }
+
         impl $name {
             pub fn parse_meta(
                 &mut self,
@@ -500,4 +533,36 @@ pub fn ty_is_option(ty: &Type) -> bool {
         }) => segments.last().unwrap().ident == "Option",
         _ => false,
     }
+}
+
+#[macro_export]
+/// The `old_new` macro desognates three structures:
+///
+/// 1. The enum wrapper name.
+/// 2. The old type name.
+/// 3. The new type name.
+///
+/// The macro creates a new enumeration with two variants: `::Old(...)` and `::New(...)`
+/// The old and new variants contain the old and new type, respectively.
+/// It also implements `From<$old>` and `From<$new>` for the new wrapper type.
+/// This is to facilitate the deprecation of extremely similar structures that have only a few
+/// differences, and to be able to warn the user of the library when the `::Old(...)` variant has
+/// been used.
+macro_rules! old_new {
+    ($attr_wrapper:ident, $old:ty, $new:ty) => {
+        pub enum $attr_wrapper {
+            Old($old),
+            New($new),
+        }
+        impl From<$old> for $attr_wrapper {
+            fn from(old: $old) -> Self {
+                Self::Old(old)
+            }
+        }
+        impl From<$new> for $attr_wrapper {
+            fn from(new: $new) -> Self {
+                Self::New(new)
+            }
+        }
+    };
 }


### PR DESCRIPTION
This removes the `dbus_` prefix before macros and macro attributes.

Fixes #477 

Fixes #478 

