### PR TITLE
🚩 zb: Add `bus-impl` cargo feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,4 +255,4 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Check documentation build
-        run: cargo doc
+        run: cargo doc --all-features

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -20,6 +20,8 @@ time = ["zvariant/time"]
 chrono = ["zvariant/chrono"]
 # Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
 option-as-array = ["zvariant/option-as-array"]
+# Enables API that is only needed for bus implementations.
+bus-impl = []
 windows-gdbus = []
 async-io = [
   "dep:async-io",

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -13,13 +13,8 @@ use uds_windows::UnixStream;
 use zvariant::{ObjectPath, Str};
 
 use crate::{
-    address::Address,
-    blocking::Connection,
-    connection::socket::BoxedSplit,
-    names::{UniqueName, WellKnownName},
-    object_server::Interface,
-    utils::block_on,
-    AuthMechanism, Error, Guid, Result,
+    address::Address, blocking::Connection, connection::socket::BoxedSplit, names::WellKnownName,
+    object_server::Interface, utils::block_on, AuthMechanism, Error, Guid, Result,
 };
 
 /// A builder for [`zbus::blocking::Connection`].
@@ -177,15 +172,18 @@ impl<'a> Builder<'a> {
 
     /// Sets the unique name of the connection.
     ///
+    /// This method is only available when the `bus-impl` feature is enabled.
+    ///
     /// # Panics
     ///
     /// This method panics if the to-be-created connection is not a peer-to-peer connection.
     /// It will always panic if the connection is to a message bus as it's the bus that assigns
     /// peers their unique names. This is mainly provided for bus implementations. All other users
     /// should not need to use this method.
+    #[cfg(feature = "bus-impl")]
     pub fn unique_name<U>(self, unique_name: U) -> Result<Self>
     where
-        U: TryInto<UniqueName<'a>>,
+        U: TryInto<crate::names::UniqueName<'a>>,
         U::Error: Into<Error>,
     {
         self.0.unique_name(unique_name).map(Self)

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -793,11 +793,14 @@ impl Connection {
 
     /// Sets the unique name of the connection (if not already set).
     ///
+    /// This method is only available when the `bus-impl` feature is enabled.
+    ///
     /// # Panics
     ///
     /// This method panics if the unique name is already set. It will always panic if the connection
     /// is to a message bus as it's the bus that assigns peers their unique names. This is mainly
     /// provided for bus implementations. All other users should not need to use this method.
+    #[cfg(feature = "bus-impl")]
     pub fn set_unique_name<U>(&self, unique_name: U) -> Result<()>
     where
         U: TryInto<OwnedUniqueName>,


### PR DESCRIPTION
API that is only needed by bus implementations now gated behind this non-default cargo feature.

Fixes #480.