### PR TITLE
📌 zm,zd: Unpin zvariant_utils version in Cargo.toml files

### DIFF
--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -25,7 +25,7 @@ syn = { version = "1.0.109", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.35"
 proc-macro-crate = "3.1.0"
 regex = "1.10.3"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.1.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "1.1.0" }
 
 [dev-dependencies]
 zbus = { path = "../zbus" }

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0"
 syn = { version = "1.0.109", features = ["extra-traits", "full"] }
 quote = "1.0.35"
 proc-macro-crate = "3.1.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.1.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "1.1.0" }
 
 [dev-dependencies]
 zvariant = { path = "../zvariant", features = ["enumflags2"] }


### PR DESCRIPTION
Otherwise, it breaks the build for folks who happen to have both zbus 3 and 4 in their dependency tree.

Fixes #652.