### PR TITLE
🚀 CI: Only publish book changes for 4.x releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deployments
 on:
   push:
     tags:
-      - zbus-*
+      - zbus-4.*
     paths:
       - book/**/*
       - .github/workflows/deploy.yml


### PR DESCRIPTION
We don't want any 3.x releases to overwrite the book.