### PR TITLE
zvariant: Fix compilation of gvariant feature on non-unix platforms

### DIFF
--- a/zvariant/src/serialized/data.rs
+++ b/zvariant/src/serialized/data.rs
@@ -304,11 +304,7 @@ impl<'bytes, 'fds> Data<'bytes, 'fds> {
                 }
                 #[cfg(not(unix))]
                 {
-                    crate::gvariant::Deserializer::<_, ()>::new(
-                        self.bytes(),
-                        signature,
-                        self.context,
-                    )
+                    crate::gvariant::Deserializer::new(self.bytes(), signature, self.context)
                 }
             }
             .map(Deserializer::GVariant)?,


### PR DESCRIPTION
This would fail compilation on eg. windows because the FD generic does not actually exist there.

Reproduce via `cargo build --features="gvariant" --target=x86_64-pc-windows-gnu`