### PR TITLE
🚑️ zx: Always use owned types for signal args

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -379,14 +379,14 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
                 match **c as char {
                     '{' => format!(
                         "std::collections::HashMap<{}>",
-                        iter_to_rust_type(it, input, false)
+                        iter_to_rust_type(it, input, as_ref)
                     ),
                     _ => {
-                        let ty = iter_to_rust_type(it, input, false);
-                        if input {
+                        let ty = iter_to_rust_type(it, input, as_ref);
+                        if input && as_ref {
                             format!("&[{ty}]")
                         } else {
-                            format!("{}Vec<{ty}>", if as_ref { "&" } else { "" })
+                            format!("Vec<{ty}>")
                         }
                     }
                 }
@@ -402,7 +402,7 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
                             it.next().unwrap();
                             break;
                         }
-                        _ => vec.push(iter_to_rust_type(it, input, false)),
+                        _ => vec.push(iter_to_rust_type(it, input, as_ref)),
                     }
                 }
                 if dict {

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -386,7 +386,7 @@ fn to_rust_type(ty: &CompleteType, input: bool, as_ref: bool) -> String {
                         if input {
                             format!("&[{ty}]")
                         } else {
-                            format!("{}Vec<{}>", if as_ref { "&" } else { "" }, ty)
+                            format!("{}Vec<{ty}>", if as_ref { "&" } else { "" })
                         }
                     }
                 }

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -30,7 +30,7 @@ trait SampleInterface0 {
     ) -> zbus::Result<(String, std::collections::HashMap<u32, String>)>;
 
     /// MogrifyMe method
-    fn mogrify_me(&self, bar: &(i32, i32, &[zbus::zvariant::Value<'_>])) -> zbus::Result<()>;
+    fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::zvariant::Value<'_>])) -> zbus::Result<()>;
 
     /// Odyssey method
     #[allow(clippy::too_many_arguments)]

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -53,6 +53,21 @@ trait SampleInterface0 {
     #[zbus(signal)]
     fn changed2(&self, new_value: bool, new_value2: bool) -> zbus::Result<()>;
 
+    /// SignalArrayOfStrings signal
+    #[zbus(signal)]
+    fn signal_array_of_strings(&self, array: Vec<&str>) -> zbus::Result<()>;
+
+    /// SignalDictStringToValue signal
+    #[zbus(signal)]
+    fn signal_dict_string_to_value(
+        &self,
+        dict: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// SignalValue signal
+    #[zbus(signal)]
+    fn signal_value(&self, value: zbus::zvariant::Value<'_>) -> zbus::Result<()>;
+
     /// Bar property
     #[zbus(property)]
     fn bar(&self) -> zbus::Result<u8>;

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -43,6 +43,15 @@
        <arg name="new_value" type="b" direction="out"/>
        <arg name="new_value2" type="b" direction="out"/>
      </signal>
+     <signal name="SignalArrayOfStrings">
+       <arg type="as" name="array"/>
+     </signal>
+     <signal name="SignalValue">
+       <arg type="v" name="value"/>
+     </signal>
+     <signal name="SignalDictStringToValue">
+       <arg type="a{sv}" name="dict"/>
+     </signal>
      <property name="Bar" type="y" access="readwrite"/>
      <property name="Foo-Bar" type="y" access="readwrite"/>
      <property name="Matryoshkas" type="a(oiasta{sv})" access="read"/>


### PR DESCRIPTION
We started doing this already in cae1a65447 but it didn't cover all cases and we still sometimes end up with types that do not implement `serde::Deserialize`.

As a side-effect, this now also turns some of the normal method args to take references instead of values, which is a good thing.

Fixes #412.
