### PR TITLE
🚩 zb: Disable UDS support on Windows for tokio

### DIFF
--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -7,7 +7,7 @@ use std::os::unix::net::UnixStream;
 use tokio::net::TcpStream;
 #[cfg(all(unix, feature = "tokio"))]
 use tokio::net::UnixStream;
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "tokio")))]
 use uds_windows::UnixStream;
 
 use zvariant::{ObjectPath, Str};
@@ -53,6 +53,12 @@ impl<'a> Builder<'a> {
     /// If the default `async-io` feature is disabled, this method will expect
     /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html)
     /// argument.
+    ///
+    /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
+    /// is not available when the `tokio` feature is enabled and building for Windows target.
+    ///
+    /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
+    #[cfg(any(unix, not(feature = "tokio")))]
     pub fn unix_stream(stream: UnixStream) -> Self {
         Self(crate::connection::Builder::unix_stream(stream))
     }


### PR DESCRIPTION
Since tokio currently [does not support Unix domain sockets on Windows][tuds], there is no reason to enable UDS support on Windows+tokio. This also fixes a build warning against rust nightly:

```rust
error: field `0` is never read
  --> zbus\src\connection\builder.rs:45:16
   |
45 |     UnixStream(UnixStream),
   |     ---------- ^^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
45 |     UnixStream(()),
   |                ~~
```

[tuds]: https://github.com/tokio-rs/tokio/issues/2201