### PR TITLE
Fix tokio testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -198,6 +198,8 @@ jobs:
           $env:PATH += ";C:\bin"
           Start-Process dbus-daemon.exe --config-file=CI/win32-session.conf
           cargo test
+          # tokio feature
+          cargo test --no-default-features --features tokio
 
           $env:DBUS_SESSION_BUS_ADDRESS = $null
           $env:ZBUS_GDBUS_TEST = "1"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,8 @@ jobs:
           sed -e s/UID/$UID/ -e s/PATH/path/ CI/dbus-session.conf > /tmp/dbus-session.conf
           sed -e s/UID/$UID/ -e s/PATH/abstract/ CI/dbus-session.conf > /tmp/dbus-session-abstract.conf
           dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo test --verbose -- basic_connection
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --all-features -- --skip fdpass_systemd
+          # All features except tokio.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --features uuid,url,time,chrono,option-as-array,vsock -- --skip fdpass_systemd
           # check cookie-sha1 auth against dbus-daemon
           sed -i s/EXTERNAL/DBUS_COOKIE_SHA1/g /tmp/dbus-session.conf
           dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose -- basic_connection

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -77,7 +77,7 @@ tokio = { version = "1.21.2", optional = true, features = [
   "tracing",
 ] }
 tracing = "0.1.37"
-vsock = { version = "0.3.0", optional = true }
+vsock = { version = "0.4.0", optional = true }
 tokio-vsock = { version = "0.4", optional = true }
 xdg-home = "1.0.0"
 
@@ -85,7 +85,7 @@ xdg-home = "1.0.0"
 windows-sys = { version = "0.52", features = [
   "Win32_Foundation",
   "Win32_Security_Authorization",
-  "Win32_System_Memory"
+  "Win32_System_Memory",
 ] }
 uds_windows = "1.1.0"
 

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -140,6 +140,7 @@ impl<'de> Deserialize<'de> for Fd<'de> {
     }
 }
 
+#[allow(clippy::unconditional_recursion)]
 impl PartialEq for Fd<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.as_raw_fd().eq(&other.as_raw_fd())


### PR DESCRIPTION
This mainly removes accidental enabling of the tokio feature in one of the `cargo test` runs. This likely means that we've been running most of the tests on Linux with tokio-only for a long time now (since 3.0 probably). This PR aims to fix that.

Some other fixes and a workaround also included.