### PR TITLE
🩹 fix impl (Try)From for owning values

### DIFF
--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -92,7 +92,7 @@ impl<'g> TryFrom<Str<'g>> for Guid<'g> {
     }
 }
 
-impl TryFrom<String> for Guid<'static> {
+impl TryFrom<String> for Guid<'_> {
     type Error = crate::Error;
 
     fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
@@ -191,7 +191,7 @@ impl Borrow<str> for OwnedGuid {
     }
 }
 
-impl From<OwnedGuid> for Guid<'static> {
+impl From<OwnedGuid> for Guid<'_> {
     fn from(o: OwnedGuid) -> Self {
         o.0
     }
@@ -209,7 +209,7 @@ impl From<Guid<'_>> for OwnedGuid {
     }
 }
 
-impl From<OwnedGuid> for Str<'static> {
+impl From<OwnedGuid> for Str<'_> {
     fn from(value: OwnedGuid) -> Self {
         value.0 .0
     }

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -511,7 +511,7 @@ impl Deref for OwnedMatchRule {
     }
 }
 
-impl From<OwnedMatchRule> for MatchRule<'static> {
+impl From<OwnedMatchRule> for MatchRule<'_> {
     fn from(o: OwnedMatchRule) -> Self {
         o.into_inner()
     }

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -306,7 +306,7 @@ impl<'name> From<&BusName<'name>> for BusName<'name> {
     }
 }
 
-impl TryFrom<OwnedValue> for BusName<'static> {
+impl TryFrom<OwnedValue> for BusName<'_> {
     type Error = Error;
 
     fn try_from(value: OwnedValue) -> Result<Self> {
@@ -328,7 +328,7 @@ impl TryFrom<BusName<'static>> for OwnedValue {
     }
 }
 
-impl From<OwnedUniqueName> for BusName<'static> {
+impl From<OwnedUniqueName> for BusName<'_> {
     fn from(name: OwnedUniqueName) -> Self {
         BusName::Unique(name.into())
     }
@@ -340,7 +340,7 @@ impl<'a> From<&'a OwnedUniqueName> for BusName<'a> {
     }
 }
 
-impl From<OwnedWellKnownName> for BusName<'static> {
+impl From<OwnedWellKnownName> for BusName<'_> {
     fn from(name: OwnedWellKnownName) -> Self {
         BusName::WellKnown(name.into())
     }
@@ -405,7 +405,7 @@ impl Display for OwnedBusName {
     }
 }
 
-impl From<OwnedBusName> for BusName<'static> {
+impl From<OwnedBusName> for BusName<'_> {
     fn from(name: OwnedBusName) -> Self {
         name.into_inner()
     }
@@ -458,7 +458,7 @@ impl TryFrom<Value<'static>> for OwnedBusName {
     }
 }
 
-impl From<OwnedBusName> for Value<'static> {
+impl From<OwnedBusName> for Value<'_> {
     fn from(name: OwnedBusName) -> Self {
         name.0.into()
     }
@@ -480,7 +480,7 @@ impl TryFrom<OwnedBusName> for OwnedValue {
     }
 }
 
-impl From<OwnedBusName> for Str<'static> {
+impl From<OwnedBusName> for Str<'_> {
     fn from(value: OwnedBusName) -> Self {
         match value.0 {
             BusName::Unique(name) => name.into(),

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -277,7 +277,7 @@ impl Borrow<str> for OwnedErrorName {
     }
 }
 
-impl From<OwnedErrorName> for ErrorName<'static> {
+impl From<OwnedErrorName> for ErrorName<'_> {
     fn from(o: OwnedErrorName) -> Self {
         o.into_inner()
     }
@@ -295,7 +295,7 @@ impl From<ErrorName<'_>> for OwnedErrorName {
     }
 }
 
-impl From<OwnedErrorName> for Str<'static> {
+impl From<OwnedErrorName> for Str<'_> {
     fn from(value: OwnedErrorName) -> Self {
         value.into_inner().0
     }

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -275,7 +275,7 @@ impl Borrow<str> for OwnedInterfaceName {
     }
 }
 
