### PR TITLE
💩 CI: Run Windows tests against nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -188,7 +188,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Test
         run: |

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -359,7 +359,7 @@ static SERIAL_NUM: AtomicU32 = AtomicU32::new(1);
 mod tests {
     use crate::message::{Field, Fields, Header, PrimaryHeader, Type};
 
-    use std::{error::Error, result::Result};
+    use std::error::Error;
     use test_log::test;
     use zbus_names::{InterfaceName, MemberName};
     use zvariant::{ObjectPath, Signature};

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1342,9 +1342,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        connection, interface, object_server::SignalContext, proxy, utils::block_on, AsyncDrop,
-    };
+    use crate::{connection, interface, object_server::SignalContext, proxy, utils::block_on};
     use futures_util::StreamExt;
     use ntest::timeout;
     use test_log::test;


### PR DESCRIPTION
This is mainly meant to reproduce xmlgen test failing on Windows against nightly.