### PR TITLE
🐛 zbus_xmlgen: Fix nested signature parser

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -228,7 +228,11 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
                 loop {
                     let c = it.peek().unwrap();
                     match **c as char {
-                        STRUCT_SIG_END_CHAR | DICT_ENTRY_SIG_END_CHAR => break,
+                        STRUCT_SIG_END_CHAR | DICT_ENTRY_SIG_END_CHAR => {
+                            // consume the closing character
+                            it.next().unwrap();
+                            break;
+                        }
                         _ => vec.push(iter_to_rust_type(it, input, false)),
                     }
                 }

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -1,6 +1,9 @@
 #[dbus_proxy(interface = "com.example.SampleInterface0", assume_defaults = true)]
 trait SampleInterface0 {
 
+    /// BarplexSig method
+    fn barplex_sig(&self, rule: &(&[i32], i32, std::collections::HashMap<&str, &str>, i32, &[i32], i32, &[&str], i32, bool)) -> zbus::Result<Vec<(String, zbus::zvariant::OwnedObjectPath)>>;
+
     /// Bazify method
     fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::zvariant::OwnedValue>;
 

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -17,6 +17,10 @@
      <method name="MogrifyMe">
        <arg name="bar" type="(iiav)" direction="in"/>
      </method>
+     <method name="BarplexSig">
+       <arg direction="in" name="rule" type="(aiia{ss}iaiiasib)"/>
+       <arg direction="out" type="a(so)"/>
+     </method>
      <signal name="Changed">
        <arg name="new_value" type="b"/>
      </signal>


### PR DESCRIPTION
Fixes: #257 

When the xml signature had a nested element (such as a nested dict), the parser wasn't cleaning up the closing character after peeking the iterator. Fixed by consuming the next iterator before proceeding.