### PR TITLE
bug zbus_xmlgen: Fix structs with a single element

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -241,7 +241,7 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
                 } else if vec.len() > 1 {
                     format!("{}({})", if as_ref { "&" } else { "" }, vec.join(", "))
                 } else {
-                    vec[0].to_string()
+                    format!("{}({},)", if as_ref { "&" } else { "" }, vec[0])
                 }
             }
             _ => unimplemented!(),

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -4,6 +4,9 @@ trait SampleInterface0 {
     /// BarplexSig method
     fn barplex_sig(&self, rule: &(&[i32], i32, std::collections::HashMap<&str, &str>, i32, &[i32], i32, &[&str], i32, bool)) -> zbus::Result<Vec<(String, zbus::zvariant::OwnedObjectPath)>>;
 
+    /// Bazic method
+    fn bazic(&self, bar: &(i32, i32), foo: &(i32,)) -> zbus::Result<((i32, i32), Vec<(i32,)>)>;
+
     /// Bazify method
     fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::zvariant::OwnedValue>;
 

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -10,6 +10,12 @@
        <arg name="baz" type="a{us}" direction="out"/>
        <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
      </method>
+      <method name="Bazic">
+       <arg name="bar" type="(ii)" direction="in"/>
+       <arg name="foo" type="(i)" direction="in"/>
+       <arg name="baz" type="(ii)" direction="out"/>
+       <arg name="foz" type="a(i)" direction="out"/>
+     </method>
      <method name="Bazify">
        <arg name="bar" type="(iiu)" direction="in"/>
        <arg name="bar" type="v" direction="out"/>


### PR DESCRIPTION
When the xml element had a struct containing only a single type, the parser was returning the element itself. This was wrong since a D-Bus struct is expected to be translated into a tuple, regardless of how many types it has (except for 0 elements, which is not accepted according to D-Bus spec). Returning a single-element tuple type instead.

Note: As defined on Rust syntax, the single-element tuple type has a trailing comma inside parenthesis, not to be confused with compiler lint "unused_parens". Examples:
(i32,) --> OK. Single-element tuple with i32 element. (i32) --> ERROR. Wrong use of parenthesis that clutters readability.

About the change itself on _zbus_xmlgen/src/lib.rs_, it was noticed that we could somewhat simplify by removing the else-if condition and doing it all in the same format. However, IMHO the approach on the PR is more readable. 
Please see the other possible approach and let me know what would be the preferred approach.
```
                if dict {
                    vec.join(", ")
                } else {
                    format!(
                        "{}({}{})",
                        if as_ref { "&" } else { "" },
                        vec.join(", "),
                        if vec.len() == 1 { "," } else { "" }
                    )
                }
```

First time contributor here, sorry if I missed something on the contributing guidelines, please let me know and I'll fix ASAP. Thanks @nagatavit for the support on the investigation IRL.