-impl From<OwnedInterfaceName> for InterfaceName<'static> {
+impl From<OwnedInterfaceName> for InterfaceName<'_> {
     fn from(o: OwnedInterfaceName) -> Self {
         o.into_inner()
     }
@@ -293,7 +293,7 @@ impl From<InterfaceName<'_>> for OwnedInterfaceName {
     }
 }
 
-impl From<OwnedInterfaceName> for Str<'static> {
+impl From<OwnedInterfaceName> for Str<'_> {
     fn from(value: OwnedInterfaceName) -> Self {
         value.into_inner().0
     }

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -253,7 +253,7 @@ impl Borrow<str> for OwnedMemberName {
     }
 }
 
-impl From<OwnedMemberName> for MemberName<'static> {
+impl From<OwnedMemberName> for MemberName<'_> {
     fn from(o: OwnedMemberName) -> Self {
         o.into_inner()
     }
@@ -271,7 +271,7 @@ impl From<MemberName<'_>> for OwnedMemberName {
     }
 }
 
-impl From<OwnedMemberName> for Str<'static> {
+impl From<OwnedMemberName> for Str<'_> {
     fn from(value: OwnedMemberName) -> Self {
         value.into_inner().0
     }

--- a/zbus_names/src/property_name.rs
+++ b/zbus_names/src/property_name.rs
@@ -233,7 +233,7 @@ impl Borrow<str> for OwnedPropertyName {
     }
 }
 
-impl From<OwnedPropertyName> for PropertyName<'static> {
+impl From<OwnedPropertyName> for PropertyName<'_> {
     fn from(o: OwnedPropertyName) -> Self {
         o.into_inner()
     }
@@ -251,7 +251,7 @@ impl From<PropertyName<'_>> for OwnedPropertyName {
     }
 }
 
-impl From<OwnedPropertyName> for Str<'static> {
+impl From<OwnedPropertyName> for Str<'_> {
     fn from(value: OwnedPropertyName) -> Self {
         value.into_inner().0
     }

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -269,7 +269,7 @@ impl Borrow<str> for OwnedUniqueName {
     }
 }
 
-impl From<OwnedUniqueName> for UniqueName<'static> {
+impl From<OwnedUniqueName> for UniqueName<'_> {
     fn from(o: OwnedUniqueName) -> Self {
         o.into_inner()
     }
@@ -294,7 +294,7 @@ impl_try_from! {
     try_from: [&'s str, String, Arc<str>, Cow<'s, str>, Str<'s>],
 }
 
-impl From<OwnedUniqueName> for Str<'static> {
+impl From<OwnedUniqueName> for Str<'_> {
     fn from(value: OwnedUniqueName) -> Self {
         value.into_inner().0
     }

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -290,7 +290,7 @@ impl Display for OwnedWellKnownName {
     }
 }
 
-impl From<OwnedWellKnownName> for WellKnownName<'static> {
+impl From<OwnedWellKnownName> for WellKnownName<'_> {
     fn from(name: OwnedWellKnownName) -> Self {
         name.into_inner()
     }
@@ -315,7 +315,7 @@ impl_try_from! {
     try_from: [&'s str, String, Arc<str>, Cow<'s, str>, Str<'s>],
 }
 
-impl From<OwnedWellKnownName> for Str<'static> {
+impl From<OwnedWellKnownName> for Str<'_> {
     fn from(value: OwnedWellKnownName) -> Self {
         value.into_inner().0
     }

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -42,13 +42,13 @@ impl<'f> From<BorrowedFd<'f>> for Fd<'f> {
     }
 }
 
-impl From<fd::OwnedFd> for Fd<'static> {
+impl From<fd::OwnedFd> for Fd<'_> {
     fn from(fd: fd::OwnedFd) -> Self {
         Self::Owned(fd)
     }
 }
 
