### PR TITLE
Stop using the async-std crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,21 @@ impl Greeter {
     }
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let greeter = Greeter { count: 0 };
-    let _conn = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
-        .build()
-        .await?;
+// Although we use `smol` here, you can use any async runtime of choice.
+smol_macros::main! {
+    async fn main() -> Result<(), Box<dyn Error>> {
+        let greeter = Greeter { count: 0 };
+        let _conn = connection::Builder::session()?
+            .name("org.zbus.MyGreeter")?
+            .serve_at("/org/zbus/MyGreeter", greeter)?
+            .build()
+            .await?;
 
-    // Do other things or go to wait forever
-    pending::<()>().await;
+        // Do other things or go to wait forever
+        pending::<()>().await;
 
-    Ok(())
+        Ok(())
+    }
 }
 ```
 
@@ -90,17 +91,18 @@ trait MyGreeter {
     async fn say_hello(&self, name: &str) -> Result<String>;
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
-async fn main() -> Result<()> {
-    let connection = Connection::session().await?;
+// Although we use `smol` here, you can use any async runtime of choice.
+smol_macros::main! {
+    async fn main() -> Result<()> {
+        let connection = Connection::session().await?;
 
-    // `dbus_proxy` macro creates `MyGreeterProxy` based on `Notifications` trait.
-    let proxy = MyGreeterProxy::new(&connection).await?;
-    let reply = proxy.say_hello("Maria").await?;
-    println!("{reply}");
+        // `dbus_proxy` macro creates `MyGreeterProxy` based on `Notifications` trait.
+        let proxy = MyGreeterProxy::new(&connection).await?;
+        let reply = proxy.say_hello("Maria").await?;
+        println!("{reply}");
 
-    Ok(())
+        Ok(())
+    }
 }
 ```
 

--- a/book/src/server.md
+++ b/book/src/server.md
@@ -20,8 +20,8 @@ our choice:
 ```rust,no_run
 use zbus::{Connection, Result};
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
+// Although we use `smol` here, you can use any async runtime of choice.
+# smol_macros::main! {
 async fn main() -> Result<()> {
     let connection = Connection::session()
         .await?;
@@ -31,6 +31,7 @@ async fn main() -> Result<()> {
 
     loop {}
 }
+# }
 ```
 
 We can check our service is running and is associated with the service name:
@@ -55,8 +56,8 @@ by replacing the loop above with this code:
 ```rust,no_run
 use futures_util::stream::TryStreamExt;
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-# #[async_std::main]
+// Although we use `smol` here, you can use any async runtime of choice.
+# smol_macros::main! {
 # async fn main() -> zbus::Result<()> {
 #    let connection = zbus::Connection::session()
 #        .await?;
@@ -84,6 +85,7 @@ while let Some(msg) = stream.try_next().await? {
 }
 
 # Ok(())
+# }
 # }
 ```
 
