### PR TITLE
zv,zn: impl `Basic` for applicable types

### DIFF
--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -5,7 +5,10 @@ use core::{
 };
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{Error, OwnedUniqueName, OwnedWellKnownName, Result, UniqueName, WellKnownName};
+use crate::{
+    utils::impl_str_basic, Error, OwnedUniqueName, OwnedWellKnownName, Result, UniqueName,
+    WellKnownName,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
@@ -53,6 +56,8 @@ pub enum BusName<'name> {
 }
 
 assert_impl_all!(BusName<'_>: Send, Sync, Unpin);
+
+impl_str_basic!(BusName<'_>);
 
 impl<'name> BusName<'name> {
     /// A borrowed clone (never allocates, unlike clone).
@@ -347,6 +352,8 @@ impl<'a> From<&'a OwnedWellKnownName> for BusName<'a> {
 /// Owned sibling of [`BusName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, PartialOrd, Ord, Type)]
 pub struct OwnedBusName(#[serde(borrow)] BusName<'static>);
+
+impl_str_basic!(OwnedBusName);
 
 impl OwnedBusName {
     /// Convert to the inner `BusName`, consuming `self`.

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -1,4 +1,7 @@
-use crate::{utils::impl_try_from, Error, Result};
+use crate::{
+    utils::{impl_str_basic, impl_try_from},
+    Error, Result,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -43,6 +46,8 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 pub struct ErrorName<'name>(Str<'name>);
 
 assert_impl_all!(ErrorName<'_>: Send, Sync, Unpin);
+
+impl_str_basic!(ErrorName<'_>);
 
 impl<'name> ErrorName<'name> {
     /// A borrowed clone (never allocates, unlike clone).
@@ -243,6 +248,8 @@ impl<'name> NoneValue for ErrorName<'name> {
 pub struct OwnedErrorName(#[serde(borrow)] ErrorName<'static>);
 
 assert_impl_all!(OwnedErrorName: Send, Sync, Unpin);
+
+impl_str_basic!(OwnedErrorName);
 
 impl OwnedErrorName {
     /// Convert to the inner `ErrorName`, consuming `self`.

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -1,4 +1,7 @@
-use crate::{utils::impl_try_from, Error, Result};
+use crate::{
+    utils::{impl_str_basic, impl_try_from},
+    Error, Result,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -39,6 +42,8 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct InterfaceName<'name>(Str<'name>);
+
+impl_str_basic!(InterfaceName<'_>);
 
 assert_impl_all!(InterfaceName<'_>: Send, Sync, Unpin);
 
@@ -241,6 +246,8 @@ impl<'name> NoneValue for InterfaceName<'name> {
 pub struct OwnedInterfaceName(#[serde(borrow)] InterfaceName<'static>);
 
 assert_impl_all!(OwnedInterfaceName: Send, Sync, Unpin);
+
+impl_str_basic!(OwnedInterfaceName);
 
 impl OwnedInterfaceName {
     /// Convert to the inner `InterfaceName`, consuming `self`.

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -1,4 +1,7 @@
-use crate::{utils::impl_try_from, Error, Result};
+use crate::{
+    utils::{impl_str_basic, impl_try_from},
+    Error, Result,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -39,6 +42,8 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 pub struct MemberName<'name>(Str<'name>);
 
 assert_impl_all!(MemberName<'_>: Send, Sync, Unpin);
+
+impl_str_basic!(MemberName<'_>);
 
 impl<'name> MemberName<'name> {
     /// A borrowed clone (never allocates, unlike clone).
@@ -219,6 +224,8 @@ impl<'name> NoneValue for MemberName<'name> {
 pub struct OwnedMemberName(#[serde(borrow)] MemberName<'static>);
 
 assert_impl_all!(OwnedMemberName: Send, Sync, Unpin);
+
+impl_str_basic!(OwnedMemberName);
 
 impl OwnedMemberName {
     /// Convert to the inner `MemberName`, consuming `self`.

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -1,4 +1,7 @@
-use crate::{utils::impl_try_from, Error, Result};
+use crate::{
+    utils::{impl_str_basic, impl_try_from},
+    Error, Result,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -38,6 +41,8 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 pub struct UniqueName<'name>(Str<'name>);
 
 assert_impl_all!(UniqueName<'_>: Send, Sync, Unpin);
+
+impl_str_basic!(UniqueName<'_>);
 
 impl<'name> UniqueName<'name> {
     /// A borrowed clone (never allocates, unlike clone).
@@ -235,6 +240,8 @@ impl<'name> NoneValue for UniqueName<'name> {
 pub struct OwnedUniqueName(#[serde(borrow)] UniqueName<'static>);
 
 assert_impl_all!(OwnedUniqueName: Send, Sync, Unpin);
+
+impl_str_basic!(OwnedUniqueName);
 
 impl OwnedUniqueName {
     /// Convert to the inner `UniqueName`, consuming `self`.

--- a/zbus_names/src/utils.rs
+++ b/zbus_names/src/utils.rs
@@ -1,3 +1,16 @@
+macro_rules! impl_str_basic {
+    ($type:ty) => {
+        impl zvariant::Basic for $type {
+            const SIGNATURE_CHAR: char = <zvariant::Str<'_>>::SIGNATURE_CHAR;
+            const SIGNATURE_STR: &'static str = <zvariant::Str<'_>>::SIGNATURE_STR;
+
+            fn alignment(format: zvariant::EncodingFormat) -> usize {
+                <zvariant::Str<'_>>::alignment(format)
+            }
+        }
+    };
+}
+
 macro_rules! impl_try_from {
     (ty: $type:ty, owned_ty: $owned_type:ty, validate_fn: $validate_fn:ident, try_from: [$($from:ty),*],) => {
         $(
@@ -22,4 +35,5 @@ macro_rules! impl_try_from {
     };
 }
 
+pub(crate) use impl_str_basic;
 pub(crate) use impl_try_from;

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -1,4 +1,7 @@
-use crate::{utils::impl_try_from, Error, Result};
+use crate::{
+    utils::{impl_str_basic, impl_try_from},
+    Error, Result,
+};
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -37,6 +40,8 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct WellKnownName<'name>(Str<'name>);
+
+impl_str_basic!(WellKnownName<'_>);
 
 assert_impl_all!(WellKnownName<'_>: Send, Sync, Unpin);
 
@@ -248,6 +253,8 @@ impl OwnedWellKnownName {
         &self.0
     }
 }
+
+impl_str_basic!(OwnedWellKnownName);
 
 impl Deref for OwnedWellKnownName {
     type Target = WellKnownName<'static>;

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -312,6 +312,15 @@ impl OwnedObjectPath {
     }
 }
 
+impl Basic for OwnedObjectPath {
+    const SIGNATURE_CHAR: char = ObjectPath::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = ObjectPath::SIGNATURE_STR;
+
+    fn alignment(format: EncodingFormat) -> usize {
+        ObjectPath::alignment(format)
+    }
+}
+
 impl std::ops::Deref for OwnedObjectPath {
     type Target = ObjectPath<'static>;
 

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -489,6 +489,15 @@ impl OwnedSignature {
     }
 }
 
+impl Basic for OwnedSignature {
+    const SIGNATURE_CHAR: char = Signature::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = Signature::SIGNATURE_STR;
+
+    fn alignment(format: EncodingFormat) -> usize {
+        Signature::alignment(format)
+    }
+}
+
 impl std::ops::Deref for OwnedSignature {
     type Target = Signature<'static>;
 


### PR DESCRIPTION
Similar to `String` is `Basic`, `OwnedObjectPath` should also be `Basic`. 
This allows to convert `OwnedValue` into `HashMap` with `OwnedObjectPath` key type.