### PR TITLE
zx: use clap for arg parsing

### DIFF
--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -29,6 +29,7 @@ zbus = { path = "../zbus", version = "4.0.0" }
 zbus_xml = { path = "../zbus_xml", version = "4.0.0" }
 zvariant = { path = "../zvariant", version = "4" }
 snakecase = "0.1.0"
+clap = { version = "4.4", features = ["derive", "wrap_help"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3"

--- a/zbus_xmlgen/src/cli.rs
+++ b/zbus_xmlgen/src/cli.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    #[clap(subcommand)]
+    pub command: Command,
+
+    /// Specify the destination for saving the output. If no argument is provided, the parsed
+    /// interfaces will be stored in separate files. If a filename is provided, the output will
+    /// be saved to that file. Use '-' to print the output to stdout.
+    #[clap(short, long, allow_hyphen_values = true)]
+    pub output: Option<String>,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub enum Command {
+    /// Generate code for interfaces in the specified file.
+    #[clap()]
+    File { path: PathBuf },
+
+    /// Generate code for interfaces from the specified system service.
+    #[clap()]
+    System {
+        service: String,
+        object_path: String,
+    },
+
+    /// Generate code for interfaces from the current users session.
+    #[clap()]
+    Session {
+        service: String,
+        object_path: String,
+    },
+
+    /// Generate code for interfaces from the specified address.
+    #[clap()]
+    Address {
+        address: String,
+        service: String,
+        object_path: String,
+    },
+}

--- a/zbus_xmlgen/src/cli.rs
+++ b/zbus_xmlgen/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Args {
     /// Specify the destination for saving the output. If no argument is provided, the parsed
     /// interfaces will be stored in separate files. If a filename is provided, the output will
     /// be saved to that file. Use '-' to print the output to stdout.
-    #[clap(short, long, allow_hyphen_values = true)]
+    #[clap(short, long, allow_hyphen_values = true, global = true)]
     pub output: Option<String>,
 }
 

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -146,6 +146,9 @@ fn write_interfaces(
     let mut process = match Command::new("rustfmt")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        // rustfmt may post warnings about features not being enabled on stable rust
+        // these can be distracting and are irrevelant to the user, so we hide them
+        .stderr(Stdio::null())
         .spawn()
     {
         Err(why) => panic!("couldn't spawn rustfmt: {}", why),


### PR DESCRIPTION
Update `zbus-xmlgen` to use [`clap`](https://crates.io/crates/clap). This change converts the `--session`, `--system`, `--address`, and `file` arguments into subcommands.

Builds on https://github.com/dbus2/zbus/pull/499 to also add the `--split-interfaces` options.

### Possible future improvements
- Improve help/documentation by adding descriptions/comments to arguments.
- Generate completions and a man page