### PR TITLE
➖ zm: Remove regex dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,6 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "regex",
  "rustversion",
  "serde",
  "syn 1.0.109",

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -24,7 +24,6 @@ proc-macro2 = "1.0"
 syn = { version = "1.0.109", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.35"
 proc-macro-crate = "3.1.0"
-regex = "1.10.4"
 zvariant_utils = { path = "../zvariant_utils", version = "=1.1.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
This removes the unneeded dependency on `regex` in `zbus_macros`. I believe this code should be equivalent to the regular expression.  
- Loops over looking for any `&` as `is_match` just requires it a match anywhere in the string
  - once found, strip off all leading spaces
  - if they're equivalent, then we've found it
  
The only ambiguity I can think of being if the type contained symbols that regex would have considered as part of the name, but I think that'd only happen for tuples and the regex wouldn't match those due to considering it a capture group and not parentheses.