### PR TITLE
✨ zx: hide clippy lints for generated functions

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -77,6 +77,7 @@ impl<'i> Display for GenTrait<'i> {
             if p.access().read() {
                 writeln!(f, "{}", fn_attribute)?;
                 let output = to_rust_type(p.ty(), false, false);
+                hide_clippy_type_complexity_lint(f, p.ty().signature())?;
                 writeln!(f, "    fn {name}(&self) -> zbus::Result<{output}>;",)?;
             }
 
@@ -98,6 +99,25 @@ fn hide_clippy_lints(fmt: &mut Formatter<'_>, method: &zbus_xml::Method<'_>) -> 
     // triggers when a functions has at least 7 paramters
     if method.args().len() >= 7 {
         writeln!(fmt, "    #[allow(clippy::too_many_arguments)]")?;
+    }
+
+    // check for <https://rust-lang.github.io/rust-clippy/master/index.html#/type_complexity>
+    for arg in method.args() {
+        let signature = arg.ty().signature();
+        hide_clippy_type_complexity_lint(fmt, signature)?;
+    }
+
+    Ok(())
+}
+
+fn hide_clippy_type_complexity_lint(
+    fmt: &mut Formatter<'_>,
+    signature: &zvariant::Signature,
+) -> std::fmt::Result {
+    let mut it = signature.as_bytes().iter().peekable();
+    let complexity = estimate_type_complexity(&mut it);
+    if complexity >= 1700 {
+        writeln!(fmt, "    #[allow(clippy::type_complexity)]")?;
     }
     Ok(())
 }
@@ -293,4 +313,55 @@ pub fn pascal_case(s: &str) -> String {
         }
     }
     pascal
+}
+
+fn estimate_type_complexity(it: &mut std::iter::Peekable<std::slice::Iter<'_, u8>>) -> u32 {
+    let mut score = 0;
+    let c = it.next().unwrap();
+    match *c as char {
+        u8::SIGNATURE_CHAR
+        | bool::SIGNATURE_CHAR
+        | i16::SIGNATURE_CHAR
+        | u16::SIGNATURE_CHAR
+        | i32::SIGNATURE_CHAR
+        | u32::SIGNATURE_CHAR
+        | i64::SIGNATURE_CHAR
+        | u64::SIGNATURE_CHAR
+        | f64::SIGNATURE_CHAR
+        | <&str>::SIGNATURE_CHAR => {
+            score += 1;
+        }
+        'h' => score += 10,
+        Signature::SIGNATURE_CHAR | VARIANT_SIGNATURE_CHAR | ObjectPath::SIGNATURE_CHAR => {
+            score *= 10
+        }
+        ARRAY_SIGNATURE_CHAR => {
+            let c = it.peek().unwrap();
+            match **c as char {
+                '{' => {
+                    score *= 10;
+                    score += estimate_type_complexity(it);
+                }
+                _ => {
+                    score += 5 * estimate_type_complexity(it);
+                }
+            }
+        }
+        STRUCT_SIG_START_CHAR | DICT_ENTRY_SIG_START_CHAR => {
+            score += 50;
+            loop {
+                let c = it.peek().unwrap();
+                match **c as char {
+                    STRUCT_SIG_END_CHAR | DICT_ENTRY_SIG_END_CHAR => {
+                        // consume the closing character
+                        it.next().unwrap();
+                        break;
+                    }
+                    _ => score += 5 * estimate_type_complexity(it),
+                }
+            }
+        }
+        _ => {}
+    };
+    score
 }

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -43,6 +43,7 @@ impl<'i> Display for GenTrait<'i> {
             if pascal_case(&name) != m.name().as_str() {
                 writeln!(f, "    #[dbus_proxy(name = \"{}\")]", m.name())?;
             }
+            hide_clippy_lints(f, m)?;
             writeln!(f, "    fn {name}({inputs}){output};")?;
         }
 
@@ -90,6 +91,15 @@ impl<'i> Display for GenTrait<'i> {
         }
         writeln!(f, "}}")
     }
+}
+
+fn hide_clippy_lints(fmt: &mut Formatter<'_>, method: &zbus_xml::Method<'_>) -> std::fmt::Result {
+    // check for <https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_arguments>
+    // triggers when a functions has at least 7 paramters
+    if method.args().len() >= 7 {
+        writeln!(fmt, "    #[allow(clippy::too_many_arguments)]")?;
+    }
+    Ok(())
 }
 
 fn inputs_output_from_args(args: &[Arg]) -> (String, String) {

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -13,6 +13,10 @@ trait SampleInterface0 {
     /// MogrifyMe method
     fn mogrify_me(&self, bar: &(i32, i32, &[zbus::zvariant::Value<'_>])) -> zbus::Result<()>;
 
+    /// Odyssey method
+    #[allow(clippy::too_many_arguments)]
+    fn odyssey(&self, odysseus: i32, penelope: &str, telemachus: u32, circe: i32, athena: bool, polyphemus: i32, calypso: &zbus::zvariant::Value<'_>) -> zbus::Result<()>;
+
     /// Changed signal
     #[dbus_proxy(signal)]
     fn changed(&self, new_value: bool) -> zbus::Result<()>;

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -30,4 +30,9 @@ trait SampleInterface0 {
     fn bar(&self) -> zbus::Result<u8>;
     #[dbus_proxy(property)]
     fn set_bar(&self, value: u8) -> zbus::Result<()>;
+
+    /// Matryoshkas property
+    #[dbus_proxy(property)]
+    #[allow(clippy::type_complexity)]
+    fn matryoshkas(&self) -> zbus::Result<Vec<(zbus::zvariant::OwnedObjectPath, i32, Vec<String>, u64, std::collections::HashMap<String, zbus::zvariant::OwnedValue>)>>;
 }

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -38,6 +38,7 @@
        <arg name="new_value2" type="b" direction="out"/>
      </signal>
      <property name="Bar" type="y" access="readwrite"/>
+     <property name="Matryoshkas" type="a(oiasta{sv})" access="read"/>
    </interface>
    <node name="child_of_sample_object"/>
    <node name="another_child_of_sample_object"/>

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -21,6 +21,15 @@
        <arg direction="in" name="rule" type="(aiia{ss}iaiiasib)"/>
        <arg direction="out" type="a(so)"/>
      </method>
+     <method name="Odyssey">
+       <arg name="odysseus" type="i"/>
+       <arg name="penelope" type="s"/>
+       <arg name="telemachus" type="u"/>
+       <arg name="circe" type="i"/>
+       <arg name="athena" type="b"/>
+       <arg name="polyphemus" type="i"/>
+       <arg name="calypso" type="v"/>
+     </method>
      <signal name="Changed">
        <arg name="new_value" type="b"/>
      </signal>


### PR DESCRIPTION
This hides the [`clippy::too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_arguments) and [`clippy::type_complexity`](https://rust-lang.github.io/rust-clippy/master/index.html#/type_complexity) lints for generated functions.

Note that type complexity is only an estimate, so future adjustments may be necessary. I tested it with the interface files for [`org.freedesktop.UDisks2.xml`](https://github.com/storaged-project/udisks/blob/a76eda89a4c747f12dc05670f376d95d8ec4cd45/data/org.freedesktop.UDisks2.xml) and confirmed that it is working correctly.

Closes https://github.com/dbus2/zbus/issues/512.