### PR TITLE
🐛zx: correctly check if fdo ifaces is empty

### DIFF
--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .cloned()
         .partition(|i| i.name().starts_with(fdo_iface_prefix));
 
-    if !fdo_iface_prefix.is_empty() {
+    if !fdo_standard_ifaces.is_empty() {
         eprintln!("Skipping `org.freedesktop.DBus` interfaces, please use https://docs.rs/zbus/latest/zbus/fdo/index.html")
     }
 


### PR DESCRIPTION
Fixes an issue where instead of checking if `fdo_standard_ifaces` was empty, it was accidentally checked if the prefix string was empty. Found by (and thanks to) @Cobinja in https://github.com/dbus2/zbus/commit/35c15c8d9e8e730dee6bdbfa6997cd7d83a8f738#r138622943.

I totally blame clippy for not having a lint against this :)