-impl From<OwnedFd> for Fd<'static> {
+impl From<OwnedFd> for Fd<'_> {
     fn from(owned: OwnedFd) -> Self {
         owned.inner
     }

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -79,7 +79,7 @@ into_value!(Fd<'a>, Fd);
 #[cfg(unix)]
 try_into_value_from_ref!(Fd<'a>, Fd);
 
-impl From<String> for Value<'static> {
+impl From<String> for Value<'_> {
     fn from(v: String) -> Self {
         Value::Str(crate::Str::from(v))
     }

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -335,7 +335,7 @@ impl std::convert::From<OwnedObjectPath> for ObjectPath<'static> {
     }
 }
 
-impl std::convert::From<OwnedObjectPath> for crate::Value<'static> {
+impl std::convert::From<OwnedObjectPath> for crate::Value<'_> {
     fn from(o: OwnedObjectPath) -> Self {
         o.into_inner().into()
     }

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -247,8 +247,8 @@ try_to_value!(Structure<'a>);
 #[cfg(unix)]
 try_to_value!(Fd<'a>);
 
-impl From<OwnedValue> for Value<'static> {
-    fn from(v: OwnedValue) -> Value<'static> {
+impl From<OwnedValue> for Value<'_> {
+    fn from(v: OwnedValue) -> Self {
         v.into_inner()
     }
 }


### PR DESCRIPTION
When trying to implement the builder pattern working with `zvariant::Value` arguments, I encountered a strange compiler error about lifetimes when using generic functions.

The following simplified code shows the problem, with comments explaining the error encountered (functions `fail1`, `fail2`).

```rust
use zbus::zvariant;

/// A simplified builder to focus on the compile problem.
pub struct Values<'a> {
    values: Vec<zvariant::Value<'a>>,
}

impl<'a> Values<'a> {
    pub fn new() -> Self {
        Self { values: Vec::new() }
    }

    /// Adds a value.
    /// 
    /// Accepts anything than can be converted into a `zvariant::Value` with
    /// a sufficient lifetime.
    pub fn value<V>(mut self, value: V) -> Self
    where
        V: Into<zvariant::Value<'a>>,
    {
        self.values.push(value.into());
        self
    }
}

// Using explicit lifetimes to show eliding is not a problem.

// As expected, this compiles just fine.
pub fn ok1<'a>(value1: &'a str) -> Values<'a> {
    Values::new().value(value1)
}

// Surprisingly this fails to compile.
// The compiler claims that "`'a` must outlive `'static`".
pub fn fail1<'a>(value1: &'a str) -> Values<'a> {
    Values::new().value(value1).value("owned value".to_string())
}

// This fails to compile too.
pub fn fail2<'a>(value1: &'a str) -> Values<'a> {
    let value2: String = "owned value".to_string();
    Values::new().value(value1).value(value2)
}

// Explicitly converting into a `zvariant::Value` works, though.
pub fn ok2<'a>(value1: &'a str) -> Values<'a> {
    let value2: zvariant::Value<'a> = "owned value".to_string().into();
    Values::new().value(value1).value(value2)
}

// It works also when using a `static` lifetime.
pub fn ok3<'a>(value1: &'a str) -> Values<'a> {
    let value2: zvariant::Value<'static> = "owned value".to_string().into();
    Values::new().value(value1).value(value2)
}

fn main() {
    println!("DONE");
}

```

Looking at zbus source code I noticed that `From<String>` is implemented for static lifetime only for `zvariant::Value`,
in contrast to e.g. `zvariant::Str` where it is implemented for all lifetimes.
When relying on the compiler to derive types (as in function `fail1`), this seems to make it think lifetimes need to be static.
Implementing `From<String>` for all lifetimes (as already is the case for `zvariant::Str`) fixes this problem.

I noticed that other owning types have also implementations of `From` and `TryFrom` limited to static lifetime, but wanted to keep the changes small.
If you think they are correct, I'm willing to look for other `impl`s needing an update.
