### PR TITLE
zb: Replace once_cell usage

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -44,7 +44,6 @@ zbus_names = { path = "../zbus_names", version = "3.0" }
 zbus_macros = { path = "../zbus_macros", version = "=4.0.0" }
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 derivative = "2.2"
-once_cell = "1.4.0"
 async-io = { version = "2.2.2", optional = true }
 futures-core = "0.3.25"
 futures-sink = "0.3.25"

--- a/zbus/src/utils.rs
+++ b/zbus/src/utils.rs
@@ -37,13 +37,14 @@ pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
 #[cfg(feature = "tokio")]
 #[doc(hidden)]
 pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
-    static TOKIO_RT: once_cell::sync::Lazy<tokio::runtime::Runtime> =
-        once_cell::sync::Lazy::new(|| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_io()
-                .enable_time()
-                .build()
-                .expect("launch of single-threaded tokio runtime")
-        });
-    TOKIO_RT.block_on(future)
+    use std::sync::OnceLock;
+    static TOKIO_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    let runtime = TOKIO_RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .expect("launch of single-threaded tokio runtime")
+    });
+    runtime.block_on(future)
 }


### PR DESCRIPTION
Replace the usage of OnceCell/Lazy from the once_cell crate with std types equivalents. The types were added before the current MSRV of zbus