### PR TITLE
👷 CI: Enable tokio-vsock tests on Linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
           sed -i s/EXTERNAL/DBUS_COOKIE_SHA1/g /tmp/dbus-session.conf
           dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose -- basic_connection
           # Test tokio support.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --tests -p zbus --no-default-features --features tokio -- --skip fdpass_systemd
+          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --tests -p zbus --no-default-features --features tokio-vsock -- --skip fdpass_systemd
           dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --doc --no-default-features connection::Connection::executor
 
   windows_test:


### PR DESCRIPTION
We currently don't have any tests that actually create a vsock socket but at least this tests the build and address parsing tests. Later if/when we add vsock tests, the CI will be ready for them.