### PR TITLE
📌 zb: Pin tokio to only its major version

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -65,7 +65,7 @@ static_assertions = "1.1.0"
 async-trait = "0.1.58"
 async-fs = { version = "2.0.0", optional = true }
 # FIXME: We should only enable process feature for Mac OS. See comment on async-process below for why we can't.
-tokio = { version = "1.21.2", optional = true, features = [
+tokio = { version = "1", optional = true, features = [
   "rt",
   "net",
   "time",


### PR DESCRIPTION
This allows it to be upgraded to any API-compatible versions. This implicitly also fixes a regression from e0c785a, where we ended up using API from a newer version of tokio than we depend on.