### PR TITLE
📝 zb: update documentation for Guid::generate

### DIFF
--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -25,9 +25,8 @@ pub struct Guid(String);
 assert_impl_all!(Guid: Send, Sync, Unpin);
 
 impl Guid {
-    /// Generate a D-Bus GUID that can be used with e.g. [`Connection::new_unix_server`].
-    ///
-    /// [`Connection::new_unix_server`]: struct.Connection.html#method.new_unix_server
+    /// Generate a D-Bus GUID that can be used with e.g.
+    /// [`connection::Builder::server`](crate::connection::Builder::server).
     pub fn generate() -> Self {
         let r: Vec<u32> = repeat_with(rand::random::<u32>).take(3).collect();
         let r3 = match SystemTime::now().duration_since(UNIX_EPOCH) {


### PR DESCRIPTION
Connection::new_unix_server no longer exists, so I've replaced it with the appropriate current method.

---

There's also a reference to this method in book-1.0, but I wasn't sure whether that should be updated.