### PR TITLE
⬆️  Bump to async-broadcast 0.7.0

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -54,7 +54,7 @@ futures-util = { version = "0.3.25", default-features = false, features = [
   "std",
 ] }
 async-lock = { version = "3.0.0", optional = true }
-async-broadcast = "0.6.0"
+async-broadcast = "0.7.0"
 async-executor = { version = "1.5.0", optional = true }
 blocking = { version = "1.0.2", optional = true }
 async-task = { version = "4.3.0", optional = true }


### PR DESCRIPTION
This is needed to eventually only use a single version of event-listener crate.