### PR TITLE
🚩 zb: Enable more required feature flags of windows-sys crate

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -90,7 +90,9 @@ windows-sys = { version = "0.52", features = [
   "Win32_Security_Authorization",
   "Win32_System_Memory",
   "Win32_Networking",
+  "Win32_Networking_WinSock",
   "Win32_NetworkManagement",
+  "Win32_NetworkManagement_IpHelper",
   "Win32_System_Threading",
 ] }
 uds_windows = "1.1.0"


### PR DESCRIPTION
We missed a few in 99cc738087306278b0e25eb9fa1751df16c3d6bd:

https://github.com/dbus2/busd/actions/runs/7846105163/job/21412035383?pr=37#step:5:220