### PR TITLE
🚩 zb: Gate all p2p API behind a `p2p` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,13 +74,18 @@ jobs:
           sed -e s/UID/$UID/ -e s/PATH/abstract/ CI/dbus-session.conf > /tmp/dbus-session-abstract.conf
           dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo test --verbose -- basic_connection
           # All features except tokio.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --features uuid,url,time,chrono,option-as-array,vsock -- --skip fdpass_systemd
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo test --verbose --features uuid,url,time,chrono,option-as-array,vsock \
+              -- --skip fdpass_systemd
           # check cookie-sha1 auth against dbus-daemon
           sed -i s/EXTERNAL/DBUS_COOKIE_SHA1/g /tmp/dbus-session.conf
           dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose -- basic_connection
           # Test tokio support.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --tests -p zbus --no-default-features --features tokio-vsock -- --skip fdpass_systemd
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo test --verbose --doc --no-default-features connection::Connection::executor
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo test --verbose --tests -p zbus --no-default-features \
+              --features tokio-vsock -- --skip fdpass_systemd
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo test --verbose --doc --no-default-features connection::Connection::executor
 
   windows_test:
     runs-on: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
           dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo test --verbose -- basic_connection
           # All features except tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo test --verbose --features uuid,url,time,chrono,option-as-array,vsock \
