### PR TITLE
👷 CI: Run lint job against nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting

--- a/zbus/src/win32.rs
+++ b/zbus/src/win32.rs
@@ -1,10 +1,10 @@
 use std::{
     ffi::{CStr, OsStr},
     io::{Error, ErrorKind},
+    mem,
     net::SocketAddr,
     os::windows::prelude::OsStrExt,
     ptr,
-    mem,
 };
 
 use windows_sys::Win32::{


### PR DESCRIPTION
We're using options that are only available in nightly.