### PR TITLE
🔨: introduce shell.nix and flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,101 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1705991032,
+        "narHash": "sha256-C+ePPXLMOxkJfJMqihUC1XbNr9Xy2F6BpWrmGDsgzXk=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "2189a3d994aaee6f83d3fc92deb13c458dd03dbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "main",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706035044,
+        "narHash": "sha256-Mjk20bVbCc0GyjHNXeWHgx7vvLnak7tyV9fEs9iWpo0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "edcff388a08f24b62dd09a27e86eb0c4313eb798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705864945,
+        "narHash": "sha256-ZATChFWHToTZQFLlzrzDUX8fjEbMHHBIyPaZU1JGmjI=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "d410d4a2baf9e99b37b03dd42f06238b14374bf7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Rust API for D-Bus communications";
+
+  inputs = {
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils/main";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+  };
+
+  outputs = { fenix, flake-utils, nixpkgs, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      rustToolchain = fenix.packages.${system}.complete.withComponents [
+        "cargo" "clippy" "rust-src" "rustc" "rustfmt"
+      ];
+    in
+    {
+      devShells.default = import ./shell.nix { inherit pkgs rustToolchain; };
+    }
+  );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {}
+, rustToolchain ? (
+    # Legacy Fallback
+    let
+      fenix = import (fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz") {};
+    in
+      fenix.complete.withComponents [
+        "cargo" "clippy" "rust-src" "rustc" "rustfmt"
+      ]
+  )
+, ...
+}:
+pkgs.mkShell {
+  name = "zbus";
+
+  nativeBuildInputs = with pkgs; [
+    glib
+    pkg-config
+    rustToolchain
+  ];
+}


### PR DESCRIPTION
`shell.nix` (for `nix-shell`) and `flake.nix` (e.g. for `nix develop`) makes developing under nix/NixOS easier as it automagically enforces a development-environment with every dependency included.

A simple `nix-shell` or `nix develop` is necessary before e.g. `cargo test` does not complain about missing dependencies or wrong version of rustc. In future PRs, [pre-commit-hooks.nix ](https://github.com/cachix/pre-commit-hooks.nix) could be introduced to add pre-commit-hooks e.g. for formatting, linting, spell-checking, etc., and more.