### PR TITLE
zb: ObjectServer should handle methods sequentially

### DIFF
--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -996,13 +996,16 @@ impl Connection {
                                     // destination doesn't matter if no name has been registered
                                     // (probably means name it's registered through external means).
                                     if !names.is_empty() && !names.contains_key(dest) {
-                                        trace!("Got a method call for a different destination: {}", dest);
+                                        trace!(
+                                            "Got a method call for a different destination: {}",
+                                            dest
+                                        );
 
                                         continue;
                                     }
                                 }
                             }
-                            let member = match hdr.member() {
+                            match hdr.member() {
                                 Some(member) => member,
                                 None => {
                                     warn!("Got a method call with no `MEMBER` field: {}", msg);
@@ -1010,27 +1013,16 @@ impl Connection {
                                     continue;
                                 }
                             };
-                            trace!("Got `{}`. Will spawn a task for dispatch..", msg);
-                            let executor = conn.inner.executor.clone();
-                            let task_name = format!("`{member}` method dispatcher");
-                            executor
-                                .spawn(
-                                    async move {
-                                        trace!("spawned a task to dispatch `{}`.", msg);
-                                        let server = conn.object_server();
-                                        if let Err(e) = server.dispatch_message(&msg).await {
-                                            debug!(
-                                                "Error dispatching message. Message: {:?}, error: {:?}",
-                                                msg, e
-                                            );
-                                        }
-                                    }
-                                    .instrument(trace_span!("{}", task_name)),
-                                    &task_name,
-                                )
-                                .detach();
+                            let server = conn.object_server();
+                            if let Err(e) = server.dispatch_message(&msg).await {
+                                debug!(
+                                    "Error dispatching message. Message: {:?}, error: {:?}",
+                                    msg, e
+                                );
+                            }
                         } else {
-                            // If connection is completely gone, no reason to keep running the task anymore.
+                            // If connection is completely gone, no reason to keep running the task
+                            // anymore.
                             trace!("Connection is gone, stopping associated object server task");
                             break;
                         }

--- a/zbus/src/message/field.rs
+++ b/zbus/src/message/field.rs
@@ -32,7 +32,7 @@ pub(super) enum FieldCode {
     ErrorName = 4,
     /// Code for [`Field::ReplySerial`](enum.Field.html#variant.ReplySerial)
     ReplySerial = 5,
-    /// Code for [`Field::Destinatione`](enum.Field.html#variant.Destination)
+    /// Code for [`Field::Destination`](enum.Field.html#variant.Destination)
     Destination = 6,
     /// Code for [`Field::Sender`](enum.Field.html#variant.Sender)
     Sender = 7,

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -295,6 +295,7 @@ impl fmt::Debug for Message {
         let mut msg = f.debug_struct("Msg");
         let h = self.header();
         msg.field("type", &h.message_type());
+        msg.field("serial", &self.primary_header().serial_num());
         if let Some(sender) = h.sender() {
             msg.field("sender", &sender);
         }

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -699,7 +699,6 @@ impl ObjectServer {
         })
     }
 
-    #[instrument(skip(self, connection))]
     async fn dispatch_method_call_try(
         &self,
         connection: &Connection,
@@ -766,7 +765,6 @@ impl ObjectServer {
         )))
     }
 
-    #[instrument(skip(self, connection))]
     async fn dispatch_method_call(&self, connection: &Connection, msg: &Message) -> Result<()> {
         match self.dispatch_method_call_try(connection, msg).await {
             Err(e) => {


### PR DESCRIPTION
Messages should be dispatched in the order they are received, otherwise, the client can't do message batching etc..
    
Spawning a task is best left to the actual implementation.
