### PR TITLE
➖ zb: Remove derivative dep 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,17 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,7 +2529,6 @@ dependencies = [
  "async-task",
  "async-trait",
  "blocking",
- "derivative",
  "doc-comment",
  "enumflags2",
  "event-listener 5.3.0",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -47,7 +47,6 @@ zvariant = { path = "../zvariant", version = "4.0.0", default-features = false, 
 zbus_names = { path = "../zbus_names", version = "3.0" }
 zbus_macros = { path = "../zbus_macros", version = "=4.1.2" }
 enumflags2 = { version = "0.7.9", features = ["serde"] }
-derivative = "2.2"
 async-io = { version = "2.3.2", optional = true }
 futures-core = "0.3.30"
 futures-sink = "0.3.30"

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -21,8 +21,7 @@ pub use builder::Builder;
 /// A blocking wrapper of [`zbus::Connection`].
 ///
 /// Most of the API is very similar to [`zbus::Connection`], except it's blocking.
-#[derive(derivative::Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 #[must_use = "Dropping a `Connection` will close the underlying socket."]
 pub struct Connection {
     inner: crate::Connection,

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -9,8 +9,7 @@ use crate::{
 ///
 /// Just like [`crate::MessageStream`] must be continuously polled, you must continuously iterate
 /// over this type until it's consumed or dropped.
-#[derive(derivative::Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct MessageIterator {
     // Wrap it in an `Option` to ensure the stream is dropped in a `block_on` call. This is needed
     // for tokio because the proxy spawns a task in its `Drop` impl and that needs a runtime

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -3,7 +3,7 @@
 use enumflags2::BitFlags;
 use futures_util::StreamExt;
 use static_assertions::assert_impl_all;
-use std::ops::Deref;
+use std::{fmt, ops::Deref};
 use zbus_names::{BusName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, OwnedValue, Value};
 
@@ -60,15 +60,21 @@ pub use builder::Builder;
 ///
 /// [`proxy`]: attr.proxy.html
 /// [al]: https://github.com/dbus2/zbus/issues/54
-#[derive(derivative::Derivative)]
-#[derivative(Clone, Debug)]
+#[derive(Clone)]
 pub struct Proxy<'a> {
-    #[derivative(Debug = "ignore")]
     conn: Connection,
     // Wrap it in an `Option` to ensure the proxy is dropped in a `block_on` call. This is needed
     // for tokio because the proxy spawns a task in its `Drop` impl and that needs a runtime
     // context in case of tokio.
     azync: Option<crate::Proxy<'a>>,
+}
+
+impl fmt::Debug for Proxy<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Proxy")
+            .field("azync", &self.azync)
+            .finish_non_exhaustive()
+    }
 }
 
 assert_impl_all!(Proxy<'_>: Send, Sync, Unpin);

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -8,7 +8,6 @@ use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    fmt,
     sync::Arc,
 };
 #[cfg(feature = "tokio")]
@@ -58,6 +57,7 @@ enum Target {
 type Interfaces<'a> = HashMap<ObjectPath<'a>, HashMap<InterfaceName<'static>, ArcInterface>>;
 
 /// A builder for [`zbus::Connection`].
+#[derive(Debug)]
 #[must_use]
 pub struct Builder<'a> {
     target: Option<Target>,
@@ -78,26 +78,6 @@ pub struct Builder<'a> {
 }
 
 assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
-
-impl fmt::Debug for Builder<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut f = f.debug_struct("Builder");
-        f.field("target", &self.target);
-        f.field("max_queued", &self.max_queued);
-        #[cfg(feature = "p2p")]
-        f.field("guid", &self.target);
-        #[cfg(feature = "p2p")]
-        f.field("p2p", &self.p2p);
-        f.field("internal_executor", &self.internal_executor);
-        f.field("names", &self.names);
-        f.field("auth_mechanisms", &self.auth_mechanisms);
-        #[cfg(feature = "bus-impl")]
-        f.field("unique_name", &self.unique_name);
-        f.field("cookie_context", &self.cookie_context);
-        f.field("cookie_id", &self.cookie_id);
-        f.finish_non_exhaustive()
-    }
-}
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -8,6 +8,7 @@ use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    fmt,
     sync::Arc,
 };
 #[cfg(feature = "tokio")]
@@ -58,8 +59,6 @@ type Interfaces<'a> =
     HashMap<ObjectPath<'a>, HashMap<InterfaceName<'static>, Arc<RwLock<dyn Interface>>>>;
 
 /// A builder for [`zbus::Connection`].
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 #[must_use]
 pub struct Builder<'a> {
     target: Option<Target>,
@@ -70,7 +69,6 @@ pub struct Builder<'a> {
     #[cfg(feature = "p2p")]
     p2p: bool,
     internal_executor: bool,
-    #[derivative(Debug = "ignore")]
     interfaces: Interfaces<'a>,
     names: HashSet<WellKnownName<'a>>,
     auth_mechanisms: Option<VecDeque<AuthMechanism>>,
