### PR TITLE
📝book: update zbus_polkit link

### DIFF
--- a/book/src/client.md
+++ b/book/src/client.md
@@ -605,7 +605,7 @@ trait Notifications {
 ```
 
 You can learn more from the zbus-ify [binding of
-PolicyKit](https://github.com/dbus2/zbus/tree/main/zbus_polkit#readme), for example, which was
+PolicyKit](https://github.com/dbus2/zbus_polkit), for example, which was
 implemented starting from the *xmlgen* output.
 
 There you have it, a Rust-friendly binding for your D-Bus service!


### PR DESCRIPTION
Updates the [zbus_polkit](https://github.com/dbus2/zbus_polkit) link in the book, since the code has been moved in https://github.com/dbus2/zbus/pull/419. The [crates.io](https://crates.io/crates/zbus_polkit) pages also still point to this repository.