### PR TITLE
🐛 zx: Prevent collisions between methods, signals and properties

### DIFF
--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -45,6 +45,12 @@ trait SampleInterface0 {
         calypso: &zbus::zvariant::Value<'_>,
     ) -> zbus::Result<()>;
 
+    /// SetWallMessage method
+    fn set_wall_message(&self) -> zbus::Result<()>;
+
+    /// State method
+    fn state(&self) -> zbus::Result<()>;
+
     /// Changed signal
     #[zbus(signal)]
     fn changed(&self, new_value: bool) -> zbus::Result<()>;
@@ -67,6 +73,10 @@ trait SampleInterface0 {
     /// SignalValue signal
     #[zbus(signal)]
     fn signal_value(&self, value: zbus::zvariant::Value<'_>) -> zbus::Result<()>;
+
+    /// State signal
+    #[zbus(signal)]
+    fn state_(&self) -> zbus::Result<()>;
 
     /// Bar property
     #[zbus(property)]
@@ -94,4 +104,16 @@ trait SampleInterface0 {
             std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
         )>,
     >;
+
+    /// State property
+    #[zbus(property)]
+    fn state__(&self) -> zbus::Result<u8>;
+    #[zbus(property)]
+    fn set_state(&self, value: u8) -> zbus::Result<()>;
+
+    /// WallMessage property
+    #[zbus(property)]
+    fn wall_message(&self) -> zbus::Result<u8>;
+    #[zbus(property)]
+    fn set_wall_message_(&self, value: u8) -> zbus::Result<()>;
 }

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -36,6 +36,10 @@
        <arg name="polyphemus" type="i"/>
        <arg name="calypso" type="v"/>
      </method>
+     <method name="SetWallMessage">
+     </method>
+     <method name="State">
+     </method>
      <signal name="Changed">
        <arg name="new_value" type="b"/>
      </signal>
@@ -52,9 +56,13 @@
      <signal name="SignalDictStringToValue">
        <arg type="a{sv}" name="dict"/>
      </signal>
+     <signal name="State">
+     </signal>
      <property name="Bar" type="y" access="readwrite"/>
      <property name="Foo-Bar" type="y" access="readwrite"/>
      <property name="Matryoshkas" type="a(oiasta{sv})" access="read"/>
+     <property name="WallMessage" type="y" access="readwrite"/>
+     <property name="State" type="y" access="readwrite"/>
    </interface>
    <node name="child_of_sample_object"/>
    <node name="another_child_of_sample_object"/>


### PR DESCRIPTION
Prevent collisons by adding an explicit suffix to properties and signals.

If a collision is detected a `_` is added to the identifier until there is no more collision.

Closes:
- #231
- #169