### PR TITLE
#323 enable `emits_changed_signal` on `dbus_interface`

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -484,14 +484,22 @@ pub fn expand(args: AttributeArgs, mut input: ItemImpl) -> syn::Result<TokenStre
     let generics = &input.generics;
     let where_clause = &generics.where_clause;
 
+    let generated_signals_impl = if generated_signals.is_empty() {
+        quote!()
+    } else {
+        quote! {
+            impl #generics #self_ty
+            #where_clause
+            {
+                #generated_signals
+            }
+        }
+    };
+
     Ok(quote! {
         #input
 
-        impl #generics #self_ty
-        #where_clause
-        {
-            #generated_signals
-        }
+        #generated_signals_impl
 
         #[#zbus::export::async_trait::async_trait]
         impl #generics #zbus::object_server::Interface for #self_ty

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -211,8 +211,17 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `property` - expose the method as a property. If the method takes an argument, it must be a
 ///   setter, with a `set_` prefix. Otherwise, it's a getter. If it may fail, a property method must
-///   return `zbus::fdo::Result`.
-///
+///   return `zbus::fdo::Result`. An additional sub-attribute exists to control the emission of
+///   signals on changes to the property:
+///   * `emits_changed_signal` - specifies how property changes are signaled. Valid values are those
+///     documented in [DBus specifications][dbus_emits_changed_signal]:
+///     * `"true"` - (default) the change signal is always emitted when the property's setter is
+///     called. The value of the property is included in the signal.
+///     * `"invalidates"` - the change signal is emitted, but the value is not included in the
+///     signal.
+///     * `"const"` - the property never changes, thus no signal is ever emitted for it.
+///     * `"false"` - the change signal is not emitted if the property changes.
+
 /// * `signal` - the method is a "signal". It must be a method declaration (without body). Its code
 ///   block will be expanded to emit the signal from the object path associated with the interface
 ///   instance.
@@ -321,6 +330,7 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// [`Connection::emit_signal()`]: https://docs.rs/zbus/latest/zbus/connection/struct.Connection.html#method.emit_signal
 /// [`SignalContext`]: https://docs.rs/zbus/latest/zbus/object_server/struct.SignalContext.html
 /// [`Interface`]: https://docs.rs/zbus/latest/zbus/object_server/trait.Interface.html
+/// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 #[proc_macro_attribute]
 pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as AttributeArgs);

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -1,4 +1,4 @@
-use crate::utils::{pat_ident, typed_arg, zbus_path};
+use crate::utils::{pat_ident, typed_arg, zbus_path, PropertyEmitsChangedSignal};
 use proc_macro2::{Literal, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use regex::Regex;
@@ -630,35 +630,6 @@ fn gen_proxy_method_call(
                     ::std::result::Result::Ok(reply)
                 }
             })
-        }
-    }
-}
-
-/// Standard annotation `org.freedesktop.DBus.Property.EmitsChangedSignal`.
-///
-/// See <https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format>.
-#[derive(Debug, Default)]
-enum PropertyEmitsChangedSignal {
-    #[default]
-    True,
-    Invalidates,
-    Const,
-    False,
-}
-
-impl PropertyEmitsChangedSignal {
-    fn parse(s: &str, span: Span) -> syn::Result<Self> {
-        use PropertyEmitsChangedSignal::*;
-
-        match s {
-            "true" => Ok(True),
-            "invalidates" => Ok(Invalidates),
-            "const" => Ok(Const),
-            "false" => Ok(False),
-            other => Err(syn::Error::new(
-                span,
-                format!("invalid value \"{other}\" for attribute `property(emits_changed_signal)`"),
-            )),
         }
     }
 }

--- a/zbus_macros/src/utils.rs
+++ b/zbus_macros/src/utils.rs
@@ -64,6 +64,18 @@ pub enum PropertyEmitsChangedSignal {
     False,
 }
 