@@ -81,6 +79,26 @@ pub struct Builder<'a> {
 }
 
 assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
+
+impl fmt::Debug for Builder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_struct("Builder");
+        f.field("target", &self.target);
+        f.field("max_queued", &self.max_queued);
+        #[cfg(feature = "p2p")]
+        f.field("guid", &self.target);
+        #[cfg(feature = "p2p")]
+        f.field("p2p", &self.p2p);
+        f.field("internal_executor", &self.internal_executor);
+        f.field("names", &self.names);
+        f.field("auth_mechanisms", &self.auth_mechanisms);
+        #[cfg(feature = "bus-impl")]
+        f.field("unique_name", &self.unique_name);
+        f.field("cookie_context", &self.cookie_context);
+        f.field("cookie_id", &self.cookie_id);
+        f.finish_non_exhaustive()
+    }
+}
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.

--- a/zbus/src/object_server/interface.rs
+++ b/zbus/src/object_server/interface.rs
@@ -1,9 +1,10 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    fmt::Write,
+    fmt::{self, Write},
     future::Future,
     pin::Pin,
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -12,7 +13,8 @@ use zbus_names::{InterfaceName, MemberName};
 use zvariant::{DynamicType, OwnedValue, Value};
 
 use crate::{
-    fdo, message::Message, object_server::SignalContext, Connection, ObjectServer, Result,
+    async_lock::RwLock, fdo, message::Message, object_server::SignalContext, Connection,
+    ObjectServer, Result,
 };
 use tracing::trace;
 
@@ -128,6 +130,17 @@ pub trait Interface: Any + Send + Sync {
 
     /// Write introspection XML to the writer, with the given indentation level.
     fn introspect_to_writer(&self, writer: &mut dyn Write, level: usize);
+}
+
+/// A newtype for a reference counted Interface trait-object, with a manual Debug impl.
+#[derive(Clone)]
+pub(crate) struct ArcInterface(pub(crate) Arc<RwLock<dyn Interface>>);
+
+impl fmt::Debug for ArcInterface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Arc<RwLock<dyn Interface>>")
+            .finish_non_exhaustive()
+    }
 }
 
 // Note: while it is possible to implement this without `unsafe`, it currently requires a helper

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -4,7 +4,6 @@ use event_listener::{Event, EventListener};
 use serde::Serialize;
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fmt,
     fmt::Write,
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -182,20 +181,11 @@ impl<I> Clone for InterfaceRef<I> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct Node {
     path: OwnedObjectPath,
     children: HashMap<String, Node>,
     interfaces: HashMap<InterfaceName<'static>, ArcInterface>,
-}
-
-impl fmt::Debug for Node {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Node")
-            .field("path", &self.path)
-            .field("children", &self.children)
-            .finish_non_exhaustive()
-    }
 }
 
 impl Node {

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -4,6 +4,7 @@ use event_listener::{Event, EventListener};
 use serde::Serialize;
 use std::{
     collections::{hash_map::Entry, HashMap},
+    fmt,
     fmt::Write,
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -180,13 +181,20 @@ impl<I> Clone for InterfaceRef<I> {
     }
 }
 
-#[derive(Default, derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Default)]
 pub(crate) struct Node {
     path: OwnedObjectPath,
     children: HashMap<String, Node>,
-    #[derivative(Debug = "ignore")]
     interfaces: HashMap<InterfaceName<'static>, Arc<RwLock<dyn Interface>>>,
+}
+
+impl fmt::Debug for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Node")
+            .field("path", &self.path)
+            .field("children", &self.children)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Node {

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -8,6 +8,7 @@ use ordered_stream::{join as join_streams, FromFuture, Join, OrderedStream, Poll
 use static_assertions::assert_impl_all;
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     future::Future,
     ops::Deref,
     pin::Pin,
@@ -74,12 +75,20 @@ assert_impl_all!(Proxy<'_>: Send, Sync, Unpin);
 
 /// This is required to avoid having the Drop impl extend the lifetime 'a, which breaks zbus_xmlgen
 /// (and possibly other crates).
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub(crate) struct ProxyInnerStatic {
-    #[derivative(Debug = "ignore")]
     pub(crate) conn: Connection,
     dest_owner_change_match_rule: OnceLock<OwnedMatchRule>,
+}
+
+impl fmt::Debug for ProxyInnerStatic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyInnerStatic")
+            .field(
+                "dest_owner_change_match_rule",
+                &self.dest_owner_change_match_rule,
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
@@ -203,8 +212,7 @@ where
 /// A [`stream::Stream`] implementation that yields property change notifications.
 ///
 /// Use [`Proxy::receive_property_changed`] to create an instance of this type.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct PropertyStream<'a, T> {
     name: &'a str,
     proxy: Proxy<'a>,


### PR DESCRIPTION
Ideally this dependency should be dropped/replaced, because it pulls old syn version, and is very unlikely to be ever updated. It is not as important while `zbus_macros` also depends on syn v1, though.