### PR TITLE
Support non-native endian

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -35,7 +35,7 @@ vsock = ["dep:vsock", "dep:async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 
 [dependencies]
-byteorder = "1.4.3"
+endi = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.9"
 zvariant = { path = "../zvariant", version = "4.0.0", default-features = false, features = [

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -35,7 +35,6 @@ vsock = ["dep:vsock", "dep:async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 
 [dependencies]
-endi = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.9"
 zvariant = { path = "../zvariant", version = "4.0.0", default-features = false, features = [

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1305,10 +1305,10 @@ enum NameStatus {
 
 #[cfg(test)]
 mod tests {
-    use endi::{Endian, NATIVE_ENDIAN};
     use futures_util::stream::TryStreamExt;
     use ntest::timeout;
     use test_log::test;
+    use zvariant::{Endian, NATIVE_ENDIAN};
 
     use crate::{fdo::DBusProxy, AuthMechanism};
 

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1305,6 +1305,7 @@ enum NameStatus {
 
 #[cfg(test)]
 mod tests {
+    use endi::{Endian, NATIVE_ENDIAN};
     use futures_util::stream::TryStreamExt;
     use ntest::timeout;
     use test_log::test;
@@ -1354,6 +1355,7 @@ mod tests {
             let method = loop {
                 let m = stream.try_next().await?.unwrap();
                 if m.to_string() == "Method call Test" {
+                    assert_eq!(m.body().deserialize::<u64>().unwrap(), 64);
                     break m;
                 }
             };
@@ -1371,14 +1373,26 @@ mod tests {
         let client_future = async move {
             let mut stream = MessageStream::from(&client1);
             server_ready_listener.await;
-            let reply = client1
-                .call_method(None::<()>, "/", Some("org.zbus.p2p"), "Test", &())
-                .await?;
-            assert_eq!(reply.to_string(), "Method return");
+            // We want to set non-native endian to ensure that:
+            // 1. the message is actually encoded with the specified endian.
+            // 2. the server side is able to decode it and replies in the same encoding.
+            let endian = match NATIVE_ENDIAN {
+                Endian::Little => Endian::Big,
+                Endian::Big => Endian::Little,
+            };
+            let method = Message::method("/", "Test")?
+                .interface("org.zbus.p2p")?
+                .endian(endian)
+                .build(&64u64)?;
+            client1.send(&method).await?;
             // Check we didn't miss the signal that was sent during the call.
             let m = stream.try_next().await?.unwrap();
             client_done.notify(1);
             assert_eq!(m.to_string(), "Signal ASignalForYou");
+            let reply = stream.try_next().await?.unwrap();
+            assert_eq!(reply.to_string(), "Method return");
+            // Check if the reply was in the non-native endian.
+            assert_eq!(Endian::from(reply.primary_header().endian_sig()), endian);
             reply.body().deserialize::<String>()
         };
 

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -180,7 +180,8 @@ impl SocketReader {
         // If we reach here, the message is complete; return it
         let seq = self.prev_seq + 1;
         self.prev_seq = seq;
-        let ctxt = Context::new_dbus(endi::NATIVE_ENDIAN, 0);
+        let endian = endi::Endian::from(primary_header.endian_sig());
+        let ctxt = Context::new_dbus(endian, 0);
         #[cfg(unix)]
         let bytes = serialized::Data::new_fds(bytes, ctxt, fds);
         #[cfg(not(unix))]

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -180,7 +180,7 @@ impl SocketReader {
         // If we reach here, the message is complete; return it
         let seq = self.prev_seq + 1;
         self.prev_seq = seq;
-        let ctxt = Context::<byteorder::NativeEndian>::new_dbus(0);
+        let ctxt = Context::new_dbus(endi::NATIVE_ENDIAN, 0);
         #[cfg(unix)]
         let bytes = serialized::Data::new_fds(bytes, ctxt, fds);
         #[cfg(not(unix))]

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use event_listener::Event;
 use tracing::{debug, instrument, trace};
-use zvariant::serialized::{self, Context};
+use zvariant::{
+    serialized::{self, Context},
+    Endian,
+};
 
 use crate::{
     async_lock::Mutex,
@@ -180,7 +183,7 @@ impl SocketReader {
         // If we reach here, the message is complete; return it
         let seq = self.prev_seq + 1;
         self.prev_seq = seq;
-        let endian = endi::Endian::from(primary_header.endian_sig());
+        let endian = Endian::from(primary_header.endian_sig());
         let ctxt = Context::new_dbus(endian, 0);
         #[cfg(unix)]
         let bytes = serialized::Data::new_fds(bytes, ctxt, fds);

--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -1,4 +1,3 @@
-use byteorder::NativeEndian;
 use zvariant::{
     serialized::{self, Data},
     Signature, Type,
@@ -11,12 +10,12 @@ use crate::{Error, Message, Result};
 /// This contains the bytes and the signature of the body.
 #[derive(Clone, Debug)]
 pub struct Body {
-    data: Data<'static, 'static, NativeEndian>,
+    data: Data<'static, 'static>,
     msg: Message,
 }
 
 impl Body {
-    pub(super) fn new(data: Data<'static, 'static, NativeEndian>, msg: Message) -> Self {
+    pub(super) fn new(data: Data<'static, 'static>, msg: Message) -> Self {
         Self { data, msg }
     }
 
@@ -64,7 +63,7 @@ impl Body {
     }
 
     /// Get a reference to the underlying byte encoding of the message.
-    pub fn data(&self) -> &serialized::Data<'static, 'static, NativeEndian> {
+    pub fn data(&self) -> &serialized::Data<'static, 'static> {
         &self.data
     }
 

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -26,7 +26,7 @@ type BuildGenericResult = ();
 
 macro_rules! dbus_context {
     ($n_bytes_before: expr) => {
-        Context::<byteorder::NativeEndian>::new_dbus($n_bytes_before)
+        Context::new_dbus(endi::NATIVE_ENDIAN, $n_bytes_before)
     };
 }
 
@@ -269,7 +269,7 @@ impl<'a> Builder<'a> {
     fn build_generic<WriteFunc>(
         self,
         mut signature: Signature<'_>,
-        body_size: serialized::Size<byteorder::NativeEndian>,
+        body_size: serialized::Size,
         write_body: WriteFunc,
     ) -> Result<Message>
     where

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -179,6 +179,7 @@ impl<'a> Builder<'a> {
     fn reply_to(mut self, reply_to: &Header<'_>) -> Result<Self> {
         let serial = reply_to.primary().serial_num();
         self.header.fields_mut().replace(Field::ReplySerial(serial));
+        self = self.endian(reply_to.primary().endian_sig().into());
 
         if let Some(sender) = reply_to.sender() {
             self.destination(sender.to_owned())

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use enumflags2::BitFlags;
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
-use zvariant::serialized;
+use zvariant::{serialized, Endian};
 
 use crate::{
     message::{Field, FieldCode, Fields, Flags, Header, Message, PrimaryHeader, Sequence, Type},
@@ -191,7 +191,7 @@ impl<'a> Builder<'a> {
     /// Set the endianness of the message.
     ///
     /// The default endianness is native.
-    pub fn endian(mut self, endian: endi::Endian) -> Self {
+    pub fn endian(mut self, endian: Endian) -> Self {
         let sig = EndianSig::from(endian);
         self.header.primary_mut().set_endian_sig(sig);
 

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -127,7 +127,7 @@ impl PrimaryHeader {
     }
 
     pub(crate) fn read(buf: &[u8]) -> Result<(PrimaryHeader, u32), Error> {
-        let ctx = Context::<byteorder::NativeEndian>::new_dbus(0);
+        let ctx = Context::new_dbus(endi::NATIVE_ENDIAN, 0);
         let data = serialized::Data::new(buf, ctx);
         let (primary_header, size) = data.deserialize()?;
         assert_eq!(size, PRIMARY_HEADER_SIZE);

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -3,7 +3,6 @@ use std::{
     sync::atomic::{AtomicU32, Ordering::SeqCst},
 };
 
-use endi::Endian;
 use enumflags2::{bitflags, BitFlags};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -12,7 +11,7 @@ use static_assertions::assert_impl_all;
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use zvariant::{
     serialized::{self, Context},
-    ObjectPath, Signature, Type as VariantType,
+    Endian, ObjectPath, Signature, Type as VariantType,
 };
 
 use crate::{

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -135,12 +135,12 @@ impl PrimaryHeader {
         Ok((primary_header, fields_len))
     }
 
-    /// D-Bus code for bytorder encoding of the message.
+    /// D-Bus code for endian encoding of the message.
     pub fn endian_sig(&self) -> EndianSig {
         self.endian_sig
     }
 
-    /// Set the D-Bus code for bytorder encoding of the message.
+    /// Set the D-Bus code for endian encoding of the message.
     pub fn set_endian_sig(&mut self, sig: EndianSig) {
         self.endian_sig = sig;
     }

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -149,6 +149,13 @@ impl PrimaryHeader {
         let endian = Endian::from(EndianSig::try_from(buf[0])?);
         let ctx = Context::new_dbus(endian, 0);
         let data = serialized::Data::new(buf, ctx);
+
+        Self::read_from_data(&data)
+    }
+
+    pub(crate) fn read_from_data(
+        data: &serialized::Data<'_, '_>,
+    ) -> Result<(PrimaryHeader, u32), Error> {
         let (primary_header, size) = data.deserialize()?;
         assert_eq!(size, PRIMARY_HEADER_SIZE);
         let (fields_len, _) = data.slice(PRIMARY_HEADER_SIZE..).deserialize()?;

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -3,7 +3,7 @@ use std::{fmt, num::NonZeroU32, sync::Arc};
 
 use static_assertions::assert_impl_all;
 use zbus_names::{ErrorName, InterfaceName, MemberName};
-use zvariant::serialized;
+use zvariant::{serialized, Endian};
 
 use crate::{utils::padding_for_8_bytes, zvariant::ObjectPath, Error, Result};
 
@@ -133,7 +133,7 @@ impl Message {
         bytes: serialized::Data<'static, 'static>,
         recv_seq: u64,
     ) -> Result<Self> {
-        let endian = endi::Endian::from(EndianSig::try_from(bytes[0])?);
+        let endian = Endian::from(EndianSig::try_from(bytes[0])?);
         if endian != bytes.context().endian() {
             return Err(Error::IncorrectEndian);
         }

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -133,7 +133,8 @@ impl Message {
         bytes: serialized::Data<'static, 'static>,
         recv_seq: u64,
     ) -> Result<Self> {
-        if EndianSig::try_from(bytes[0])? != NATIVE_ENDIAN_SIG {
+        let endian = endi::Endian::from(EndianSig::try_from(bytes[0])?);
+        if endian != bytes.context().endian() {
             return Err(Error::IncorrectEndian);
         }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -118,11 +118,6 @@ impl Message {
 
     /// Create a message from bytes.
     ///
-    /// The `fds` parameter is only available on unix. It specifies the file descriptors that
-    /// accompany the message. On the wire, values of the UNIX_FD types store the index of the
-    /// corresponding file descriptor in this vector. Passing an empty vector on a message that
-    /// has UNIX_FD will result in an error.
-    ///
     /// **Note:** Since the constructed message is not construct by zbus, the receive sequence,
     /// which can be acquired from [`Message::recv_position`], is not applicable and hence set
     /// to `0`.

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -1,7 +1,6 @@
 //! D-Bus Message.
 use std::{fmt, num::NonZeroU32, sync::Arc};
 
-use byteorder::NativeEndian;
 use static_assertions::assert_impl_all;
 use zbus_names::{ErrorName, InterfaceName, MemberName};
 use zvariant::serialized;
@@ -61,7 +60,7 @@ pub struct Message {
 pub(super) struct Inner {
     pub(crate) primary_header: PrimaryHeader,
     pub(crate) quick_fields: QuickFields,
-    pub(crate) bytes: serialized::Data<'static, 'static, NativeEndian>,
+    pub(crate) bytes: serialized::Data<'static, 'static>,
     pub(crate) body_offset: usize,
     pub(crate) recv_seq: Sequence,
 }
@@ -125,15 +124,13 @@ impl Message {
     /// # Safety
     ///
     /// This method is unsafe as bytes may have an invalid encoding.
-    pub unsafe fn from_bytes(
-        bytes: serialized::Data<'static, 'static, NativeEndian>,
-    ) -> Result<Self> {
+    pub unsafe fn from_bytes(bytes: serialized::Data<'static, 'static>) -> Result<Self> {
         Self::from_raw_parts(bytes, 0)
     }
 
     /// Create a message from its full contents
     pub(crate) fn from_raw_parts(
-        bytes: serialized::Data<'static, 'static, NativeEndian>,
+        bytes: serialized::Data<'static, 'static>,
         recv_seq: u64,
     ) -> Result<Self> {
         if EndianSig::try_from(bytes[0])? != NATIVE_ENDIAN_SIG {
@@ -264,7 +261,7 @@ impl Message {
     }
 
     /// Get a reference to the underlying byte encoding of the message.
-    pub fn data(&self) -> &serialized::Data<'static, 'static, NativeEndian> {
+    pub fn data(&self) -> &serialized::Data<'static, 'static> {
         &self.inner.bytes
     }
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -138,7 +138,7 @@ impl Message {
             return Err(Error::IncorrectEndian);
         }
 
-        let (primary_header, fields_len) = PrimaryHeader::read(&bytes)?;
+        let (primary_header, fields_len) = PrimaryHeader::read_from_data(&bytes)?;
         let (header, _) = bytes.deserialize()?;
 
         let header_len = MIN_MESSAGE_SIZE + fields_len as usize;

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -21,7 +21,7 @@ ostree-tests = ["gvariant"]
 option-as-array = []
 
 [dependencies]
-byteorder = "1.4.3"
+endi = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 arrayvec = { version = "0.7.2", features = ["serde"], optional = true }
 enumflags2 = { version = "0.7.7", features = ["serde"], optional = true }

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -19,9 +19,8 @@ Serialization and deserialization is achieved through the [toplevel functions]:
 
 ```rust
 use std::collections::HashMap;
-use zvariant::{serialized::Context, to_bytes, Type};
+use zvariant::{serialized::Context, to_bytes, Type, LE};
 use serde::{Deserialize, Serialize};
-use endi::LE;
 
 // All serialization and deserialization API, needs a context.
 let ctxt = Context::new_dbus(LE, 0);

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -21,12 +21,12 @@ Serialization and deserialization is achieved through the [toplevel functions]:
 use std::collections::HashMap;
 use zvariant::{serialized::Context, to_bytes, Type};
 use serde::{Deserialize, Serialize};
-use byteorder::LE;
+use endi::LE;
 
 // All serialization and deserialization API, needs a context.
-let ctxt = Context::<LE>::new_dbus(0);
+let ctxt = Context::new_dbus(LE, 0);
 // You can also use the more efficient GVariant format:
-// let ctxt = Context::<LE>::new_gvariant(0);
+// let ctxt = Context::new_gvariant(LE, 0);
 
 // i16
 let encoded = to_bytes(ctxt, &42i16).unwrap();
@@ -73,7 +73,7 @@ let s = Struct {
     field2: i64::max_value(),
     field3: "hello",
 };
-let ctxt = Context::<LE>::new_dbus(0);
+let ctxt = Context::new_dbus(LE, 0);
 let encoded = to_bytes(ctxt, &s).unwrap();
 let decoded: Struct = encoded.deserialize().unwrap().0;
 assert_eq!(decoded, s);

--- a/zvariant/benches/benchmarks.rs
+++ b/zvariant/benches/benchmarks.rs
@@ -1,10 +1,9 @@
-use endi::LE;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use zvariant::{serialized::Context, to_bytes_for_signature, Type, Value};
+use zvariant::{serialized::Context, to_bytes_for_signature, Type, Value, LE};
 
 fn fixed_size_array(c: &mut Criterion) {
     let ay = vec![77u8; 100_000];

--- a/zvariant/benches/benchmarks.rs
+++ b/zvariant/benches/benchmarks.rs
@@ -1,4 +1,4 @@
-use byteorder::LE;
+use endi::LE;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -8,7 +8,7 @@ use zvariant::{serialized::Context, to_bytes_for_signature, Type, Value};
 
 fn fixed_size_array(c: &mut Criterion) {
     let ay = vec![77u8; 100_000];
-    let ctxt = Context::<LE>::new_dbus(0);
+    let ctxt = Context::new_dbus(LE, 0);
     let signature = Vec::<u8>::signature();
     c.bench_function("byte_array_ser", |b| {
         b.iter(|| {
@@ -70,7 +70,7 @@ fn big_array_ser_and_de(c: &mut Criterion) {
     };
 
     // Let's try with DBus format first
-    let ctxt = Context::<LE>::new_dbus(0);
+    let ctxt = Context::new_dbus(LE, 0);
     let signature = ZVStruct::signature();
 
     c.bench_function("big_array_ser_dbus", |b| {
@@ -95,7 +95,7 @@ fn big_array_ser_and_de(c: &mut Criterion) {
     // Now GVariant.
     #[cfg(feature = "gvariant")]
     {
-        let ctxt = Context::<LE>::new_gvariant(0);
+        let ctxt = Context::new_gvariant(LE, 0);
 
         c.bench_function("big_array_ser_gvariant", |b| {
             b.iter(|| {

--- a/zvariant/fuzz/Cargo.toml
+++ b/zvariant/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-byteorder = "*"
+endi = "1.1.0"
 
 [dependencies.zvariant]
 path = ".."

--- a/zvariant/fuzz/fuzz_targets/dbus.rs
+++ b/zvariant/fuzz/fuzz_targets/dbus.rs
@@ -2,6 +2,6 @@
 mod utils;
 
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    utils::fuzz_for_context(data, zvariant::serialized::Context::<byteorder::LE>::new_dbus(0));
-    utils::fuzz_for_context(data, zvariant::serialized::Context::<byteorder::BE>::new_dbus(0));
+    utils::fuzz_for_context(data, zvariant::serialized::Context::new_dbus(endi::LE, 0));
+    utils::fuzz_for_context(data, zvariant::serialized::Context::new_dbus(endi::BE, 0));
 });

--- a/zvariant/fuzz/fuzz_targets/dbus.rs
+++ b/zvariant/fuzz/fuzz_targets/dbus.rs
@@ -2,6 +2,12 @@
 mod utils;
 
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    utils::fuzz_for_context(data, zvariant::serialized::Context::new_dbus(endi::LE, 0));
-    utils::fuzz_for_context(data, zvariant::serialized::Context::new_dbus(endi::BE, 0));
+    utils::fuzz_for_context(
+        data,
+        zvariant::serialized::Context::new_dbus(zvariant::LE, 0),
+    );
+    utils::fuzz_for_context(
+        data,
+        zvariant::serialized::Context::new_dbus(zvariant::BE, 0),
+    );
 });

--- a/zvariant/fuzz/fuzz_targets/gvariant.rs
+++ b/zvariant/fuzz/fuzz_targets/gvariant.rs
@@ -4,10 +4,10 @@ mod utils;
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     utils::fuzz_for_context(
         data,
-        zvariant::serialized::Context::new_gvariant(endi::LE, 0),
+        zvariant::serialized::Context::new_gvariant(zvariant::LE, 0),
     );
     utils::fuzz_for_context(
         data,
-        zvariant::serialized::Context::new_gvariant(endi::BE, 0),
+        zvariant::serialized::Context::new_gvariant(zvariant::BE, 0),
     );
 });

--- a/zvariant/fuzz/fuzz_targets/gvariant.rs
+++ b/zvariant/fuzz/fuzz_targets/gvariant.rs
@@ -2,6 +2,12 @@
 mod utils;
 
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    utils::fuzz_for_context(data, zvariant::serialized::Context::<byteorder::LE>::new_gvariant(0));
-    utils::fuzz_for_context(data, zvariant::serialized::Context::<byteorder::BE>::new_gvariant(0));
+    utils::fuzz_for_context(
+        data,
+        zvariant::serialized::Context::new_gvariant(endi::LE, 0),
+    );
+    utils::fuzz_for_context(
+        data,
+        zvariant::serialized::Context::new_gvariant(endi::BE, 0),
+    );
 });

--- a/zvariant/fuzz/fuzz_targets/utils.rs
+++ b/zvariant/fuzz/fuzz_targets/utils.rs
@@ -1,10 +1,9 @@
-use byteorder::ByteOrder;
 use zvariant::{
     serialized::{Context, Data},
     to_bytes, Value,
 };
 
-pub fn fuzz_for_context<B: ByteOrder>(bytes: &[u8], ctx: Context<B>) {
+pub fn fuzz_for_context(bytes: &[u8], ctx: Context) {
     let data = Data::new(bytes, ctx);
     if let Ok((decoded, _)) = data.deserialize::<Value>() {
         to_bytes(ctx, &decoded).unwrap();

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -1,4 +1,3 @@
-use endi::WriteBytes;
 use serde::{ser, ser::SerializeSeq, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
@@ -11,7 +10,7 @@ use crate::{
     serialized::{Context, Format},
     signature_parser::SignatureParser,
     utils::*,
-    Basic, Error, ObjectPath, Result, Signature,
+    Basic, Error, ObjectPath, Result, Signature, WriteBytes,
 };
 
 #[cfg(unix)]

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -1,9 +1,8 @@
-use byteorder::WriteBytesExt;
+use endi::WriteBytes;
 use serde::{ser, ser::SerializeSeq, Serialize};
 use static_assertions::assert_impl_all;
 use std::{
     io::{Seek, Write},
-    marker::PhantomData,
     str,
 };
 
@@ -19,15 +18,12 @@ use crate::{
 use crate::Fd;
 
 /// Our D-Bus serialization implementation.
-pub(crate) struct Serializer<'ser, 'sig, B, W>(
-    pub(crate) crate::SerializerCommon<'ser, 'sig, B, W>,
-);
+pub(crate) struct Serializer<'ser, 'sig, W>(pub(crate) crate::SerializerCommon<'ser, 'sig, W>);
 
-assert_impl_all!(Serializer<'_, '_, i32, i32>: Send, Sync, Unpin);
+assert_impl_all!(Serializer<'_, '_, i32>: Send, Sync, Unpin);
 
-impl<'ser, 'sig, B, W> Serializer<'ser, 'sig, B, W>
+impl<'ser, 'sig, W> Serializer<'ser, 'sig, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     /// Create a D-Bus Serializer struct instance.
@@ -37,7 +33,7 @@ where
         signature: S,
         writer: &'w mut W,
         #[cfg(unix)] fds: &'f mut crate::ser::FdList,
-        ctxt: Context<B>,
+        ctxt: Context,
     ) -> Result<Self>
     where
         S: TryInto<Signature<'sig>>,
@@ -56,7 +52,6 @@ where
             bytes_written: 0,
             value_sign: None,
             container_depths: Default::default(),
-            b: PhantomData,
         }))
     }
 }
@@ -68,26 +63,25 @@ macro_rules! serialize_basic {
     ($method:ident($type:ty) $write_method:ident($as:ty)) => {
         fn $method(self, v: $type) -> Result<()> {
             self.0.prep_serialize_basic::<$type>()?;
-            self.0.$write_method::<B>(v as $as).map_err(|e| Error::InputOutput(e.into()))
+            self.0.$write_method(self.0.ctxt.endian(), v as $as).map_err(|e| Error::InputOutput(e.into()))
         }
     };
 }
 
-impl<'ser, 'sig, 'b, B, W> ser::Serializer for &'b mut Serializer<'ser, 'sig, B, W>
+impl<'ser, 'sig, 'b, W> ser::Serializer for &'b mut Serializer<'ser, 'sig, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     type Ok = ();
     type Error = Error;
 
-    type SerializeSeq = SeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeTuple = StructSeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeTupleStruct = StructSeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeTupleVariant = StructSeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeMap = SeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeStruct = StructSeqSerializer<'ser, 'sig, 'b, B, W>;
-    type SerializeStructVariant = StructSeqSerializer<'ser, 'sig, 'b, B, W>;
+    type SerializeSeq = SeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeTuple = StructSeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeTupleStruct = StructSeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeTupleVariant = StructSeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeMap = SeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeStruct = StructSeqSerializer<'ser, 'sig, 'b, W>;
+    type SerializeStructVariant = StructSeqSerializer<'ser, 'sig, 'b, W>;
 
     serialize_basic!(serialize_bool(bool) write_u32(u32));
     // No i8 type in D-Bus/GVariant, let's pretend it's i16
@@ -103,13 +97,13 @@ where
                 self.0.add_padding(u32::alignment(Format::DBus))?;
                 let idx = self.0.add_fd(v)?;
                 self.0
-                    .write_u32::<B>(idx)
+                    .write_u32(self.0.ctxt.endian(), idx)
                     .map_err(|e| Error::InputOutput(e.into()))
             }
             _ => {
                 self.0.prep_serialize_basic::<i32>()?;
                 self.0
-                    .write_i32::<B>(v)
+                    .write_i32(self.0.ctxt.endian(), v)
                     .map_err(|e| Error::InputOutput(e.into()))
             }
         }
@@ -118,7 +112,9 @@ where
     fn serialize_u8(self, v: u8) -> Result<()> {
         self.0.prep_serialize_basic::<u8>()?;
         // Endianness is irrelevant for single bytes.
-        self.0.write_u8(v).map_err(|e| Error::InputOutput(e.into()))
+        self.0
+            .write_u8(self.0.ctxt.endian(), v)
+            .map_err(|e| Error::InputOutput(e.into()))
     }
 
     serialize_basic!(serialize_u16(u16) write_u16);
@@ -149,12 +145,12 @@ where
             ObjectPath::SIGNATURE_CHAR | <&str>::SIGNATURE_CHAR => {
                 self.0.add_padding(<&str>::alignment(Format::DBus))?;
                 self.0
-                    .write_u32::<B>(usize_to_u32(v.len()))
+                    .write_u32(self.0.ctxt.endian(), usize_to_u32(v.len()))
                     .map_err(|e| Error::InputOutput(e.into()))?;
             }
             Signature::SIGNATURE_CHAR | VARIANT_SIGNATURE_CHAR => {
                 self.0
-                    .write_u8(usize_to_u8(v.len()))
+                    .write_u8(self.0.ctxt.endian(), usize_to_u8(v.len()))
                     .map_err(|e| Error::InputOutput(e.into()))?;
             }
             _ => {
@@ -276,7 +272,7 @@ where
         // Length in bytes (unfortunately not the same as len passed to us here) which we
         // initially set to 0.
         self.0
-            .write_u32::<B>(0_u32)
+            .write_u32(self.0.ctxt.endian(), 0_u32)
             .map_err(|e| Error::InputOutput(e.into()))?;
 
         let element_signature = self.0.sig_parser.next_signature()?;
@@ -358,8 +354,8 @@ where
 }
 
 #[doc(hidden)]
-pub struct SeqSerializer<'ser, 'sig, 'b, B, W> {
-    ser: &'b mut Serializer<'ser, 'sig, B, W>,
+pub struct SeqSerializer<'ser, 'sig, 'b, W> {
+    ser: &'b mut Serializer<'ser, 'sig, W>,
     start: usize,
     // alignment of element
     element_alignment: usize,
@@ -369,9 +365,8 @@ pub struct SeqSerializer<'ser, 'sig, 'b, B, W> {
     first_padding: usize,
 }
 
-impl<'ser, 'sig, 'b, B, W> SeqSerializer<'ser, 'sig, 'b, B, W>
+impl<'ser, 'sig, 'b, W> SeqSerializer<'ser, 'sig, 'b, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     pub(self) fn end_seq(self) -> Result<()> {
@@ -392,7 +387,7 @@ where
         self.ser
             .0
             .writer
-            .write_u32::<B>(len)
+            .write_u32(self.ser.0.ctxt.endian(), len)
             .map_err(|e| Error::InputOutput(e.into()))?;
         self.ser
             .0
@@ -406,9 +401,8 @@ where
     }
 }
 
-impl<'ser, 'sig, 'b, B, W> ser::SerializeSeq for SeqSerializer<'ser, 'sig, 'b, B, W>
+impl<'ser, 'sig, 'b, W> ser::SerializeSeq for SeqSerializer<'ser, 'sig, 'b, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     type Ok = ();
@@ -435,20 +429,19 @@ where
 }
 
 #[doc(hidden)]
-pub struct StructSerializer<'ser, 'sig, 'b, B, W> {
-    ser: &'b mut Serializer<'ser, 'sig, B, W>,
+pub struct StructSerializer<'ser, 'sig, 'b, W> {
+    ser: &'b mut Serializer<'ser, 'sig, W>,
     // The number of `)` in the signature to skip at the end.
     end_parens: u8,
     // The original container depths. We restore to that at the end.
     container_depths: ContainerDepths,
 }
 
-impl<'ser, 'sig, 'b, B, W> StructSerializer<'ser, 'sig, 'b, B, W>
+impl<'ser, 'sig, 'b, W> StructSerializer<'ser, 'sig, 'b, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
-    fn variant(ser: &'b mut Serializer<'ser, 'sig, B, W>) -> Result<Self> {
+    fn variant(ser: &'b mut Serializer<'ser, 'sig, W>) -> Result<Self> {
         ser.0.add_padding(VARIANT_ALIGNMENT_DBUS)?;
         let container_depths = ser.0.container_depths;
         ser.0.container_depths = ser.0.container_depths.inc_variant()?;
@@ -460,7 +453,7 @@ where
         })
     }
 
-    fn structure(ser: &'b mut Serializer<'ser, 'sig, B, W>) -> Result<Self> {
+    fn structure(ser: &'b mut Serializer<'ser, 'sig, W>) -> Result<Self> {
         let c = ser.0.sig_parser.next_char()?;
         if c != STRUCT_SIG_START_CHAR && c != DICT_ENTRY_SIG_START_CHAR {
             let expected = format!("`{STRUCT_SIG_START_STR}` or `{DICT_ENTRY_SIG_START_STR}`",);
@@ -486,7 +479,7 @@ where
         })
     }
 
-    fn unit(ser: &'b mut Serializer<'ser, 'sig, B, W>) -> Result<Self> {
+    fn unit(ser: &'b mut Serializer<'ser, 'sig, W>) -> Result<Self> {
         // serialize as a `0u8`
         serde::Serializer::serialize_u8(&mut *ser, 0)?;
 
@@ -498,7 +491,7 @@ where
         })
     }
 
-    fn enum_variant(ser: &'b mut Serializer<'ser, 'sig, B, W>) -> Result<Self> {
+    fn enum_variant(ser: &'b mut Serializer<'ser, 'sig, W>) -> Result<Self> {
         let mut ser = Self::structure(ser)?;
         ser.end_parens += 1;
 
@@ -522,7 +515,7 @@ where
 
                 let sig_parser = SignatureParser::new(signature);
                 let bytes_written = self.ser.0.bytes_written;
-                let mut ser = Serializer(crate::SerializerCommon::<B, W> {
+                let mut ser = Serializer(crate::SerializerCommon::<W> {
                     ctxt: self.ser.0.ctxt,
                     sig_parser,
                     writer: self.ser.0.writer,
@@ -531,7 +524,6 @@ where
                     bytes_written,
                     value_sign: None,
                     container_depths: self.ser.0.container_depths,
-                    b: PhantomData,
                 });
                 value.serialize(&mut ser)?;
                 self.ser.0.bytes_written = ser.0.bytes_written;
@@ -555,16 +547,15 @@ where
 
 #[doc(hidden)]
 /// Allows us to serialize a struct as an ARRAY.
-pub enum StructSeqSerializer<'ser, 'sig, 'b, B, W> {
-    Struct(StructSerializer<'ser, 'sig, 'b, B, W>),
-    Seq(SeqSerializer<'ser, 'sig, 'b, B, W>),
+pub enum StructSeqSerializer<'ser, 'sig, 'b, W> {
+    Struct(StructSerializer<'ser, 'sig, 'b, W>),
+    Seq(SeqSerializer<'ser, 'sig, 'b, W>),
 }
 
 macro_rules! serialize_struct_anon_fields {
     ($trait:ident $method:ident) => {
-        impl<'ser, 'sig, 'b, B, W> ser::$trait for StructSerializer<'ser, 'sig, 'b, B, W>
+        impl<'ser, 'sig, 'b, W> ser::$trait for StructSerializer<'ser, 'sig, 'b, W>
         where
-            B: byteorder::ByteOrder,
             W: Write + Seek,
         {
             type Ok = ();
@@ -582,9 +573,8 @@ macro_rules! serialize_struct_anon_fields {
             }
         }
 
-        impl<'ser, 'sig, 'b, B, W> ser::$trait for StructSeqSerializer<'ser, 'sig, 'b, B, W>
+        impl<'ser, 'sig, 'b, W> ser::$trait for StructSeqSerializer<'ser, 'sig, 'b, W>
         where
-            B: byteorder::ByteOrder,
             W: Write + Seek,
         {
             type Ok = ();
@@ -613,9 +603,8 @@ serialize_struct_anon_fields!(SerializeTuple serialize_element);
 serialize_struct_anon_fields!(SerializeTupleStruct serialize_field);
 serialize_struct_anon_fields!(SerializeTupleVariant serialize_field);
 
-impl<'ser, 'sig, 'b, B, W> ser::SerializeMap for SeqSerializer<'ser, 'sig, 'b, B, W>
+impl<'ser, 'sig, 'b, W> ser::SerializeMap for SeqSerializer<'ser, 'sig, 'b, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     type Ok = ();
@@ -667,9 +656,8 @@ where
 
 macro_rules! serialize_struct_named_fields {
     ($trait:ident) => {
-        impl<'ser, 'sig, 'b, B, W> ser::$trait for StructSerializer<'ser, 'sig, 'b, B, W>
+        impl<'ser, 'sig, 'b, W> ser::$trait for StructSerializer<'ser, 'sig, 'b, W>
         where
-            B: byteorder::ByteOrder,
             W: Write + Seek,
         {
             type Ok = ();
@@ -687,9 +675,8 @@ macro_rules! serialize_struct_named_fields {
             }
         }
 
-        impl<'ser, 'sig, 'b, B, W> ser::$trait for StructSeqSerializer<'ser, 'sig, 'b, B, W>
+        impl<'ser, 'sig, 'b, W> ser::$trait for StructSeqSerializer<'ser, 'sig, 'b, W>
         where
-            B: byteorder::ByteOrder,
             W: Write + Seek,
         {
             type Ok = ();

--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -14,7 +14,7 @@ use crate::{Signature, Type, Value};
 /// ```
 /// # use zvariant::{to_bytes, serialized::Context, DeserializeValue, SerializeValue};
 /// #
-/// # let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// # let ctxt = Context::new_dbus(endi::LE, 0);
 /// # let array = [0, 1, 2];
 /// # let v = SerializeValue(&array);
 /// # let encoded = to_bytes(ctxt, &v).unwrap();

--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -12,9 +12,9 @@ use crate::{Signature, Type, Value};
 /// generic [`Value`] and instead use this wrapper.
 ///
 /// ```
-/// # use zvariant::{to_bytes, serialized::Context, DeserializeValue, SerializeValue};
+/// # use zvariant::{to_bytes, serialized::Context, DeserializeValue, SerializeValue, LE};
 /// #
-/// # let ctxt = Context::new_dbus(endi::LE, 0);
+/// # let ctxt = Context::new_dbus(LE, 0);
 /// # let array = [0, 1, 2];
 /// # let v = SerializeValue(&array);
 /// # let encoded = to_bytes(ctxt, &v).unwrap();

--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -1,5 +1,4 @@
-use crate::{Error, Result};
-use endi::{WriteBytes, LE};
+use crate::{Error, Result, WriteBytes, LE};
 
 // Used internally for GVariant encoding and decoding.
 //

--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Result};
-use byteorder::{ByteOrder, WriteBytesExt, LE};
+use endi::{WriteBytes, LE};
 
 // Used internally for GVariant encoding and decoding.
 //
@@ -39,11 +39,11 @@ impl FramingOffsetSize {
         W: std::io::Write,
     {
         match self {
-            FramingOffsetSize::U8 => writer.write_u8(offset as u8),
-            FramingOffsetSize::U16 => writer.write_u16::<LE>(offset as u16),
-            FramingOffsetSize::U32 => writer.write_u32::<LE>(offset as u32),
+            FramingOffsetSize::U8 => writer.write_u8(LE, offset as u8),
+            FramingOffsetSize::U16 => writer.write_u16(LE, offset as u16),
+            FramingOffsetSize::U32 => writer.write_u32(LE, offset as u32),
             #[cfg(not(target_pointer_width = "32"))]
-            FramingOffsetSize::U64 => writer.write_u64::<LE>(offset as u64),
+            FramingOffsetSize::U64 => writer.write_u64(LE, offset as u64),
         }
         .map_err(|e| Error::InputOutput(e.into()))
     }
@@ -56,10 +56,10 @@ impl FramingOffsetSize {
         let end = buffer.len();
         match self {
             FramingOffsetSize::U8 => buffer[end - 1] as usize,
-            FramingOffsetSize::U16 => LE::read_u16(&buffer[end - 2..end]) as usize,
-            FramingOffsetSize::U32 => LE::read_u32(&buffer[end - 4..end]) as usize,
+            FramingOffsetSize::U16 => LE.read_u16(&buffer[end - 2..end]) as usize,
+            FramingOffsetSize::U32 => LE.read_u32(&buffer[end - 4..end]) as usize,
             #[cfg(not(target_pointer_width = "32"))]
-            FramingOffsetSize::U64 => LE::read_u64(&buffer[end - 8..end]) as usize,
+            FramingOffsetSize::U64 => LE.read_u64(&buffer[end - 8..end]) as usize,
         }
     }
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -112,6 +112,9 @@ pub mod export {
     pub use serde;
 }
 
+// Re-export all of the `endi` API for ease of use.
+pub use endi::*;
+
 #[cfg(test)]
 #[allow(clippy::disallowed_names)]
 mod tests {
@@ -122,7 +125,6 @@ mod tests {
 
     #[cfg(feature = "arrayvec")]
     use arrayvec::{ArrayString, ArrayVec};
-    use endi::{BE, LE, NATIVE_ENDIAN};
     #[cfg(feature = "arrayvec")]
     use std::str::FromStr;
 
@@ -137,7 +139,8 @@ mod tests {
     use crate::{
         serialized::{Context, Format},
         Array, Basic, DeserializeDict, DeserializeValue, Dict, Error, ObjectPath, Result,
-        SerializeDict, SerializeValue, Signature, Str, Structure, Type, Value,
+        SerializeDict, SerializeValue, Signature, Str, Structure, Type, Value, BE, LE,
+        NATIVE_ENDIAN,
     };
 
     // Test through both generic and specific API (wrt byte order)

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -48,10 +48,10 @@ where
 ///
 /// ```
 /// use zvariant::{serialized::Context, Optional, to_bytes};
-/// use byteorder::LE;
+/// use endi::LE;
 ///
 /// // `Null` case.
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let s = Optional::<&str>::default();
 /// let encoded = to_bytes(ctxt, &s).unwrap();
 /// assert_eq!(encoded.bytes(), &[0, 0, 0, 0, 0]);

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -47,8 +47,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use zvariant::{serialized::Context, Optional, to_bytes};
-/// use endi::LE;
+/// use zvariant::{serialized::Context, Optional, to_bytes, LE};
 ///
 /// // `Null` case.
 /// let ctxt = Context::new_dbus(LE, 0);

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -281,10 +281,9 @@ impl<'de> Deserialize<'de> for OwnedValue {
 
 #[cfg(test)]
 mod tests {
-    use endi::LE;
     use std::{collections::HashMap, error::Error, result::Result};
 
-    use crate::{serialized::Context, to_bytes, OwnedValue, Value};
+    use crate::{serialized::Context, to_bytes, OwnedValue, Value, LE};
 
     #[cfg(feature = "enumflags2")]
     #[test]

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -281,7 +281,7 @@ impl<'de> Deserialize<'de> for OwnedValue {
 
 #[cfg(test)]
 mod tests {
-    use byteorder::LE;
+    use endi::LE;
     use std::{collections::HashMap, error::Error, result::Result};
 
     use crate::{serialized::Context, to_bytes, OwnedValue, Value};
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn serde() -> Result<(), Box<dyn Error>> {
-        let ec = Context::<LE>::new_dbus(0);
+        let ec = Context::new_dbus(LE, 0);
         let ov: OwnedValue = Value::from("hi!").try_into()?;
         let ser = to_bytes(ec, &ov)?;
         let (de, parsed): (Value<'_>, _) = ser.deserialize()?;

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -1,9 +1,6 @@
-use byteorder::WriteBytesExt;
+use endi::WriteBytes;
 use serde::Serialize;
-use std::{
-    io::{Seek, Write},
-    marker::PhantomData,
-};
+use std::io::{Seek, Write};
 
 #[cfg(unix)]
 use std::os::fd::OwnedFd;
@@ -44,16 +41,15 @@ impl Seek for NullWriteSeek {
 /// ```
 /// use zvariant::{serialized::Context, serialized_size};
 ///
-/// let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(endi::LE, 0);
 /// let len = serialized_size(ctxt, "hello world").unwrap();
 /// assert_eq!(*len, 16);
 ///
 /// let len = serialized_size(ctxt, &("hello world!", 42_u64)).unwrap();
 /// assert_eq!(*len, 32);
 /// ```
-pub fn serialized_size<B, T: ?Sized>(ctxt: Context<B>, value: &T) -> Result<Size<B>>
+pub fn serialized_size<T: ?Sized>(ctxt: Context, value: &T) -> Result<Size>
 where
-    B: byteorder::ByteOrder,
     T: Serialize + DynamicType,
 {
     let mut null = NullWriteSeek;
@@ -63,7 +59,7 @@ where
 
     let len = match ctxt.format() {
         Format::DBus => {
-            let mut ser = DBusSerializer::<B, NullWriteSeek>::new(
+            let mut ser = DBusSerializer::<NullWriteSeek>::new(
                 signature,
                 &mut null,
                 #[cfg(unix)]
@@ -75,7 +71,7 @@ where
         }
         #[cfg(feature = "gvariant")]
         Format::GVariant => {
-            let mut ser = GVSerializer::<B, NullWriteSeek>::new(
+            let mut ser = GVSerializer::<NullWriteSeek>::new(
                 signature,
                 &mut null,
                 #[cfg(unix)]
@@ -104,7 +100,7 @@ where
 /// ```
 /// use zvariant::{serialized::{Context, Data}, to_writer};
 ///
-/// let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(endi::LE, 0);
 /// let mut cursor = std::io::Cursor::new(vec![]);
 /// // SAFETY: No FDs are being serialized here so its completely safe.
 /// unsafe { to_writer(&mut cursor, ctxt, &42u32) }.unwrap();
@@ -124,13 +120,8 @@ where
 /// hence is safe to drop.
 ///
 /// [`to_writer_fds`]: fn.to_writer_fds.html
-pub unsafe fn to_writer<B, W, T: ?Sized>(
-    writer: &mut W,
-    ctxt: Context<B>,
-    value: &T,
-) -> Result<Written<B>>
+pub unsafe fn to_writer<W, T: ?Sized>(writer: &mut W, ctxt: Context, value: &T) -> Result<Written>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
     T: Serialize + DynamicType,
 {
@@ -142,9 +133,8 @@ where
 /// Serialize `T` as a byte vector.
 ///
 /// See [`Data::deserialize`] documentation for an example of how to use this function.
-pub fn to_bytes<B, T: ?Sized>(ctxt: Context<B>, value: &T) -> Result<Data<'static, 'static, B>>
+pub fn to_bytes<T: ?Sized>(ctxt: Context, value: &T) -> Result<Data<'static, 'static>>
 where
-    B: byteorder::ByteOrder,
     T: Serialize + DynamicType,
 {
     to_bytes_for_signature(ctxt, value.dynamic_signature(), value)
@@ -166,14 +156,13 @@ where
 /// hence is safe to drop.
 ///
 /// [`to_writer`]: fn.to_writer.html
-pub unsafe fn to_writer_for_signature<'s, B, W, S, T: ?Sized>(
+pub unsafe fn to_writer_for_signature<'s, W, S, T: ?Sized>(
     writer: &mut W,
-    ctxt: Context<B>,
+    ctxt: Context,
     signature: S,
     value: &T,
-) -> Result<Written<B>>
+) -> Result<Written>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
     S: TryInto<Signature<'s>>,
     S::Error: Into<Error>,
@@ -184,7 +173,7 @@ where
 
     let len = match ctxt.format() {
         Format::DBus => {
-            let mut ser = DBusSerializer::<B, W>::new(
+            let mut ser = DBusSerializer::<W>::new(
                 signature,
                 writer,
                 #[cfg(unix)]
@@ -196,7 +185,7 @@ where
         }
         #[cfg(feature = "gvariant")]
         Format::GVariant => {
-            let mut ser = GVSerializer::<B, W>::new(
+            let mut ser = GVSerializer::<W>::new(
                 signature,
                 writer,
                 #[cfg(unix)]
@@ -226,13 +215,12 @@ where
 ///
 /// [`to_bytes`]: fn.to_bytes.html
 /// [`from_slice_for_signature`]: fn.from_slice_for_signature.html#examples
-pub fn to_bytes_for_signature<'s, B, S, T: ?Sized>(
-    ctxt: Context<B>,
+pub fn to_bytes_for_signature<'s, S, T: ?Sized>(
+    ctxt: Context,
     signature: S,
     value: &T,
-) -> Result<Data<'static, 'static, B>>
+) -> Result<Data<'static, 'static>>
 where
-    B: byteorder::ByteOrder,
     S: TryInto<Signature<'s>>,
     S::Error: Into<Error>,
     T: Serialize,
@@ -253,8 +241,8 @@ where
 }
 
 /// Context for all our serializers and provides shared functionality.
-pub(crate) struct SerializerCommon<'ser, 'sig, B, W> {
-    pub(crate) ctxt: Context<B>,
+pub(crate) struct SerializerCommon<'ser, 'sig, W> {
+    pub(crate) ctxt: Context,
     pub(crate) writer: &'ser mut W,
     pub(crate) bytes_written: usize,
     #[cfg(unix)]
@@ -265,8 +253,6 @@ pub(crate) struct SerializerCommon<'ser, 'sig, B, W> {
     pub(crate) value_sign: Option<Signature<'static>>,
 
     pub(crate) container_depths: ContainerDepths,
-
-    pub(crate) b: PhantomData<B>,
 }
 
 #[cfg(unix)]
@@ -275,9 +261,8 @@ pub(crate) enum FdList {
     Number(u32),
 }
 
-impl<'ser, 'sig, B, W> SerializerCommon<'ser, 'sig, B, W>
+impl<'ser, 'sig, W> SerializerCommon<'ser, 'sig, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     #[cfg(unix)]
@@ -346,7 +331,7 @@ where
         self.add_padding(alignment)?;
 
         // Now serialize the veriant index.
-        self.write_u32::<B>(variant_index)
+        self.write_u32(self.ctxt.endian(), variant_index)
             .map_err(|e| Error::InputOutput(e.into()))?;
 
         // Skip the `(`, `u`.
@@ -360,9 +345,8 @@ where
     }
 }
 
-impl<'ser, 'sig, B, W> Write for SerializerCommon<'ser, 'sig, B, W>
+impl<'ser, 'sig, W> Write for SerializerCommon<'ser, 'sig, W>
 where
-    B: byteorder::ByteOrder,
     W: Write + Seek,
 {
     /// Write `buf` and increment internal bytes written counter.

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -1,4 +1,3 @@
-use endi::WriteBytes;
 use serde::Serialize;
 use std::io::{Seek, Write};
 
@@ -13,7 +12,7 @@ use crate::{
     serialized::{Context, Data, Format, Size, Written},
     signature_parser::SignatureParser,
     utils::*,
-    Basic, DynamicType, Error, Result, Signature,
+    Basic, DynamicType, Error, Result, Signature, WriteBytes,
 };
 
 struct NullWriteSeek;
@@ -39,9 +38,9 @@ impl Seek for NullWriteSeek {
 /// # Examples
 ///
 /// ```
-/// use zvariant::{serialized::Context, serialized_size};
+/// use zvariant::{serialized::Context, serialized_size, LE};
 ///
-/// let ctxt = Context::new_dbus(endi::LE, 0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let len = serialized_size(ctxt, "hello world").unwrap();
 /// assert_eq!(*len, 16);
 ///
@@ -98,9 +97,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use zvariant::{serialized::{Context, Data}, to_writer};
+/// use zvariant::{serialized::{Context, Data}, to_writer, LE};
 ///
-/// let ctxt = Context::new_dbus(endi::LE, 0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let mut cursor = std::io::Cursor::new(vec![]);
 /// // SAFETY: No FDs are being serialized here so its completely safe.
 /// unsafe { to_writer(&mut cursor, ctxt, &42u32) }.unwrap();

--- a/zvariant/src/serialize_value.rs
+++ b/zvariant/src/serialize_value.rs
@@ -9,9 +9,9 @@ use crate::{Signature, Type, Value};
 /// generic [`Value`] and instead use this wrapper.
 ///
 /// ```
-/// # use zvariant::{to_bytes, serialized::Context, SerializeValue};
+/// # use zvariant::{to_bytes, serialized::Context, SerializeValue, LE};
 /// #
-/// # let ctxt = Context::new_dbus(endi::LE, 0);
+/// # let ctxt = Context::new_dbus(LE, 0);
 /// let _ = to_bytes(ctxt, &SerializeValue(&[0, 1, 2])).unwrap();
 /// ```
 ///

--- a/zvariant/src/serialize_value.rs
+++ b/zvariant/src/serialize_value.rs
@@ -11,7 +11,7 @@ use crate::{Signature, Type, Value};
 /// ```
 /// # use zvariant::{to_bytes, serialized::Context, SerializeValue};
 /// #
-/// # let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// # let ctxt = Context::new_dbus(endi::LE, 0);
 /// let _ = to_bytes(ctxt, &SerializeValue(&[0, 1, 2])).unwrap();
 /// ```
 ///

--- a/zvariant/src/serialized/context.rs
+++ b/zvariant/src/serialized/context.rs
@@ -1,27 +1,25 @@
-use std::marker::PhantomData;
-
+use endi::Endian;
 use static_assertions::assert_impl_all;
 
 use crate::serialized::Format;
 
 /// The encoding context to use with the [serialization and deserialization] API.
 ///
-/// This type is generic over the [ByteOrder] trait. Moreover, the encoding is dependent on the
-/// position of the encoding in the entire message and hence the need to [specify] the byte
-/// position of the data being serialized or deserialized. Simply pass `0` if serializing or
-/// deserializing to or from the beginning of message, or the preceding bytes end on an 8-byte
-/// boundary.
+/// The encoding is dependent on the position of the encoding in the entire message and hence the
+/// need to [specify] the byte position of the data being serialized or deserialized. Simply pass
+/// `0` if serializing or deserializing to or from the beginning of message, or the preceding bytes
+/// end on an 8-byte boundary.
 ///
 /// # Examples
 ///
 /// ```
-/// use byteorder::LE;
+/// use endi::Endian;
 ///
 /// use zvariant::serialized::Context;
 /// use zvariant::to_bytes;
 ///
 /// let str_vec = vec!["Hello", "World"];
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(Endian::Little, 0);
 /// let encoded = to_bytes(ctxt, &str_vec).unwrap();
 ///
 /// // Let's decode the 2nd element of the array only
@@ -31,49 +29,49 @@ use crate::serialized::Format;
 /// ```
 ///
 /// [serialization and deserialization]: index.html#functions
-/// [ByteOrder]: https://docs.rs/byteorder/1.3.4/byteorder/trait.ByteOrder.html
 /// [specify]: #method.new
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct Context<B> {
+pub struct Context {
     format: Format,
     position: usize,
-
-    b: PhantomData<B>,
+    endian: Endian,
 }
 
-assert_impl_all!(Context<byteorder::NativeEndian>: Send, Sync, Unpin);
+assert_impl_all!(Context: Send, Sync, Unpin);
 
-impl<B> Context<B>
-where
-    B: byteorder::ByteOrder,
-{
+impl Context {
     /// Create a new encoding context.
-    pub fn new(format: Format, position: usize) -> Self {
+    pub fn new(format: Format, endian: Endian, position: usize) -> Self {
         Self {
             format,
             position,
-            b: PhantomData,
+            endian,
         }
     }
 
     /// Convenient wrapper for [`new`] to create a context for D-Bus format.
     ///
     /// [`new`]: #method.new
-    pub fn new_dbus(position: usize) -> Self {
-        Self::new(Format::DBus, position)
+    pub fn new_dbus(endian: Endian, position: usize) -> Self {
+        Self::new(Format::DBus, endian, position)
     }
 
     /// Convenient wrapper for [`new`] to create a context for GVariant format.
     ///
     /// [`new`]: #method.new
     #[cfg(feature = "gvariant")]
-    pub fn new_gvariant(position: usize) -> Self {
-        Self::new(Format::GVariant, position)
+    pub fn new_gvariant(endian: Endian, position: usize) -> Self {
+        Self::new(Format::GVariant, endian, position)
     }
 
     /// The [`Format`] of this context.
     pub fn format(self) -> Format {
         self.format
+    }
+
+    /// The [`Endian`] of this context.
+    pub fn endian(self) -> Endian {
+        self.endian
     }
 
     /// The byte position of the value to be encoded or decoded, in the entire message.

--- a/zvariant/src/serialized/context.rs
+++ b/zvariant/src/serialized/context.rs
@@ -1,7 +1,6 @@
-use endi::Endian;
 use static_assertions::assert_impl_all;
 
-use crate::serialized::Format;
+use crate::{serialized::Format, Endian};
 
 /// The encoding context to use with the [serialization and deserialization] API.
 ///
@@ -13,8 +12,7 @@ use crate::serialized::Format;
 /// # Examples
 ///
 /// ```
-/// use endi::Endian;
-///
+/// use zvariant::Endian;
 /// use zvariant::serialized::Context;
 /// use zvariant::to_bytes;
 ///

--- a/zvariant/src/serialized/data.rs
+++ b/zvariant/src/serialized/data.rs
@@ -126,10 +126,11 @@ impl<'bytes, 'fds> Data<'bytes, 'fds> {
     /// # Examples
     ///
     /// ```
+    /// use zvariant::LE;
     /// use zvariant::to_bytes;
     /// use zvariant::serialized::Context;
     ///
-    /// let ctxt = Context::new_dbus(endi::Endian::Little, 0);
+    /// let ctxt = Context::new_dbus(LE, 0);
     /// let encoded = to_bytes(ctxt, "hello world").unwrap();
     /// let decoded: &str = encoded.deserialize().unwrap().0;
     /// assert_eq!(decoded, "hello world");
@@ -158,11 +159,12 @@ impl<'bytes, 'fds> Data<'bytes, 'fds> {
     ///
     /// ```
     /// use serde::{Deserialize, Serialize};
+    /// use zvariant::LE;
     ///
     /// use zvariant::to_bytes_for_signature;
     /// use zvariant::serialized::Context;
     ///
-    /// let ctxt = Context::new_dbus(endi::Endian::Little, 0);
+    /// let ctxt = Context::new_dbus(LE, 0);
     /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     /// enum Unit {
     ///     Variant1,

--- a/zvariant/src/serialized/size.rs
+++ b/zvariant/src/serialized/size.rs
@@ -1,7 +1,5 @@
 use std::ops::Deref;
 
-use byteorder::ByteOrder;
-
 use crate::serialized::Context;
 
 /// Represents the return value of [`crate::serialized_size`] function.
@@ -11,16 +9,16 @@ use crate::serialized::Context;
 /// On Unix platforms, it also contains the number of file descriptors, whose indexes are included
 /// in the serialized bytes.
 #[derive(Debug)]
-pub struct Size<B: ByteOrder> {
+pub struct Size {
     size: usize,
-    context: Context<B>,
+    context: Context,
     #[cfg(unix)]
     num_fds: u32,
 }
 
-impl<B: ByteOrder> Size<B> {
+impl Size {
     /// Create a new `EncodedSize` instance.
-    pub fn new(size: usize, context: Context<B>) -> Self {
+    pub fn new(size: usize, context: Context) -> Self {
         Self {
             size,
             context,
@@ -42,7 +40,7 @@ impl<B: ByteOrder> Size<B> {
     }
 
     /// The encoding context.
-    pub fn context(&self) -> Context<B> {
+    pub fn context(&self) -> Context {
         self.context
     }
 
@@ -55,7 +53,7 @@ impl<B: ByteOrder> Size<B> {
     }
 }
 
-impl<B: ByteOrder> Deref for Size<B> {
+impl Deref for Size {
     type Target = usize;
 
     fn deref(&self) -> &Self::Target {

--- a/zvariant/src/serialized/written.rs
+++ b/zvariant/src/serialized/written.rs
@@ -2,8 +2,6 @@ use std::ops::Deref;
 #[cfg(unix)]
 use std::os::fd::OwnedFd;
 
-use byteorder::ByteOrder;
-
 use crate::serialized::Context;
 
 /// Represents the return value of [`crate::to_writer`] function.
@@ -13,16 +11,16 @@ use crate::serialized::Context;
 /// On Unix platforms, it also contains a list of file descriptors, whose indexes are included in
 /// the serialized bytes.
 #[derive(Debug)]
-pub struct Written<B: ByteOrder> {
+pub struct Written {
     size: usize,
-    context: Context<B>,
+    context: Context,
     #[cfg(unix)]
     fds: Vec<OwnedFd>,
 }
 
-impl<B: ByteOrder> Written<B> {
+impl Written {
     /// Create a new `EncodedSize` instance.
-    pub fn new(size: usize, context: Context<B>) -> Self {
+    pub fn new(size: usize, context: Context) -> Self {
         Self {
             size,
             context,
@@ -44,7 +42,7 @@ impl<B: ByteOrder> Written<B> {
     }
 
     /// The encoding context.
-    pub fn context(&self) -> Context<B> {
+    pub fn context(&self) -> Context {
         self.context
     }
 
@@ -65,7 +63,7 @@ impl<B: ByteOrder> Written<B> {
     }
 }
 
-impl<B: ByteOrder> Deref for Written<B> {
+impl Deref for Written {
     type Target = usize;
 
     fn deref(&self) -> &Self::Target {

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -42,7 +42,7 @@ use crate::Fd;
 /// let v = Value::new(i16::max_value());
 ///
 /// // Encode it
-/// let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(endi::LE, 0);
 /// let encoding = to_bytes(ctxt, &v).unwrap();
 ///
 /// // Decode it back
@@ -62,7 +62,7 @@ use crate::Fd;
 /// let v = Value::new((i16::max_value(), "hello", true));
 ///
 /// // Same drill as previous example
-/// let ctxt = Context::<byteorder::LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(endi::LE, 0);
 /// let encoding = to_bytes(ctxt, &v).unwrap();
 /// let v: Value = encoding.deserialize().unwrap().0;
 ///

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -36,13 +36,13 @@ use crate::Fd;
 /// # Examples
 ///
 /// ```
-/// use zvariant::{to_bytes, serialized::Context, Value};
+/// use zvariant::{to_bytes, serialized::Context, Value, LE};
 ///
 /// // Create a Value from an i16
 /// let v = Value::new(i16::max_value());
 ///
 /// // Encode it
-/// let ctxt = Context::new_dbus(endi::LE, 0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoding = to_bytes(ctxt, &v).unwrap();
 ///
 /// // Decode it back
@@ -55,14 +55,14 @@ use crate::Fd;
 /// Now let's try a more complicated example:
 ///
 /// ```
-/// use zvariant::{to_bytes, serialized::Context};
+/// use zvariant::{to_bytes, serialized::Context, LE};
 /// use zvariant::{Structure, Value, Str};
 ///
 /// // Create a Value from a tuple this time
 /// let v = Value::new((i16::max_value(), "hello", true));
 ///
 /// // Same drill as previous example
-/// let ctxt = Context::new_dbus(endi::LE, 0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoding = to_bytes(ctxt, &v).unwrap();
 /// let v: Value = encoding.deserialize().unwrap().0;
 ///

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro-crate = "1.2.1"
 zvariant_utils = { path = "../zvariant_utils", version = "=1.0.1" }
 
 [dev-dependencies]
-byteorder = "1.4.3"
+endi = "1.1.0"
 zvariant = { path = "../zvariant", features = ["enumflags2"] }
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -24,7 +24,6 @@ proc-macro-crate = "1.2.1"
 zvariant_utils = { path = "../zvariant_utils", version = "=1.0.1" }
 
 [dev-dependencies]
-endi = "1.1.0"
 zvariant = { path = "../zvariant", features = ["enumflags2"] }
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/zvariant_derive/README.md
+++ b/zvariant_derive/README.md
@@ -12,7 +12,7 @@ macros for your convenience so you do not need to use this crate directly.
 ```rust
 use zvariant::{serialized::Context, to_bytes, Type};
 use serde::{Deserialize, Serialize};
-use byteorder::LE;
+use endi::LE;
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 struct Struct<'s> {
@@ -27,7 +27,7 @@ let s = Struct {
     field2: i64::max_value(),
     field3: "hello",
 };
-let ctxt = Context::<LE>::new_dbus(0);
+let ctxt = Context::new_dbus(LE, 0);
 let encoded = to_bytes(ctxt, &s).unwrap();
 let decoded: Struct = encoded.deserialize().unwrap().0;
 assert_eq!(decoded, s);

--- a/zvariant_derive/README.md
+++ b/zvariant_derive/README.md
@@ -10,9 +10,8 @@ macros for your convenience so you do not need to use this crate directly.
 ## Example code
 
 ```rust
-use zvariant::{serialized::Context, to_bytes, Type};
+use zvariant::{serialized::Context, to_bytes, Type, LE};
 use serde::{Deserialize, Serialize};
-use endi::LE;
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 struct Struct<'s> {

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -25,9 +25,8 @@ mod value;
 /// For structs it works just like serde's [`Serialize`] and [`Deserialize`] macros:
 ///
 /// ```
-/// use zvariant::{serialized::Context, to_bytes, Type};
+/// use zvariant::{serialized::Context, to_bytes, Type, LE};
 /// use serde::{Deserialize, Serialize};
-/// use endi::LE;
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 /// struct Struct<'s> {
@@ -53,10 +52,9 @@ mod value;
 /// `repr` attribute (like in the example below), you'll also need [serde_repr] crate.
 ///
 /// ```
-/// use zvariant::{serialized::Context, to_bytes, Type};
+/// use zvariant::{serialized::Context, to_bytes, Type, LE};
 /// use serde::{Deserialize, Serialize};
 /// use serde_repr::{Deserialize_repr, Serialize_repr};
-/// use endi::LE;
 ///
 /// #[repr(u8)]
 /// #[derive(Deserialize_repr, Serialize_repr, Type, Debug, PartialEq)]
@@ -111,8 +109,7 @@ mod value;
 /// an alias for `a{sv}`. Here is an example:
 ///
 /// ```
-/// use zvariant::{SerializeDict, DeserializeDict, serialized::Context, to_bytes, Type};
-/// use endi::LE;
+/// use zvariant::{SerializeDict, DeserializeDict, serialized::Context, to_bytes, Type, LE};
 ///
 /// #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug)]
 /// // `#[zvariant(signature = "a{sv}")]` would be the same.
@@ -138,9 +135,8 @@ mod value;
 /// Another common use for custom signatures is (de)serialization of unit enums as strings:
 ///
 /// ```
-/// use zvariant::{serialized::Context, to_bytes, Type};
+/// use zvariant::{serialized::Context, to_bytes, Type, LE};
 /// use serde::{Deserialize, Serialize};
-/// use endi::LE;
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 /// #[zvariant(signature = "s")]

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -27,7 +27,7 @@ mod value;
 /// ```
 /// use zvariant::{serialized::Context, to_bytes, Type};
 /// use serde::{Deserialize, Serialize};
-/// use byteorder::LE;
+/// use endi::LE;
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 /// struct Struct<'s> {
@@ -42,7 +42,7 @@ mod value;
 ///     field2: i64::max_value(),
 ///     field3: "hello",
 /// };
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &s).unwrap();
 /// let decoded: Struct = encoded.deserialize().unwrap().0;
 /// assert_eq!(decoded, s);
@@ -56,7 +56,7 @@ mod value;
 /// use zvariant::{serialized::Context, to_bytes, Type};
 /// use serde::{Deserialize, Serialize};
 /// use serde_repr::{Deserialize_repr, Serialize_repr};
-/// use byteorder::LE;
+/// use endi::LE;
 ///
 /// #[repr(u8)]
 /// #[derive(Deserialize_repr, Serialize_repr, Type, Debug, PartialEq)]
@@ -65,7 +65,7 @@ mod value;
 ///     Variant2,
 /// }
 /// assert_eq!(Enum::signature(), u8::signature());
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &Enum::Variant2).unwrap();
 /// let decoded: Enum = encoded.deserialize().unwrap().0;
 /// assert_eq!(decoded, Enum::Variant2);
@@ -112,7 +112,7 @@ mod value;
 ///
 /// ```
 /// use zvariant::{SerializeDict, DeserializeDict, serialized::Context, to_bytes, Type};
-/// use byteorder::LE;
+/// use endi::LE;
 ///
 /// #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug)]
 /// // `#[zvariant(signature = "a{sv}")]` would be the same.
@@ -129,7 +129,7 @@ mod value;
 ///     field2: i64::max_value(),
 ///     field3: "hello".to_string(),
 /// };
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &s).unwrap();
 /// let decoded: Struct = encoded.deserialize().unwrap().0;
 /// assert_eq!(decoded, s);
@@ -140,7 +140,7 @@ mod value;
 /// ```
 /// use zvariant::{serialized::Context, to_bytes, Type};
 /// use serde::{Deserialize, Serialize};
-/// use byteorder::LE;
+/// use endi::LE;
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 /// #[zvariant(signature = "s")]
@@ -151,7 +151,7 @@ mod value;
 /// }
 ///
 /// assert_eq!(StrEnum::signature(), "s");
-/// let ctxt = Context::<LE>::new_dbus(0);
+/// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &StrEnum::Variant2).unwrap();
 /// assert_eq!(encoded.len(), 13);
 /// let decoded: StrEnum = encoded.deserialize().unwrap().0;

--- a/zvariant_derive/tests/tests.rs
+++ b/zvariant_derive/tests/tests.rs
@@ -1,10 +1,9 @@
 #![allow(dead_code)]
 
-use endi::LE;
 use std::collections::HashMap;
 use zvariant::{
     serialized::{Context, Format},
-    DeserializeDict, OwnedValue, SerializeDict, Type, Value,
+    DeserializeDict, OwnedValue, SerializeDict, Type, Value, LE,
 };
 
 #[test]

--- a/zvariant_derive/tests/tests.rs
+++ b/zvariant_derive/tests/tests.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use byteorder::LE;
+use endi::LE;
 use std::collections::HashMap;
 use zvariant::{
     serialized::{Context, Format},
@@ -57,7 +57,7 @@ fn derive_dict() {
         field_c: vec![1, 2, 3],
     };
 
-    let ctxt = Context::<LE>::new(Format::DBus, 0);
+    let ctxt = Context::new(Format::DBus, LE, 0);
     let serialized = zvariant::to_bytes(ctxt, &test).unwrap();
     let deserialized: HashMap<String, OwnedValue> = serialized.deserialize().unwrap().0;
 


### PR DESCRIPTION
With this PR, zbus can now received and decode non-native endian-encoded messages and replies to them in the same endian.

I first tried to solve this using `byteorder` that we were already using but that turned out to be a huge change and extremely disruptive, breaking all API. This is because `byteorder` handles things through a trait and if your types hold endian-encoded data in a generic way, you need a generic added to your types as well. This ended up having to add the generic to Message, Connection, Proxy etc. That would have also meant that user has to make a decision, which encoding to use and we'll not be able to receive messages in any other encoding, which is unexpected from dbus implementations (according to comments in GIO code).

So I ended up creating a new crate, [`endi`](https://crates.io/crates/endi) that uses an enum instead. While enum could be *slightly* less performant and larger binary size, in most cases the compiler is able to optimize out the match and the performance ends up the same as that of `byteorder`.

Fixes #252.