+impl ToString for PropertyEmitsChangedSignal {
+    fn to_string(&self) -> String {
+        let emits_changed_signal = match self {
+            PropertyEmitsChangedSignal::True => "true",
+            PropertyEmitsChangedSignal::Const => "const",
+            PropertyEmitsChangedSignal::False => "false",
+            PropertyEmitsChangedSignal::Invalidates => "invalidates",
+        };
+        emits_changed_signal.to_string()
+    }
+}
+
 impl PropertyEmitsChangedSignal {
     pub fn parse(s: &str, span: Span) -> syn::Result<Self> {
         use PropertyEmitsChangedSignal::*;

--- a/zbus_macros/src/utils.rs
+++ b/zbus_macros/src/utils.rs
@@ -55,7 +55,7 @@ pub fn is_blank(s: &str) -> bool {
 /// Standard annotation `org.freedesktop.DBus.Property.EmitsChangedSignal`.
 ///
 /// See <https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format>.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub enum PropertyEmitsChangedSignal {
     #[default]
     True,

--- a/zbus_macros/src/utils.rs
+++ b/zbus_macros/src/utils.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
 use syn::{Attribute, FnArg, Ident, Pat, PatIdent, PatType};
@@ -50,4 +50,33 @@ pub fn pascal_case(s: &str) -> String {
 
 pub fn is_blank(s: &str) -> bool {
     s.trim().is_empty()
+}
+
+/// Standard annotation `org.freedesktop.DBus.Property.EmitsChangedSignal`.
+///
+/// See <https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format>.
+#[derive(Debug, Default)]
+pub enum PropertyEmitsChangedSignal {
+    #[default]
+    True,
+    Invalidates,
+    Const,
+    False,
+}
+
+impl PropertyEmitsChangedSignal {
+    pub fn parse(s: &str, span: Span) -> syn::Result<Self> {
+        use PropertyEmitsChangedSignal::*;
+
+        match s {
+            "true" => Ok(True),
+            "invalidates" => Ok(Invalidates),
+            "const" => Ok(Const),
+            "false" => Ok(False),
+            other => Err(syn::Error::new(
+                span,
+                format!("invalid value \"{other}\" for attribute `property(emits_changed_signal)`"),
+            )),
+        }
+    }
 }

--- a/zbus_macros/src/utils.rs
+++ b/zbus_macros/src/utils.rs
@@ -55,7 +55,7 @@ pub fn is_blank(s: &str) -> bool {
 /// Standard annotation `org.freedesktop.DBus.Property.EmitsChangedSignal`.
 ///
 /// See <https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format>.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub enum PropertyEmitsChangedSignal {
     #[default]
     True,

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -170,6 +170,22 @@ fn test_interface() {
             _value = MyCustomPropertyType(42);
         }
 
+        // Test that the emits_changed_signal property results in the correct annotation
+        #[dbus_interface(property(emits_changed_signal = "false"))]
+        fn my_custom_property_emits_false(&self) -> MyCustomPropertyType {
+            unimplemented!()
+        }
+
+        #[dbus_interface(property(emits_changed_signal = "invalidates"))]
+        fn my_custom_property_emits_invalidates(&self) -> MyCustomPropertyType {
+            unimplemented!()
+        }
+
+        #[dbus_interface(property(emits_changed_signal = "const"))]
+        fn my_custom_property_emits_const(&self) -> MyCustomPropertyType {
+            unimplemented!()
+        }
+
         #[dbus_interface(name = "CheckVEC")]
         fn check_vec(&self) -> Vec<u8> {
             unimplemented!()
@@ -221,6 +237,15 @@ fn test_interface() {
     <arg name="other" type="s"/>
   </signal>
   <property name="MyCustomProperty" type="u" access="readwrite"/>
+  <property name="MyCustomPropertyEmitsConst" type="u" access="read">
+    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="MyCustomPropertyEmitsFalse" type="u" access="read">
+    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MyCustomPropertyEmitsInvalidates" type="u" access="read">
+    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
+  </property>
   <!--
    Testing my_prop documentation is reflected in XML.
 


### PR DESCRIPTION
Implements  #323: enables interface property macros on getters to be annotated with `emits_changed_signal`. 