@@ -120,24 +122,25 @@ impl Greeter {
     }
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
-async fn main() -> Result<()> {
-    let connection = Connection::session().await?;
-    // setup the server
-    connection
-        .object_server()
-        .at("/org/zbus/MyGreeter", Greeter)
-        .await?;
-    // before requesting the name
-    connection
-        .request_name("org.zbus.MyGreeter")
-        .await?;
+// Although we use `smol` here, you can use any async runtime of choice.
+smol_macros::main! {
+    async fn main() -> Result<()> {
+        let connection = Connection::session().await?;
+        // setup the server
+        connection
+            .object_server()
+            .at("/org/zbus/MyGreeter", Greeter)
+            .await?;
+        // before requesting the name
+        connection
+            .request_name("org.zbus.MyGreeter")
+            .await?;
 
-    loop {
-        // do something else, wait forever or timeout here:
-        // handling D-Bus messages is done in the background
-        std::future::pending::<()>().await;
+        loop {
+            // do something else, wait forever or timeout here:
+            // handling D-Bus messages is done in the background
+            std::future::pending::<()>().await;
+        }
     }
 }
 ```
@@ -162,7 +165,7 @@ setting up your interfaces and requesting names, and not have to care about this
 #     }
 # }
 #
-# #[async_std::main]
+# smol_macros::main! {
 # async fn main() -> Result<()> {
     let _connection = connection::Builder::session()?
         .name("org.zbus.MyGreeter")?
@@ -174,6 +177,7 @@ setting up your interfaces and requesting names, and not have to care about this
 #         // handling D-Bus messages is done in the background
 #         std::future::pending::<()>().await;
 #     }
+# }
 # }
 ```
 
@@ -255,8 +259,8 @@ impl Greeter {
     async fn greeted_everyone(ctxt: &SignalContext<'_>) -> Result<()>;
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
+// Although we use `smol` here, you can use any async runtime of choice.
+# smol_macros::main! {
 async fn main() -> Result<()> {
     let greeter = Greeter {
         name: "GreeterName".to_string(),
@@ -273,6 +277,7 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+# }
 ```
 
 This is the introspection result:
@@ -340,7 +345,7 @@ example code:
 #     }
 # }
 #
-# #[async_std::main]
+# smol_macros::main! {
 # async fn main() -> zbus::Result<()> {
 # let connection = zbus::Connection::session().await?;
 # let object_server = connection.object_server();
@@ -350,6 +355,7 @@ let mut iface = iface_ref.get_mut().await;
 iface.name = String::from("👋");
 iface.greeter_name_changed(iface_ref.signal_context()).await?;
 # Ok(())
+# }
 # }
 ```
 

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -128,13 +128,14 @@ tokio = { version = "1", features = [
   "net",
   "sync",
 ] }
-async-std = { version = "1.12.0", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.16", features = [
   "env-filter",
   "fmt",
   "ansi",
 ], default-features = false }
 tempfile = "3.3.0"
+smol-macros = "0.1.0"
+async-global-executor = "2.4.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -41,20 +41,21 @@ impl Greeter {
     }
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let greeter = Greeter { count: 0 };
-    let _conn = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
-        .build()
-        .await?;
+// Although we use `smol` here, you can use any async runtime of choice.
+smol_macros::main! {
+    async fn main() -> Result<(), Box<dyn Error>> {
+        let greeter = Greeter { count: 0 };
+        let _conn = connection::Builder::session()?
+            .name("org.zbus.MyGreeter")?
+            .serve_at("/org/zbus/MyGreeter", greeter)?
+            .build()
+            .await?;
 
-    // Do other things or go to wait forever
-    pending::<()>().await;
+        // Do other things or go to wait forever
+        pending::<()>().await;
 
-    Ok(())
+        Ok(())
+    }
 }
 ```
 
@@ -81,17 +82,18 @@ trait MyGreeter {
     async fn say_hello(&self, name: &str) -> Result<String>;
 }
 
-// Although we use `async-std` here, you can use any async runtime of choice.
-#[async_std::main]
-async fn main() -> Result<()> {
-    let connection = Connection::session().await?;
+// Although we use `smol` here, you can use any async runtime of choice.
+smol_macros::main! {
+    async fn main() -> Result<()> {
+        let connection = Connection::session().await?;
 
-    // `dbus_proxy` macro creates `MyGreaterProxy` based on `Notifications` trait.
-    let proxy = MyGreeterProxy::new(&connection).await?;
-    let reply = proxy.say_hello("Maria").await?;
-    println!("{reply}");
+        // `dbus_proxy` macro creates `MyGreaterProxy` based on `Notifications` trait.
+        let proxy = MyGreeterProxy::new(&connection).await?;
+        let reply = proxy.say_hello("Maria").await?;
+        println!("{reply}");
 
-    Ok(())
+        Ok(())
+    }
 }
 ```
 

--- a/zbus/examples/watch-systemd-jobs.rs
+++ b/zbus/examples/watch-systemd-jobs.rs
@@ -4,7 +4,7 @@
 //!
 //! Run with command: `cargo run --example watch-systemd-jobs`
 
-use async_std::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use zbus::Connection;
 use zbus_macros::dbus_proxy;
 use zvariant::OwnedObjectPath;

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -1026,9 +1026,9 @@ impl HandshakeCommon {
 #[cfg(unix)]
 #[cfg(test)]
 mod tests {
-    #[cfg(not(feature = "tokio"))]
-    use async_std::io::{Write as AsyncWrite, WriteExt};
     use futures_util::future::join;
+    #[cfg(not(feature = "tokio"))]
+    use futures_util::{AsyncWrite, AsyncWriteExt};
     use ntest::timeout;
     #[cfg(not(feature = "tokio"))]
     use std::os::unix::net::UnixStream;

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -844,8 +844,8 @@ impl Connection {
     /// # // https://gitlab.freedesktop.org/zeenix/zbus/-/jobs/34023494
     /// # #[cfg(all(not(feature = "tokio"), not(target_os = "windows")))]
     /// # {
+    /// use async_global_executor::{block_on, spawn};
     /// use zbus::connection::Builder;
-    /// use async_std::task::{block_on, spawn};
     ///
     /// # struct SomeIface;
     /// #
@@ -869,7 +869,7 @@ impl Connection {
     ///            loop {
     ///                conn.executor().tick().await;
     ///            }
-    ///        });
+    ///        }).detach();
     ///     }
     ///
     ///     // All your other async code goes here.


### PR DESCRIPTION
The async-std crate didn't had a release in 1 1/2 years and is pulling in a lot of outdated and unnecessary dependencies.

Therefore I replaced all uses with actively maintained crates.