### PR TITLE
🔥 zb: Drop `windows-gdbus` feature & support autolaunch address unconditionally

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,25 +113,11 @@ jobs:
             c:/lib/*dbus*
             c:/bin/*pkg-config*
             c:/var/lib/*dbus*
-            c:/lib/*glib*
-            c:/lib/*gio*
-            c:/lib/*gobject*
-            c:/lib/*gmodule*
-            c:/lib/*gthread*
-            c:/lib/*gspawn*
-            c:/lib/*gresource*
             c:/lib/*pcre*
             c:/lib/*z*
             c:/lib/*ffi*
             c:/lib/*intl*
             c:/lib/*pkgconfig*
-            c:/bin/*glib*
-            c:/bin/*gio*
-            c:/bin/*gobject*
-            c:/bin/*gmodule*
-            c:/bin/*gthread*
-            c:/bin/*gspawn*
-            c:/bin/*gresource*
             c:/bin/*pcre*
             c:/bin/*z*
             c:/bin/*ffi*
@@ -154,17 +140,6 @@ jobs:
       - name: Setup MSVC Environment
         if: steps.cache-deps.outputs.cache-hit != 'true'
         uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Build & Install GLib
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          (New-Object System.Net.WebClient).DownloadString('https://wrapdb.mesonbuild.com/v2/pcre_8.37-2/get_patch') >$null
-          (New-Object System.Net.WebClient).DownloadString('https://zlib.net/fossils/') >$null
-          git clone --depth 1 --branch 2.74.1 https://gitlab.gnome.org/GNOME/glib.git \glib
-          cd -Path \glib
-          meson setup builddir
-          meson compile -C builddir
-          meson install --no-rebuild -C builddir
 
       - name: Build & Install libexpat
         if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,8 +97,6 @@ jobs:
       RUST_LOG: trace
       PKG_CONFIG: C:\bin\pkg-config.exe
       PKG_CONFIG_PATH: C:\lib\pkgconfig
-      DBUS_SESSION_BUS_ADDRESS: tcp:host=127.0.0.1,port=9876
-      ZBUS_GDBUS_TEST: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -194,21 +192,10 @@ jobs:
       - name: Test
         run: |
           $env:PATH += ";C:\bin"
-          Start-Process dbus-daemon.exe --config-file=CI/win32-session.conf
+          Start-Process dbus-daemon.exe '--config-file=CI/win32-session.conf --address=autolaunch:'
           cargo --locked test
           # tokio feature
           cargo --locked test --no-default-features --features tokio
-
-      - name: Test gdbus feature
-        run: |
-          $env:DBUS_SESSION_BUS_ADDRESS = $null
-          $env:PATH += ";C:\bin"
-          # This is an undocumented implementation detail, but easier and faster than calling the gdbus C library
-          Start-Process gdbus.exe _win32_run_session_bus
-          # The gdbus process above will exit when idle for more than three seconds, usually right in the middle
-          # of the doc tests. This process will keep it alive.
-          Start-Process gdbus.exe 'monitor -e -d org.freedesktop.DBus'
-          cargo --locked test --features zbus/windows-gdbus
 
   zvariant_fuzz:
     runs-on: ubuntu-latest

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -18,10 +18,6 @@ more appropriate for your use case.
 all `session()` share the same underlying connection for example. At the time of this writing,
 zbus doesn't do that.
 
-**Note:** on Windows, there is no standard implicit way to connect to a session bus. zbus provides
-opt-in compatibility to the GDBus session bus discovery mechanism via the `windows-gdbus` feature.
-This mechanism uses a machine-wide mutex however, so only one GDBus session bus can run at a time.
-
 **Note:** on macOS, there is no standard implicit way to connect to a session bus. zbus provides
 opt-in compatibility to the Launchd session bus discovery mechanism via the `launchctl getenv` feature.
 The official dbus installation method via `Homebrew` provides a session bus installation,

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -24,7 +24,6 @@ option-as-array = ["zvariant/option-as-array"]
 bus-impl = ["p2p"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = []
-windows-gdbus = []
 async-io = [
   "dep:async-io",
   "async-executor",

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -130,10 +130,6 @@ tick any executors etc. 😼
 **Note**: On Windows, the `async-io` feature is currently required for UNIX domain socket support,
 see [the corresponding tokio issue on GitHub][tctiog].
 
-**Note:** On Windows, there is no standard implicit way to connect to a session bus. zbus provides
-opt-in compatibility to the GDBus session bus discovery mechanism via the `windows-gdbus` feature.
-This mechanism uses a machine-wide mutex however, so only one GDBus session bus can run at a time.
-
 [zbus]: https://github.com/dbus2/zbus\#readme
 [bw]: https://docs.rs/zbus/latest/zbus/blocking/index.html
 [iektc]: https://docs.rs/zbus/latest/zbus/connection/struct.Connection.html#examples-1

--- a/zbus/src/address/transport/mod.rs
+++ b/zbus/src/address/transport/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the trasport information for D-Bus addresses.
 
 #[cfg(windows)]
-use crate::win32::windows_autolaunch_bus_address;
+use crate::win32::autolaunch_bus_address;
 use crate::{Error, Result};
 #[cfg(not(feature = "tokio"))]
 use async_io::Async;
@@ -194,7 +194,7 @@ impl Transport {
                     "Autolaunch scopes are currently unsupported".to_owned(),
                 )),
                 None => {
-                    let addr = windows_autolaunch_bus_address()?;
+                    let addr = autolaunch_bus_address()?;
                     addr.connect().await
                 }
             },

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1303,7 +1303,7 @@ mod tests {
     #[cfg(all(windows, feature = "windows-gdbus"))]
     #[test]
     fn connect_gdbus_session_bus() {
-        let addr = crate::win32::windows_autolaunch_bus_address()
+        let addr = crate::win32::autolaunch_bus_address()
             .expect("Unable to get GDBus session bus address");
 
         crate::block_on(async { addr.connect().await }).expect("Unable to connect to session bus");

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1300,11 +1300,11 @@ mod tests {
     use ntest::timeout;
     use test_log::test;
 
-    #[cfg(all(windows, feature = "windows-gdbus"))]
+    #[cfg(windows)]
     #[test]
-    fn connect_gdbus_session_bus() {
-        let addr = crate::win32::autolaunch_bus_address()
-            .expect("Unable to get GDBus session bus address");
+    fn connect_autolaunch_session_bus() {
+        let addr =
+            crate::win32::autolaunch_bus_address().expect("Unable to get session bus address");
 
         crate::block_on(async { addr.connect().await }).expect("Unable to connect to session bus");
     }

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -213,10 +213,6 @@ mod tests {
         Connection, Result,
     };
 
-    fn is_gdbus_test() -> bool {
-        std::env::var_os("ZBUS_GDBUS_TEST").is_some()
-    }
-
     #[test]
     fn msg() {
         let m = Message::method("/org/freedesktop/DBus", "GetMachineId")
@@ -256,9 +252,6 @@ mod tests {
             Err(crate::Error::MethodError(_, _, _)) => (),
             Err(e) => panic!("{}", e),
 
-            // GDBus allows the method to be called multiple times
-            Ok(_) if is_gdbus_test() => (),
-
             _ => panic!(),
         };
     }
@@ -284,9 +277,6 @@ mod tests {
         {
             Err(crate::Error::MethodError(_, _, _)) => (),
             Err(e) => panic!("{}", e),
-
-            // GDBus allows the method to be called multiple times
-            Ok(_) if is_gdbus_test() => (),
 
             _ => panic!(),
         };
@@ -395,11 +385,6 @@ mod tests {
             *connection.unique_name().unwrap(),
         );
 
-        // GDBus doesn't provide this method
-        if is_gdbus_test() {
-            return;
-        }
-
         let reply = connection
             .call_method(
                 Some("org.freedesktop.DBus"),
@@ -501,11 +486,6 @@ mod tests {
             body.deserialize::<UniqueName<'_>>().unwrap(),
             *connection.unique_name().unwrap(),
         );
-
-        // GDBus doesn't provide this method
-        if is_gdbus_test() {
-            return Ok(());
-        }
 
         let reply = connection
             .call_method(

--- a/zbus/src/win32.rs
+++ b/zbus/src/win32.rs
@@ -305,7 +305,7 @@ fn read_shm(name: &str) -> Result<Vec<u8>, crate::Error> {
     Ok(data.to_bytes().to_owned())
 }
 
-pub fn windows_autolaunch_bus_address() -> Result<Address, crate::Error> {
+pub fn autolaunch_bus_address() -> Result<Address, crate::Error> {
     let mutex = Mutex::new("DBusAutolaunchMutex")?;
     let _guard = mutex.lock();
 


### PR DESCRIPTION
Turns out that the reference dbus implementation supports autolaunch fine and we don't need gdbus binary or special support for it. Hopefully, in the near future, [busd will also support it](https://github.com/dbus2/busd/issues/67).

This PR drops the `windows-gdbus` feature. This means we're no longer compatible with gdbus binary but that's not our fault that it can't handle handshake pipelining. I seriously doubt anyone uses this anyway.

Fixes #687.
