### PR TITLE
✨ zv: do not ignore field-names of a{sv}-structs

### DIFF
--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -687,7 +687,14 @@ macro_rules! serialize_struct_named_fields {
             {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.serialize_field(key, value),
-                    StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Seq(ser) => match ser.ser.0.sig_parser.next_char()? {
+                        DICT_ENTRY_SIG_START_CHAR => {
+                            use ser::SerializeMap as _;
+                            ser.serialize_key(key)?;
+                            ser.serialize_value(value)
+                        }
+                        _ => ser.serialize_element(value),
+                    },
                 }
             }
 

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -774,7 +774,14 @@ macro_rules! serialize_struct_named_fields {
             {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.serialize_field(key, value),
-                    StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Seq(ser) => match ser.ser.0.sig_parser.next_char()? {
+                        DICT_ENTRY_SIG_START_CHAR => {
+                            use ser::SerializeMap as _;
+                            ser.serialize_key(key)?;
+                            ser.serialize_value(value)
+                        }
+                        _ => ser.serialize_element(value),
+                    },
                 }
             }
 


### PR DESCRIPTION
If `#[derive(Serialize)]` is used on a `struct`, serde will generate some code using `serialize_struct` to construct a `SerializeStruct`-object and calls its method `serialize_field` to serialise the fields. 

If a signature is set with `#[derive(Type)] #[zvariant(signature = "a{sv}")]` and e.g. the dbus-serialiser is used, its implementation of the trait-method `serialize_struct` will use the first character of the signature, which is `a`, and will return a `StructSeqSerializer::Seq`, for which the traits `SerializeStruct` and `SerializeStructVariant` are implemented. But these implementations implement `serialize_field` in a way, that will ignore the field names.

This would be fine for e.g. `av`, where structs are (de)serialised like tuples, but `a{sv}` should be (de)serialised as dictionaries.