### PR TITLE
🚩 zb: Enable required feature flags of windows-sys crate

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -89,6 +89,9 @@ windows-sys = { version = "0.52", features = [
   "Win32_Foundation",
   "Win32_Security_Authorization",
   "Win32_System_Memory",
+  "Win32_Networking",
+  "Win32_NetworkManagement",
+  "Win32_System_Threading",
 ] }
 uds_windows = "1.1.0"
 


### PR DESCRIPTION
Not sure what enables these features for us in the CI and our Windows build doesn't seem to be failing but busd port picked it up:

https://github.com/dbus2/busd/actions/runs/7845734969/job/21410861140?pr=37#step:5:220