### PR TITLE
🚑️ zb: Fix build on Windows with p2p enabled

### DIFF
--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -120,7 +120,7 @@ async fn self_credentials() -> io::Result<ConnectionCredentials> {
     #[cfg(windows)]
     {
         let sid = crate::win32::ProcessToken::open(None)?.sid()?;
-        creds = creds.set_windows_session_id(sid);
+        creds = creds.set_windows_sid(sid);
     }
 
     Ok(creds)


### PR DESCRIPTION
This fixes a regression from 5a6cdd00a8c19aabd32e25bb53a79c7d503078c6 where we used the wrong method name.