### PR TITLE
⚡️ zv,internal: Make use of serde_bytes for byte arrays

### DIFF
--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -198,9 +198,9 @@ impl<'a> Proxy<'a> {
     /// Set the property `property_name`.
     ///
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
-    pub fn set_property<'t, T: 't>(&self, property_name: &str, value: T) -> fdo::Result<()>
+    pub fn set_property<'t, T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: Into<Value<'t>>,
+        T: 't + Into<Value<'t>>,
     {
         block_on(self.inner().set_property(property_name, value))
     }

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -794,9 +794,9 @@ impl<'a> Proxy<'a> {
     /// Set the property `property_name`.
     ///
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
-    pub async fn set_property<'t, T: 't>(&self, property_name: &str, value: T) -> fdo::Result<()>
+    pub async fn set_property<'t, T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: Into<Value<'t>>,
+        T: 't + Into<Value<'t>>,
     {
         self.properties_proxy()
             .set(self.inner.interface.as_ref(), property_name, &value.into())

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -47,9 +47,9 @@ impl Seek for NullWriteSeek {
 /// let len = serialized_size(ctxt, &("hello world!", 42_u64)).unwrap();
 /// assert_eq!(*len, 32);
 /// ```
-pub fn serialized_size<T: ?Sized>(ctxt: Context, value: &T) -> Result<Size>
+pub fn serialized_size<T>(ctxt: Context, value: &T) -> Result<Size>
 where
-    T: Serialize + DynamicType,
+    T: ?Sized + Serialize + DynamicType,
 {
     let mut null = NullWriteSeek;
     let signature = value.dynamic_signature();
@@ -119,10 +119,10 @@ where
 /// hence is safe to drop.
 ///
 /// [`to_writer_fds`]: fn.to_writer_fds.html
-pub unsafe fn to_writer<W, T: ?Sized>(writer: &mut W, ctxt: Context, value: &T) -> Result<Written>
+pub unsafe fn to_writer<W, T>(writer: &mut W, ctxt: Context, value: &T) -> Result<Written>
 where
     W: Write + Seek,
-    T: Serialize + DynamicType,
+    T: ?Sized + Serialize + DynamicType,
 {
     let signature = value.dynamic_signature();
 
@@ -132,9 +132,9 @@ where
 /// Serialize `T` as a byte vector.
 ///
 /// See [`Data::deserialize`] documentation for an example of how to use this function.
-pub fn to_bytes<T: ?Sized>(ctxt: Context, value: &T) -> Result<Data<'static, 'static>>
+pub fn to_bytes<T>(ctxt: Context, value: &T) -> Result<Data<'static, 'static>>
 where
-    T: Serialize + DynamicType,
+    T: ?Sized + Serialize + DynamicType,
 {
     to_bytes_for_signature(ctxt, value.dynamic_signature(), value)
 }
@@ -155,7 +155,7 @@ where
 /// hence is safe to drop.
 ///
 /// [`to_writer`]: fn.to_writer.html
-pub unsafe fn to_writer_for_signature<'s, W, S, T: ?Sized>(
+pub unsafe fn to_writer_for_signature<'s, W, S, T>(
     writer: &mut W,
     ctxt: Context,
     signature: S,
@@ -165,7 +165,7 @@ where
     W: Write + Seek,
     S: TryInto<Signature<'s>>,
     S::Error: Into<Error>,
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     #[cfg(unix)]
     let mut fds = FdList::Fds(vec![]);
@@ -214,7 +214,7 @@ where
 ///
 /// [`to_bytes`]: fn.to_bytes.html
 /// [`from_slice_for_signature`]: fn.from_slice_for_signature.html#examples
-pub fn to_bytes_for_signature<'s, S, T: ?Sized>(
+pub fn to_bytes_for_signature<'s, S, T>(
     ctxt: Context,
     signature: S,
     value: &T,
@@ -222,7 +222,7 @@ pub fn to_bytes_for_signature<'s, S, T: ?Sized>(
 where
     S: TryInto<Signature<'s>>,
     S::Error: Into<Error>,
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut cursor = std::io::Cursor::new(vec![]);
     // SAFETY: We put the bytes and FDs in the `Data` to ensure that the data and FDs are only

--- a/zvariant/src/serialized/data.rs
+++ b/zvariant/src/serialized/data.rs
@@ -139,9 +139,9 @@ impl<'bytes, 'fds> Data<'bytes, 'fds> {
     /// # Return value
     ///
     /// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
-    pub fn deserialize<'d, T: ?Sized>(&'d self) -> Result<(T, usize)>
+    pub fn deserialize<'d, T>(&'d self) -> Result<(T, usize)>
     where
-        T: Deserialize<'d> + Type,
+        T: ?Sized + Deserialize<'d> + Type,
     {
         let signature = T::signature();
         self.deserialize_for_signature(&signature)
@@ -213,9 +213,9 @@ impl<'bytes, 'fds> Data<'bytes, 'fds> {
     /// # Return value
     ///
     /// A tuple containing the deserialized value and the number of bytes parsed from `bytes`.
-    pub fn deserialize_for_signature<'d, S, T: ?Sized>(&'d self, signature: S) -> Result<(T, usize)>
+    pub fn deserialize_for_signature<'d, S, T>(&'d self, signature: S) -> Result<(T, usize)>
     where
-        T: Deserialize<'d>,
+        T: ?Sized + Deserialize<'d>,
         S: TryInto<Signature<'d>>,
         S::Error: Into<Error>,
     {

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -387,9 +387,9 @@ impl<'a> Value<'a> {
     /// [`Value::Value`]: enum.Value.html#variant.Value
     /// [`TryFrom<Value>`]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
     /// [`From<Value>`]: https://doc.rust-lang.org/std/convert/trait.From.html
-    pub fn downcast<T: ?Sized>(self) -> Result<T, crate::Error>
+    pub fn downcast<T>(self) -> Result<T, crate::Error>
     where
-        T: TryFrom<Value<'a>>,
+        T: ?Sized + TryFrom<Value<'a>>,
         <T as TryFrom<Value<'a>>>::Error: Into<crate::Error>,
     {
         if let Value::Value(v) = self {


### PR DESCRIPTION
This demonstrates a huge performance difference when using serde_bytes:

```
byte_array_ser          time:   [1.7867 µs 1.7883 µs 1.7901 µs]
                        change: [-99.922% -99.922% -99.922%] (p = 0.00 < 0.05)
```