### PR TITLE
♻️  zb: Split Display impl of address::Transport

### DIFF
--- a/zbus/src/address/transport/autolaunch.rs
+++ b/zbus/src/address/transport/autolaunch.rs
@@ -7,6 +7,17 @@ pub struct Autolaunch {
     pub(super) scope: Option<AutolaunchScope>,
 }
 
+impl std::fmt::Display for Autolaunch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "autolaunch:")?;
+        if let Some(scope) = &self.scope {
+            write!(f, "scope={}", scope)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Autolaunch {
     /// Create a new autolaunch transport.
     pub fn new() -> Self {

--- a/zbus/src/address/transport/launchd.rs
+++ b/zbus/src/address/transport/launchd.rs
@@ -52,3 +52,9 @@ impl Launchd {
             })
     }
 }
+
+impl std::fmt::Display for Launchd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "launchd:env={}", self.env)
+    }
+}

--- a/zbus/src/address/transport/tcp.rs
+++ b/zbus/src/address/transport/tcp.rs
@@ -1,3 +1,4 @@
+use super::encode_percents;
 use crate::{Error, Result};
 #[cfg(not(feature = "tokio"))]
 use async_io::Async;
@@ -165,6 +166,35 @@ impl Tcp {
         TcpStream::connect((self.host(), self.port()))
             .await
             .map_err(|e| Error::InputOutput(e.into()))
+    }
+}
+
+impl Display for Tcp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.nonce_file() {
+            Some(nonce_file) => {
+                f.write_str("nonce-tcp:noncefile=")?;
+                encode_percents(f, nonce_file)?;
+                f.write_str(",")?;
+            }
+            None => f.write_str("tcp:")?,
+        }
+        f.write_str("host=")?;
+
+        encode_percents(f, self.host().as_bytes())?;
+
+        write!(f, ",port={}", self.port())?;
+
+        if let Some(bind) = self.bind() {
+            f.write_str(",bind=")?;
+            encode_percents(f, bind.as_bytes())?;
+        }
+
+        if let Some(family) = self.family() {
+            write!(f, ",family={family}")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/zbus/src/address/transport/vsock.rs
+++ b/zbus/src/address/transport/vsock.rs
@@ -41,3 +41,9 @@ impl Vsock {
         Ok(Self { cid, port })
     }
 }
+
+impl std::fmt::Display for Vsock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "vsock:cid={},port={}", self.cid, self.port)
+    }
+}


### PR DESCRIPTION
Let each transport impl have its own Display impl. This not only makes the code more readbable, but also makes it possible for users to display the transport types independently.