+            cargo test --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
               -- --skip fdpass_systemd
           # check cookie-sha1 auth against dbus-daemon
           sed -i s/EXTERNAL/DBUS_COOKIE_SHA1/g /tmp/dbus-session.conf

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -67,6 +67,9 @@ let (client_conn, server_conn) = futures_util::try_join!(
 # }
 ```
 
+**Note:** the `p2p` and `server` methods of `connection::Builder` are only available when `p2p`
+cargo feature of `zbus` is enabled.
+
 [NetworkManager]: https://developer.gnome.org/NetworkManager/stable/spec.html
 [BlueZ]: https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc
 [PID1]: https://www.freedesktop.org/wiki/Software/systemd/dbus/

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -20,8 +20,10 @@ time = ["zvariant/time"]
 chrono = ["zvariant/chrono"]
 # Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
 option-as-array = ["zvariant/option-as-array"]
-# Enables API that is only needed for bus implementations.
-bus-impl = []
+# Enables API that is only needed for bus implementations (enables `p2p`).
+bus-impl = ["p2p"]
+# Enables API that is only needed for peer-to-peer (p2p) connections.
+p2p = []
 windows-gdbus = []
 async-io = [
   "dep:async-io",

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -12,9 +12,11 @@ use uds_windows::UnixStream;
 
 use zvariant::{ObjectPath, Str};
 
+#[cfg(feature = "p2p")]
+use crate::Guid;
 use crate::{
     address::Address, blocking::Connection, connection::socket::BoxedSplit, names::WellKnownName,
-    object_server::Interface, utils::block_on, AuthMechanism, Error, Guid, Result,
+    object_server::Interface, utils::block_on, AuthMechanism, Error, Result,
 };
 
 /// A builder for [`zbus::blocking::Connection`].
@@ -102,6 +104,9 @@ impl<'a> Builder<'a> {
     }
 
     /// The to-be-created connection will be a peer-to-peer connection.
+    ///
+    /// This method is only available when the `p2p` feature is enabled.
+    #[cfg(feature = "p2p")]
     pub fn p2p(self) -> Self {
         Self(self.0.p2p())
     }
@@ -110,6 +115,9 @@ impl<'a> Builder<'a> {
     ///
     /// The to-be-created connection will wait for incoming client authentication handshake and
     /// negotiation messages, for peer-to-peer communications after successful creation.
+    ///
+    /// This method is only available when the `p2p` feature is enabled.
+    #[cfg(feature = "p2p")]
     pub fn server<G>(self, guid: G) -> Result<Self>
     where
         G: TryInto<Guid<'a>>,

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -271,6 +271,7 @@ impl From<crate::Connection> for Connection {
     }
 }
 
+#[cfg(feature = "p2p")]
 #[cfg(all(test, unix))]
 mod tests {
     use event_listener::Listener;

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -23,12 +23,14 @@ use vsock::VsockStream;
 
 use zvariant::{ObjectPath, Str};
 
+#[cfg(feature = "p2p")]
+use crate::Guid;
 use crate::{
     address::{self, Address},
     async_lock::RwLock,
     names::{InterfaceName, WellKnownName},
     object_server::Interface,
-    Connection, Error, Executor, Guid, OwnedGuid, Result,
+    Connection, Error, Executor, OwnedGuid, Result,
 };
 
 use super::{
@@ -61,8 +63,10 @@ type Interfaces<'a> =
 pub struct Builder<'a> {
     target: Option<Target>,
     max_queued: Option<usize>,
-    // This is only set for server case.
+    // This is only set for p2p server case.
+    #[cfg(feature = "p2p")]
     guid: Option<Guid<'a>>,
+    #[cfg(feature = "p2p")]
     p2p: bool,
     internal_executor: bool,
     #[derivative(Debug = "ignore")]
@@ -204,6 +208,9 @@ impl<'a> Builder<'a> {
     }
 
     /// The to-be-created connection will be a peer-to-peer connection.
+    ///
+    /// This method is only available when the `p2p` feature is enabled.
+    #[cfg(feature = "p2p")]
     pub fn p2p(mut self) -> Self {
         self.p2p = true;
 
@@ -214,6 +221,9 @@ impl<'a> Builder<'a> {
     ///
     /// The to-be-created connection will wait for incoming client authentication handshake and
     /// negotiation messages, for peer-to-peer communications after successful creation.
+    ///
+    /// This method is only available when the `p2p` feature is enabled.
+    #[cfg(feature = "p2p")]
     pub fn server<G>(mut self, guid: G) -> Result<Self>
     where
         G: TryInto<Guid<'a>>,
@@ -346,7 +356,9 @@ impl<'a> Builder<'a> {
     }
 
     async fn build_(mut self, executor: Executor<'static>) -> Result<Connection> {
+        #[allow(unused_mut)]
         let (mut stream, server_guid) = self.target_connect().await?;
+        #[cfg(feature = "p2p")]
         let mut auth = match self.guid {
             None => {
                 // SASL Handshake
@@ -377,11 +389,19 @@ impl<'a> Builder<'a> {
                 .await?
             }
         };
+
+        #[cfg(not(feature = "p2p"))]
+        let mut auth = Authenticated::client(stream, server_guid, self.auth_mechanisms).await?;
+
         // SAFETY: `Authenticated` is always built with these fields set to `Some`.
         let socket_read = auth.socket_read.take().unwrap();
         let already_received_bytes = auth.already_received_bytes.take().unwrap();
 
-        let mut conn = Connection::new(auth, !self.p2p, executor).await?;
+        #[cfg(feature = "p2p")]
+        let is_bus_conn = !self.p2p;
+        #[cfg(not(feature = "p2p"))]
+        let is_bus_conn = true;
+        let mut conn = Connection::new(auth, is_bus_conn, executor).await?;
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));
         #[cfg(feature = "bus-impl")]
         if let Some(unique_name) = self.unique_name {
@@ -413,7 +433,7 @@ impl<'a> Builder<'a> {
         // Start the socket reader task.
         conn.init_socket_reader(socket_read, already_received_bytes);
 
-        if !self.p2p {
+        if is_bus_conn {
             // Now that the server has approved us, we must send the bus Hello, as per specs
             conn.hello_bus().await?;
         }
@@ -441,8 +461,10 @@ impl<'a> Builder<'a> {
     fn new(target: Target) -> Self {
         Self {
             target: Some(target),
+            #[cfg(feature = "p2p")]
             p2p: false,
             max_queued: None,
+            #[cfg(feature = "p2p")]
             guid: None,
             internal_executor: true,
             interfaces: HashMap::new(),

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -304,14 +304,13 @@ impl<'a> Builder<'a> {
 
     /// Sets the unique name of the connection.
     ///
-    /// This method is only available when the `bus-impl` feature is enabled.
+    /// This is mainly provided for bus implementations. All other users should not need to use this
+    /// method. Hence why this method is only available when the `bus-impl` feature is enabled.
     ///
     /// # Panics
     ///
-    /// This method panics if the to-be-created connection is not a peer-to-peer connection.
-    /// It will always panic if the connection is to a message bus as it's the bus that assigns
-    /// peers their unique names. This is mainly provided for bus implementations. All other users
-    /// should not need to use this method.
+    /// It will panic if the connection is to a message bus as it's the bus that assigns
+    /// peers their unique names.
     #[cfg(feature = "bus-impl")]
     pub fn unique_name<U>(mut self, unique_name: U) -> Result<Self>
     where

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -76,6 +76,7 @@ impl Authenticated {
     /// Create a server-side `Authenticated` for the given `socket`.
     ///
     /// The function takes `client_uid` on Unix only. On Windows, it takes `client_sid` instead.
+    #[cfg(feature = "p2p")]
     pub async fn server(
         socket: BoxedSplit,
         guid: OwnedGuid,
@@ -351,6 +352,7 @@ impl Cookie {
             .ok_or_else(|| Error::Handshake(format!("DBus cookie ID {id} not found")))
     }
 
+    #[cfg(feature = "p2p")]
     async fn first(context: &CookieContext<'_>) -> Result<Cookie> {
         let keyring = Self::read_keyring(context).await?;
         keyring
@@ -527,6 +529,7 @@ impl Handshake for ClientHandshake {
  * Server-side handshake logic
  */
 
+#[cfg(feature = "p2p")]
 #[derive(Debug)]
 #[allow(clippy::upper_case_acronyms)]
 enum ServerHandshakeStep {
@@ -553,6 +556,7 @@ enum ServerHandshakeStep {
 /// [`Authenticated`]: struct.Authenticated.html
 /// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
+#[cfg(feature = "p2p")]
 pub struct ServerHandshake<'s> {
     common: HandshakeCommon,
     step: ServerHandshakeStep,
@@ -565,6 +569,7 @@ pub struct ServerHandshake<'s> {
     cookie_context: CookieContext<'s>,
 }
 
+#[cfg(feature = "p2p")]
 impl<'s> ServerHandshake<'s> {
     pub fn new(
         socket: BoxedSplit,
@@ -700,6 +705,7 @@ impl<'s> ServerHandshake<'s> {
     }
 }
 
+#[cfg(feature = "p2p")]
 #[async_trait]
 impl Handshake for ServerHandshake<'_> {
     #[instrument(skip(self))]
@@ -1027,6 +1033,7 @@ impl HandshakeCommon {
     }
 }
 
+#[cfg(feature = "p2p")]
 #[cfg(unix)]
 #[cfg(test)]
 mod tests {

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -53,6 +53,7 @@ pub(crate) struct ConnectionInner {
     server_guid: OwnedGuid,
     #[cfg(unix)]
     cap_unix_fd: bool,
+    #[cfg(feature = "p2p")]
     bus_conn: bool,
     unique_name: OnceLock<OwnedUniqueName>,
     registered_names: Mutex<HashMap<WellKnownName<'static>, NameStatus>>,
@@ -778,9 +779,17 @@ impl Connection {
 
     /// Checks if `self` is a connection to a message bus.
     ///
-    /// This will return `false` for p2p connections.
+    /// This will return `false` for p2p connections. When the `p2p` feature is enabled, this will
+    /// always return `true`.
     pub fn is_bus(&self) -> bool {
-        self.inner.bus_conn
+        #[cfg(feature = "p2p")]
+        {
+            self.inner.bus_conn
+        }
+        #[cfg(not(feature = "p2p"))]
+        {
+            true
+        }
     }
 
     /// The unique name of the connection, if set/applicable.
@@ -1144,7 +1153,7 @@ impl Connection {
 
     pub(crate) async fn new(
         auth: Authenticated,
-        bus_connection: bool,
+        #[allow(unused)] bus_connection: bool,
         executor: Executor<'static>,
     ) -> Result<Self> {
         #[cfg(unix)]
@@ -1184,6 +1193,7 @@ impl Connection {
                 server_guid: auth.server_guid,
                 #[cfg(unix)]
                 cap_unix_fd,
+                #[cfg(feature = "p2p")]
                 bus_conn: bus_connection,
                 unique_name: OnceLock::new(),
                 subscriptions,
@@ -1307,12 +1317,87 @@ enum NameStatus {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::fdo::DBusProxy;
+    use ntest::timeout;
+    use test_log::test;
+
+    #[cfg(all(windows, feature = "windows-gdbus"))]
+    #[test]
+    fn connect_gdbus_session_bus() {
+        let addr = crate::win32::windows_autolaunch_bus_address()
+            .expect("Unable to get GDBus session bus address");
+
+        crate::block_on(async { addr.connect().await }).expect("Unable to connect to session bus");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn connect_launchd_session_bus() {
+        use crate::address::{transport::Launchd, Address, Transport};
+        crate::block_on(async {
+            let addr = Address::from(Transport::Launchd(Launchd::new(
+                "DBUS_LAUNCHD_SESSION_BUS_SOCKET",
+            )));
+            addr.connect().await
+        })
+        .expect("Unable to connect to session bus");
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn disconnect_on_drop() {
+        // Reproducer for https://github.com/dbus2/zbus/issues/308 where setting up the
+        // objectserver would cause the connection to not disconnect on drop.
+        crate::utils::block_on(test_disconnect_on_drop());
+    }
+
+    async fn test_disconnect_on_drop() {
+        #[derive(Default)]
+        struct MyInterface {}
+
+        #[crate::interface(name = "dev.peelz.FooBar.Baz")]
+        impl MyInterface {
+            fn do_thing(&self) {}
+        }
+        let name = "dev.peelz.foobar";
+        let connection = Builder::session()
+            .unwrap()
+            .name(name)
+            .unwrap()
+            .serve_at("/dev/peelz/FooBar", MyInterface::default())
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        let connection2 = Connection::session().await.unwrap();
+        let dbus = DBusProxy::new(&connection2).await.unwrap();
+        let mut stream = dbus
+            .receive_name_owner_changed_with_args(&[(0, name), (2, "")])
+            .await
+            .unwrap();
+
+        drop(connection);
+
+        // If the connection is not dropped, this will hang forever.
+        stream.next().await.unwrap();
+
+        // Let's still make sure the name is gone.
+        let name_has_owner = dbus.name_has_owner(name.try_into().unwrap()).await.unwrap();
+        assert!(!name_has_owner);
+    }
+}
+
+#[cfg(feature = "p2p")]
+#[cfg(test)]
+mod p2p_tests {
     use futures_util::stream::TryStreamExt;
     use ntest::timeout;
     use test_log::test;
     use zvariant::{Endian, NATIVE_ENDIAN};
 
-    use crate::{fdo::DBusProxy, AuthMechanism, Guid};
+    use crate::{AuthMechanism, Guid};
 
     use super::*;
 
@@ -1552,73 +1637,6 @@ mod tests {
             Builder::vsock_stream(client).p2p().build(),
         )
     }
-
-    #[cfg(all(windows, feature = "windows-gdbus"))]
-    #[test]
-    fn connect_gdbus_session_bus() {
-        let addr = crate::win32::windows_autolaunch_bus_address()
-            .expect("Unable to get GDBus session bus address");
-
-        crate::block_on(async { addr.connect().await }).expect("Unable to connect to session bus");
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn connect_launchd_session_bus() {
-        use crate::address::{transport::Launchd, Address, Transport};
-        crate::block_on(async {
-            let addr = Address::from(Transport::Launchd(Launchd::new(
-                "DBUS_LAUNCHD_SESSION_BUS_SOCKET",
-            )));
-            addr.connect().await
-        })
-        .expect("Unable to connect to session bus");
-    }
-
-    #[test]
-    #[timeout(15000)]
-    fn disconnect_on_drop() {
-        // Reproducer for https://github.com/dbus2/zbus/issues/308 where setting up the
-        // objectserver would cause the connection to not disconnect on drop.
-        crate::utils::block_on(test_disconnect_on_drop());
-    }
-
-    async fn test_disconnect_on_drop() {
-        #[derive(Default)]
-        struct MyInterface {}
-
-        #[crate::interface(name = "dev.peelz.FooBar.Baz")]
-        impl MyInterface {
-            fn do_thing(&self) {}
-        }
-        let name = "dev.peelz.foobar";
-        let connection = Builder::session()
-            .unwrap()
-            .name(name)
-            .unwrap()
-            .serve_at("/dev/peelz/FooBar", MyInterface::default())
-            .unwrap()
-            .build()
-            .await
-            .unwrap();
-
-        let connection2 = Connection::session().await.unwrap();
-        let dbus = DBusProxy::new(&connection2).await.unwrap();
-        let mut stream = dbus
-            .receive_name_owner_changed_with_args(&[(0, name), (2, "")])
-            .await
-            .unwrap();
-
-        drop(connection);
-
-        // If the connection is not dropped, this will hang forever.
-        stream.next().await.unwrap();
-
-        // Let's still make sure the name is gone.
-        let name_has_owner = dbus.name_has_owner(name.try_into().unwrap()).await.unwrap();
-        assert!(!name_has_owner);
-    }
-
     #[cfg(any(unix, not(feature = "tokio")))]
     #[test]
     #[timeout(15000)]

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -793,13 +793,13 @@ impl Connection {
 
     /// Sets the unique name of the connection (if not already set).
     ///
-    /// This method is only available when the `bus-impl` feature is enabled.
+    /// This is mainly provided for bus implementations. All other users should not need to use this
+    /// method. Hence why this method is only available when the `bus-impl` feature is enabled.
     ///
     /// # Panics
     ///
     /// This method panics if the unique name is already set. It will always panic if the connection
-    /// is to a message bus as it's the bus that assigns peers their unique names. This is mainly
-    /// provided for bus implementations. All other users should not need to use this method.
+    /// is to a message bus as it's the bus that assigns peers their unique names.
     #[cfg(feature = "bus-impl")]
     pub fn set_unique_name<U>(&self, unique_name: U) -> Result<()>
     where

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -15,6 +15,8 @@ mod doctests {
     // Book markdown checks
     doc_comment::doctest!("../../book/src/client.md");
     doc_comment::doctest!("../../book/src/concepts.md");
+    // The connection chapter contains a p2p example.
+    #[cfg(feature = "p2p")]
     doc_comment::doctest!("../../book/src/connection.md");
     doc_comment::doctest!("../../book/src/contributors.md");
     doc_comment::doctest!("../../book/src/introduction.md");
@@ -934,7 +936,7 @@ mod tests {
 
     #[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
     // Issue specific to tokio runtime.
-    #[cfg(all(unix, feature = "tokio"))]
+    #[cfg(all(unix, feature = "tokio", feature = "p2p"))]
     #[instrument]
     async fn issue_279() {
         // On failure to read from the socket, we were closing the error channel from the sender


### PR DESCRIPTION
Given that typical users do not need this API, we don't enable it by default.