### PR TITLE
Make task spawning for method call optional

### DIFF
--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -450,10 +450,9 @@ impl<'a> Builder<'a> {
             let object_server = conn.sync_object_server(false, None);
             for (path, interfaces) in self.interfaces {
                 for (name, iface) in interfaces {
-                    let iface = iface.clone();
                     let added = object_server
                         .inner()
-                        .at_ready(path.to_owned(), name.clone(), || iface)
+                        .add_arc_interface(path.clone(), name.clone(), iface.clone())
                         .await?;
                     if !added {
                         return Err(Error::InterfaceExists(name.clone(), path.to_owned()));

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     async_lock::Mutex,
     blocking,
     fdo::{self, ConnectionCredentials, RequestNameFlags, RequestNameReply},
-    message::{Flags, Header, Message, Type},
+    message::{Flags, Message, Type},
     proxy::CacheProperties,
     DBusError, Error, Executor, MatchRule, MessageStream, ObjectServer, OwnedGuid, OwnedMatchRule,
     Result, Task,
@@ -980,35 +980,13 @@ impl Connection {
                                     }
                                 }
                             }
-                            let member = match hdr.member() {
-                                Some(member) => member,
-                                None => {
-                                    warn!("Got a method call with no `MEMBER` field: {}", msg);
-
-                                    continue;
-                                }
-                            };
-                            trace!("Got `{}`. Will spawn a task for dispatch..", msg);
-                            let executor = conn.inner.executor.clone();
-                            let task_name = format!("`{member}` method dispatcher");
-                            // SAFETY: msg becomes 'static when moved to the task, and dropped after
-                            let hdr = unsafe { std::mem::transmute::<_, Header<'static>>(hdr) };
-                            executor
-                                .spawn(
-                                    async move {
-                                        trace!("spawned a task to dispatch `{}`.", msg);
-                                        let server = conn.object_server();
-                                        if let Err(e) = server.dispatch_call(&msg, &hdr).await {
-                                            debug!(
-                                                "Error dispatching message. Message: {:?}, error: {:?}",
-                                                msg, e
-                                            );
-                                        }
-                                    }
-                                    .instrument(trace_span!("{}", task_name)),
-                                    &task_name,
-                                )
-                                .detach();
+                            let server = conn.object_server();
+                            if let Err(e) = server.dispatch_call(&msg, &hdr).await {
+                                debug!(
+                                    "Error dispatching message. Message: {:?}, error: {:?}",
+                                    msg, e
+                                );
+                            }
                         } else {
                             // If connection is completely gone, no reason to keep running the task
                             // anymore.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -996,7 +996,7 @@ impl Connection {
                                     async move {
                                         trace!("spawned a task to dispatch `{}`.", msg);
                                         let server = conn.object_server();
-                                        if let Err(e) = server.dispatch_message(&msg).await {
+                                        if let Err(e) = server.dispatch_call(&msg).await {
                                             debug!(
                                                 "Error dispatching message. Message: {:?}, error: {:?}",
                                                 msg, e

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -971,7 +971,10 @@ impl Connection {
                                     // destination doesn't matter if no name has been registered
                                     // (probably means name it's registered through external means).
                                     if !names.is_empty() && !names.contains_key(dest) {
-                                        trace!("Got a method call for a different destination: {}", dest);
+                                        trace!(
+                                            "Got a method call for a different destination: {}",
+                                            dest
+                                        );
 
                                         continue;
                                     }
@@ -1005,7 +1008,8 @@ impl Connection {
                                 )
                                 .detach();
                         } else {
-                            // If connection is completely gone, no reason to keep running the task anymore.
+                            // If connection is completely gone, no reason to keep running the task
+                            // anymore.
                             trace!("Connection is gone, stopping associated object server task");
                             break;
                         }

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -134,7 +134,7 @@ impl Properties {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
             })?;
 
-        let res = iface.read().await.get(property_name).await;
+        let res = iface.instance.read().await.get(property_name).await;
         res.unwrap_or_else(|| {
             Err(Error::UnknownProperty(format!(
                 "Unknown property '{property_name}'"
@@ -160,7 +160,12 @@ impl Properties {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
             })?;
 
-        match iface.read().await.set(property_name, &value, &ctxt) {
+        match iface
+            .instance
+            .read()
+            .await
+            .set(property_name, &value, &ctxt)
+        {
             zbus::object_server::DispatchResult::RequiresMut => {}
             zbus::object_server::DispatchResult::NotFound => {
                 return Err(Error::UnknownProperty(format!(
@@ -172,6 +177,7 @@ impl Properties {
             }
         }
         let res = iface
+            .instance
             .write()
             .await
             .set_mut(property_name, &value, &ctxt)
@@ -198,7 +204,7 @@ impl Properties {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
             })?;
 
-        let res = iface.read().await.get_all().await?;
+        let res = iface.instance.read().await.get_all().await?;
         Ok(res)
     }
 

--- a/zbus/src/message/field.rs
+++ b/zbus/src/message/field.rs
@@ -32,7 +32,7 @@ pub(super) enum FieldCode {
     ErrorName = 4,
     /// Code for [`Field::ReplySerial`](enum.Field.html#variant.ReplySerial)
     ReplySerial = 5,
-    /// Code for [`Field::Destinatione`](enum.Field.html#variant.Destination)
+    /// Code for [`Field::Destination`](enum.Field.html#variant.Destination)
     Destination = 6,
     /// Code for [`Field::Sender`](enum.Field.html#variant.Sender)
     Sender = 7,

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -295,6 +295,7 @@ impl fmt::Debug for Message {
         let mut msg = f.debug_struct("Msg");
         let h = self.header();
         msg.field("type", &h.message_type());
+        msg.field("serial", &self.primary_header().serial_num());
         if let Some(sender) = h.sender() {
             msg.field("sender", &sender);
         }

--- a/zbus/src/object_server/interface.rs
+++ b/zbus/src/object_server/interface.rs
@@ -72,6 +72,14 @@ pub trait Interface: Any + Send + Sync {
     where
         Self: Sized;
 
+    /// Whether each method call will be handled from a different spawned task.
+    ///
+    /// Note: When methods are called from separate tasks, they may not be run in the order in which
+    /// they were called.
+    fn spawn_tasks_for_methods(&self) -> bool {
+        true
+    }
+
     /// Get a property value. Returns `None` if the property doesn't exist.
     async fn get(&self, property_name: &str) -> Option<fdo::Result<OwnedValue>>;
 

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -744,7 +744,7 @@ impl ObjectServer {
     ///
     /// Returns an error if the message is malformed, true if it's handled, false otherwise.
     #[instrument(skip(self))]
-    pub(crate) async fn dispatch_message(&self, msg: &Message) -> Result<bool> {
+    pub(crate) async fn dispatch_call(&self, msg: &Message) -> Result<bool> {
         let conn = self.connection();
 
         if let Err(e) = self.dispatch_method_call_try(&conn, msg).await {

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -670,7 +670,7 @@ impl ObjectServer {
         &self,
         connection: &Connection,
         msg: &Message,
-    ) -> fdo::Result<Result<()>> {
+    ) -> fdo::Result<()> {
         let hdr = msg.header();
         let path = hdr
             .path()
@@ -710,7 +710,10 @@ impl ObjectServer {
                 )));
             }
             DispatchResult::Async(f) => {
-                return Ok(f.await);
+                return f.await.map_err(|e| match e {
+                    Error::FDO(e) => *e,
+                    e => fdo::Error::Failed(format!("{e}")),
+                });
             }
             DispatchResult::RequiresMut => {}
         }
@@ -722,7 +725,10 @@ impl ObjectServer {
             DispatchResult::NotFound => {}
             DispatchResult::RequiresMut => {}
             DispatchResult::Async(f) => {
-                return Ok(f.await);
+                return f.await.map_err(|e| match e {
+                    Error::FDO(e) => *e,
+                    e => fdo::Error::Failed(format!("{e}")),
+                });
             }
         }
         drop(write_lock);

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -666,7 +666,6 @@ impl ObjectServer {
         })
     }
 
-    #[instrument(skip(self, connection))]
     async fn dispatch_method_call_try(
         &self,
         connection: &Connection,
@@ -732,7 +731,6 @@ impl ObjectServer {
         )))
     }
 
-    #[instrument(skip(self, connection))]
     async fn dispatch_method_call(&self, connection: &Connection, msg: &Message) -> Result<()> {
         match self.dispatch_method_call_try(connection, msg).await {
             Err(e) => {

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -735,6 +735,13 @@ impl ObjectServer {
             // error, or deliver the message as though it had an arbitrary one of those
             // interfaces.
             .ok_or_else(|| fdo::Error::Failed("Missing interface".into()))?;
+        // Check that the message has a member before spawning.
+        // Note that an unknown member will still spawn a task. We should instead gather
+        // all the details for the call before spawning.
+        // See also https://github.com/dbus2/zbus/issues/674 for future of Interface.
+        let _ = hdr
+            .member()
+            .ok_or_else(|| fdo::Error::Failed("Missing member".into()))?;
 
         // Ensure the root lock isn't held while dispatching the message. That
         // way, the object server can be mutated during that time.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -194,9 +194,9 @@ impl Node {
             path,
             ..Default::default()
         };
-        node.at(Peer::name(), || ArcInterface::new(Peer));
-        node.at(Introspectable::name(), || ArcInterface::new(Introspectable));
-        node.at(Properties::name(), || ArcInterface::new(Properties));
+        debug_assert!(node.add_interface(Peer));
+        debug_assert!(node.add_interface(Introspectable));
+        debug_assert!(node.add_interface(Properties));
 
         node
     }
@@ -275,6 +275,23 @@ impl Node {
 
     fn remove_node(&mut self, node: &str) -> bool {
         self.children.remove(node).is_some()
+    }
+
+    fn add_arc_interface(&mut self, name: InterfaceName<'static>, arc_iface: ArcInterface) -> bool {
+        match self.interfaces.entry(name) {
+            Entry::Vacant(e) => {
+                e.insert(arc_iface);
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
+    }
+
+    fn add_interface<I>(&mut self, iface: I) -> bool
+    where
+        I: Interface,
+    {
+        self.add_arc_interface(I::name(), ArcInterface::new(iface))
     }
 
     // Takes a closure so caller can avoid having to create an Arc & RwLock in case interface was

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -742,9 +742,9 @@ impl ObjectServer {
     /// - returning a message (responding to the caller with either a return or error message) to
     ///   the caller through the associated server connection.
     ///
-    /// Returns an error if the message is malformed, true if it's handled, false otherwise.
+    /// Returns an error if the message is malformed.
     #[instrument(skip(self))]
-    pub(crate) async fn dispatch_call(&self, msg: &Message) -> Result<bool> {
+    pub(crate) async fn dispatch_call(&self, msg: &Message) -> Result<()> {
         let conn = self.connection();
 
         if let Err(e) = self.dispatch_method_call_try(&conn, msg).await {
@@ -754,7 +754,7 @@ impl ObjectServer {
         }
         trace!("Handled: {}", msg);
 
-        Ok(true)
+        Ok(())
     }
 
     pub(crate) fn connection(&self) -> Connection {

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -215,6 +215,25 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// properties or signal depending on the item attributes. It will implement the [`Interface`] trait
 /// `for T` on your behalf, to handle the message dispatching and introspection support.
 ///
+/// The trait accepts the `interface` attributes:
+///
+/// * `name` - the D-Bus interface name
+///
+/// * `spawn` - Controls the spawning of tasks for method calls. By default, `true`, allowing zbus
+///   to spawn a separate task for each method call. This default behavior can lead to methods being
+///   handled out of their received order, which might not always align with expected or desired
+///   behavior.
+///
+///   - **When True (Default):** Suitable for interfaces where method calls are independent of each
+///   other or can be processed asynchronously without strict ordering. In scenarios where a client
+///   must wait for a reply before making further dependent calls, this default behavior is
+///   appropriate.
+///
+///   - **When False:** Use this setting to ensure methods are handled in the order they are
+///   received, which is crucial for interfaces requiring sequential processing of method calls.
+///   However, care must be taken to avoid making D-Bus method calls from within your interface
+///   methods when this setting is false, as it may lead to deadlocks under certain conditions.
+///
 /// The methods accepts the `interface` attributes:
 ///
 /// * `name` - override the D-Bus name (pascal case form of the method by default)

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -139,7 +139,7 @@ fn test_interface() {
     #[derive(Serialize, Deserialize, Type, Value)]
     struct MyCustomPropertyType(u32);
 
-    #[interface(name = "org.freedesktop.zbus.Test")]
+    #[interface(name = "org.freedesktop.zbus.Test", spawn = false)]
     impl<T: 'static> Test<T>
     where
         T: serde::ser::Serialize + zbus::zvariant::Type + Send + Sync,


### PR DESCRIPTION
Clients can expect calls to be handled in order they are sent. Although the specification doesn't explicitly state so  (https://gitlab.freedesktop.org/dbus/dbus/-/issues/179), bus implementations have respected message ordering. This can also be  expected when the bus and client are fully managed, as in p2p.

Add an option to avoid the default task spawning when dispatching methods on a specific interface.

This currently prevents parallel handling of other incoming calls which will have to wait for the method to return (current pending calls are still running in parallel).

Supersedes: #668 