### PR TITLE
🔌 zb: Send `Hello` method as part of the handshake (client-side)

### DIFF
--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -378,6 +378,16 @@ impl<'a> Builder<'a> {
     }
 
     async fn build_(mut self, executor: Executor<'static>) -> Result<Connection> {
+        #[cfg(feature = "p2p")]
+        let is_bus_conn = !self.p2p;
+        #[cfg(not(feature = "p2p"))]
+        let is_bus_conn = true;
+
+        #[cfg(not(feature = "bus-impl"))]
+        let unique_name = None;
+        #[cfg(feature = "bus-impl")]
+        let unique_name = self.unique_name.take().map(Into::into);
+
         #[allow(unused_mut)]
         let (mut stream, server_guid, authenticated) = self.target_connect().await?;
         let mut auth = if authenticated {
@@ -390,13 +400,15 @@ impl<'a> Builder<'a> {
                 // SAFETY: `server_guid` is provided as arg of `Builder::authenticated_socket`.
                 server_guid: server_guid.unwrap(),
                 already_received_bytes: None,
+                unique_name,
             }
         } else {
             #[cfg(feature = "p2p")]
             match self.guid {
                 None => {
                     // SASL Handshake
-                    Authenticated::client(stream, server_guid, self.auth_mechanisms).await?
+                    Authenticated::client(stream, server_guid, self.auth_mechanisms, is_bus_conn)
+                        .await?
                 }
                 Some(guid) => {
                     if !self.p2p {
@@ -419,29 +431,22 @@ impl<'a> Builder<'a> {
                         self.auth_mechanisms,
                         self.cookie_id,
                         self.cookie_context.unwrap_or_default(),
+                        unique_name,
                     )
                     .await?
                 }
             }
 
             #[cfg(not(feature = "p2p"))]
-            Authenticated::client(stream, server_guid, self.auth_mechanisms).await?
+            Authenticated::client(stream, server_guid, self.auth_mechanisms, is_bus_conn).await?
         };
 
         // SAFETY: `Authenticated` is always built with these fields set to `Some`.
         let socket_read = auth.socket_read.take().unwrap();
         let already_received_bytes = auth.already_received_bytes.take();
 
-        #[cfg(feature = "p2p")]
-        let is_bus_conn = !self.p2p;
-        #[cfg(not(feature = "p2p"))]
-        let is_bus_conn = true;
         let mut conn = Connection::new(auth, is_bus_conn, executor).await?;
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));
-        #[cfg(feature = "bus-impl")]
-        if let Some(unique_name) = self.unique_name {
-            conn.set_unique_name(unique_name)?;
-        }
 
         if !self.interfaces.is_empty() {
             let object_server = conn.sync_object_server(false, None);
@@ -467,11 +472,6 @@ impl<'a> Builder<'a> {
 
         // Start the socket reader task.
         conn.init_socket_reader(socket_read, already_received_bytes);
-
-        if is_bus_conn {
-            // Now that the server has approved us, we must send the bus Hello, as per specs
-            conn.hello_bus().await?;
-        }
 
         for name in self.names {
             conn.request_name(name).await?;

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -389,7 +389,7 @@ impl<'a> Builder<'a> {
                 socket_write,
                 // SAFETY: `server_guid` is provided as arg of `Builder::authenticated_socket`.
                 server_guid: server_guid.unwrap(),
-                already_received_bytes: Some(vec![]),
+                already_received_bytes: None,
             }
         } else {
             #[cfg(feature = "p2p")]
@@ -430,7 +430,7 @@ impl<'a> Builder<'a> {
 
         // SAFETY: `Authenticated` is always built with these fields set to `Some`.
         let socket_read = auth.socket_read.take().unwrap();
-        let already_received_bytes = auth.already_received_bytes.take().unwrap();
+        let already_received_bytes = auth.already_received_bytes.take();
 
         #[cfg(feature = "p2p")]
         let is_bus_conn = !self.p2p;

--- a/zbus/src/connection/handshake/common.rs
+++ b/zbus/src/connection/handshake/common.rs
@@ -54,11 +54,15 @@ impl Common {
 
     #[instrument(skip(self))]
     pub async fn write_command(&mut self, command: Command) -> Result<()> {
-        self.write_commands(&[command]).await
+        self.write_commands(&[command], None).await
     }
 
     #[instrument(skip(self))]
-    pub async fn write_commands(&mut self, commands: &[Command]) -> Result<()> {
+    pub async fn write_commands(
+        &mut self,
+        commands: &[Command],
+        extra_bytes: Option<&[u8]>,
+    ) -> Result<()> {
         let mut send_buffer =
             commands
                 .iter()
@@ -68,6 +72,9 @@ impl Common {
                     acc.extend_from_slice(b"\r\n");
                     acc
                 });
+        if let Some(extra_bytes) = extra_bytes {
+            send_buffer.extend_from_slice(extra_bytes);
+        }
         while !send_buffer.is_empty() {
             let written = self
                 .socket

--- a/zbus/src/connection/handshake/server.rs
+++ b/zbus/src/connection/handshake/server.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
+use sha1::{Digest, Sha1};
 use std::collections::VecDeque;
 use tracing::{instrument, trace};
 
-use sha1::{Digest, Sha1};
+use crate::names::OwnedUniqueName;
 
 use super::{
     random_ascii, sasl_auth_id, AuthMechanism, Authenticated, BoxedSplit, Command, Common, Cookie,
@@ -36,6 +37,7 @@ pub struct Server<'s> {
     client_sid: Option<String>,
     cookie_id: Option<usize>,
     cookie_context: CookieContext<'s>,
+    unique_name: Option<OwnedUniqueName>,
 }
 
 impl<'s> Server<'s> {
@@ -47,6 +49,7 @@ impl<'s> Server<'s> {
         mechanisms: Option<VecDeque<AuthMechanism>>,
         cookie_id: Option<usize>,
         cookie_context: CookieContext<'s>,
+        unique_name: Option<OwnedUniqueName>,
     ) -> Result<Server<'s>> {
         let mechanisms = match mechanisms {
             Some(mechanisms) => mechanisms,
@@ -68,6 +71,7 @@ impl<'s> Server<'s> {
             cookie_id,
             cookie_context,
             guid,
+            unique_name,
         })
     }
 
@@ -288,6 +292,7 @@ impl Handshake for Server<'_> {
                         #[cfg(unix)]
                         cap_unix_fd,
                         already_received_bytes: Some(recv_buffer),
+                        unique_name: self.unique_name,
                     });
                 }
             }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1240,7 +1240,7 @@ impl Connection {
     pub(crate) fn init_socket_reader(
         &self,
         socket_read: Box<dyn socket::ReadHalf>,
-        already_read: Vec<u8>,
+        already_read: Option<Vec<u8>>,
     ) {
         let inner = &self.inner;
         inner

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -22,13 +22,13 @@ impl SocketReader {
     pub fn new(
         socket: Box<dyn ReadHalf>,
         senders: Arc<Mutex<HashMap<Option<OwnedMatchRule>, MsgBroadcaster>>>,
-        already_received_bytes: Vec<u8>,
+        already_received_bytes: Option<Vec<u8>>,
         activity_event: Arc<Event>,
     ) -> Self {
         Self {
             socket,
             senders,
-            already_received_bytes: Some(already_received_bytes),
+            already_received_bytes,
             prev_seq: 0,
             activity_event,
         }

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -1101,8 +1101,13 @@ mod tests {
         // Let's first create an interator to get the signals (it has to be another connection).
         let conn = blocking::Connection::session().unwrap();
         let mut iterator = blocking::MessageIterator::for_match_rule(
-            "type='signal',interface='org.freedesktop.DBus.ObjectManager',\
-            path='/org/zbus/NoObjectManagerSignalsBeforeHello'",
+            zbus::MatchRule::builder()
+                .msg_type(zbus::MessageType::Signal)
+                .interface("org.freedesktop.DBus.ObjectManager")
+                .unwrap()
+                .path("/org/zbus/NoObjectManagerSignalsBeforeHello")
+                .unwrap()
+                .build(),
             &conn,
             None,
         )

--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -57,8 +57,7 @@ impl Introspectable {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let node = root
-            .get_child(path, false)
-            .0
+            .get_child(path)
             .ok_or_else(|| Error::UnknownObject(format!("Unknown object '{path}'")))?;
 
         Ok(node.introspect().await)
@@ -129,8 +128,7 @@ impl Properties {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
-            .get_child(path, false)
-            .0
+            .get_child(path)
             .and_then(|node| node.interface_lock(interface_name.as_ref()))
             .ok_or_else(|| {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
@@ -156,8 +154,7 @@ impl Properties {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
-            .get_child(path, false)
-            .0
+            .get_child(path)
             .and_then(|node| node.interface_lock(interface_name.as_ref()))
             .ok_or_else(|| {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
@@ -195,8 +192,7 @@ impl Properties {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
-            .get_child(path, false)
-            .0
+            .get_child(path)
             .and_then(|node| node.interface_lock(interface_name.as_ref()))
             .ok_or_else(|| {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
@@ -297,8 +293,7 @@ impl ObjectManager {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let node = root
-            .get_child(path, false)
-            .0
+            .get_child(path)
             .ok_or_else(|| Error::UnknownObject(format!("Unknown object '{path}'")))?;
 
         node.get_managed_objects().await


### PR DESCRIPTION
This avoids unnecessary round trips and makes the connection setup faster.