### PR TITLE
⚡️ zb: Pipeline client-side handshake as much as possible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,9 +57,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build and Test
         run: |
-          mkdir -p /run/user/$UID
-          sed -e s/UID/$UID/ -e s/PATH/path/ CI/dbus-session.conf > /tmp/dbus-session.conf
-          sed -e s/UID/$UID/ -e s/PATH/abstract/ CI/dbus-session.conf > /tmp/dbus-session-abstract.conf
           dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --verbose -- basic_connection
           # All features except tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -707,7 +707,10 @@ impl Handshake for ServerHandshake<'_> {
                                 _ => self.rejected_error().await?,
                             }
                         }
-                        Command::Error(_) => self.rejected_error().await?,
+                        Command::Cancel | Command::Error(_) => {
+                            trace!("Received CANCEL or ERROR command from the client");
+                            self.rejected_error().await?;
+                        }
                         _ => self.unsupported_command_error().await?,
                     }
                 }

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -42,12 +42,10 @@ pub enum AuthMechanism {
 
 /// The result of a finalized handshake
 ///
-/// The result of a finalized [`ClientHandshake`] or [`ServerHandshake`]. It can be passed to
-/// [`Connection::new_authenticated`] to initialize a connection.
+/// The result of a finalized [`ClientHandshake`] or [`ServerHandshake`].
 ///
 /// [`ClientHandshake`]: struct.ClientHandshake.html
 /// [`ServerHandshake`]: struct.ServerHandshake.html
-/// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
 pub struct Authenticated {
     pub(crate) socket_write: Box<dyn WriteHalf>,
@@ -123,16 +121,7 @@ enum Command {
 /// A representation of an in-progress handshake, client-side
 ///
 /// This struct is an async-compatible representation of the initial handshake that must be
-/// performed before a D-Bus connection can be used. To use it, you should call the
-/// [`advance_handshake`] method whenever the underlying socket becomes ready (tracking the
-/// readiness itself is not managed by this abstraction) until it returns `Ok(())`, at which point
-/// you can invoke the [`try_finish`] method to get an [`Authenticated`], which can be given to
-/// [`Connection::new_authenticated`].
-///
-/// [`advance_handshake`]: struct.ClientHandshake.html#method.advance_handshake
-/// [`try_finish`]: struct.ClientHandshake.html#method.try_finish
-/// [`Authenticated`]: struct.AUthenticated.html
-/// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
+/// performed before a D-Bus connection can be used.
 #[derive(Debug)]
 pub struct ClientHandshake {
     common: HandshakeCommon,
@@ -522,18 +511,6 @@ enum ServerHandshakeStep {
 /// A representation of an in-progress handshake, server-side
 ///
 /// This would typically be used to implement a D-Bus broker, or in the context of a P2P connection.
-///
-/// This struct is an async-compatible representation of the initial handshake that must be
-/// performed before a D-Bus connection can be used. To use it, you should call the
-/// [`advance_handshake`] method whenever the underlying socket becomes ready (tracking the
-/// readiness itself is not managed by this abstraction) until it returns `Ok(())`, at which point
-/// you can invoke the [`try_finish`] method to get an [`Authenticated`], which can be given to
-/// [`Connection::new_authenticated`].
-///
-/// [`advance_handshake`]: struct.ServerHandshake.html#method.advance_handshake
-/// [`try_finish`]: struct.ServerHandshake.html#method.try_finish
-/// [`Authenticated`]: struct.Authenticated.html
-/// [`Connection::new_authenticated`]: ../struct.Connection.html#method.new_authenticated
 #[derive(Debug)]
 #[cfg(feature = "p2p")]
 pub struct ServerHandshake<'s> {

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -1074,6 +1074,7 @@ mod tests {
     }
 
     #[test]
+    #[timeout(15000)]
     fn handshake() {
         let (p0, p1) = create_async_socket_pair();
 

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -863,8 +863,7 @@ impl fmt::Display for Command {
             }
             Command::Ok(guid) => write!(f, "OK {guid}"),
             Command::AgreeUnixFD => write!(f, "AGREE_UNIX_FD"),
-        }?;
-        write!(f, "\r\n")
+        }
     }
 }
 
@@ -955,6 +954,7 @@ impl HandshakeCommon {
                 .map(Vec::<u8>::from)
                 .fold(vec![], |mut acc, mut c| {
                     acc.append(&mut c);
+                    acc.extend_from_slice(b"\r\n");
                     acc
                 });
         while !send_buffer.is_empty() {

--- a/zbus/src/connection/handshake.rs
+++ b/zbus/src/connection/handshake.rs
@@ -642,10 +642,8 @@ impl<'s> ServerHandshake<'s> {
     }
 
     async fn unsupported_command_error(&mut self) -> Result<()> {
-        let cmd = Command::Error("Unsupported command".to_string());
-        trace!("Sending authentication error");
+        let cmd = Command::Error("Unsupported or misplaced command".to_string());
         self.common.write_command(cmd).await?;
-        self.step = ServerHandshakeStep::WaitingForAuth;
 
         Ok(())
     }
@@ -710,11 +708,6 @@ impl Handshake for ServerHandshake<'_> {
                             }
                         }
                         Command::Error(_) => self.rejected_error().await?,
-                        Command::Begin => {
-                            return Err(Error::Handshake(
-                                "Received BEGIN while not authenticated".to_string(),
-                            ));
-                        }
                         _ => self.unsupported_command_error().await?,
                     }
                 }


### PR DESCRIPTION
We now send `DATA`, `NEGOTIATE_UNIX_FD` and `BEGIN` commands at once. This reduces latency and hence improves performance.

It would have been the best to send all the commands at the same time, but seems dbus-daemon kick us out if we send multiple commands after it rejects the auth command. It wants us to negotiate the auth first. We could in theory just reconnect but that would require some architectural changes and rethinking the code.

Moreover cookie auth requires a round-trip to the server to get the cookie context first so we can't fully pipeline that one.

The server side is not possible to pipeline as it the server just responds to commands from the client and it can not assume that clients will always pipeline all commands.

Fixes #493.

