### PR TITLE
🚸 zv: Dict add iterator support

### DIFF
--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -151,12 +151,29 @@ impl<'k, 'v> Dict<'k, 'v> {
         }
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&Value<'k>, &Value<'v>)> {
+        self.map.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Value<'k>, &mut Value<'v>)> {
+        self.map.iter_mut()
+    }
+
     // TODO: Provide more API like https://docs.rs/toml/0.5.5/toml/map/struct.Map.html
 }
 
 impl Display for Dict<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         dict_display_fmt(self, f, true)
+    }
+}
+
+impl<'k, 'v> IntoIterator for Dict<'k, 'v> {
+    type Item = (Value<'k>, Value<'v>);
+    type IntoIter = <BTreeMap<Value<'k>, Value<'v>> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
     }
 }
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1156,6 +1156,30 @@ mod tests {
         let map: BTreeMap<i64, String> = dict.try_into().unwrap();
         assert_eq!(map[&1], "123");
         assert_eq!(map[&2], "456");
+        // Use iterator
+        let mut dict = Dict::from(map);
+        let expect = vec![
+            (Value::from(1i64), Value::from("123")),
+            (Value::from(2i64), Value::from("456")),
+        ];
+        let expect_iter = expect.iter().map(|(k, v)| (k, v)).collect::<Vec<_>>();
+        let actual = dict.iter().collect::<Vec<_>>();
+        assert_eq!(actual, expect_iter);
+        let actual = (&dict).iter().collect::<Vec<_>>();
+        assert_eq!(actual, expect_iter);
+        let actual = (&mut dict).iter().collect::<Vec<_>>();
+        assert_eq!(actual, expect_iter);
+        for (_, v) in dict.iter_mut() {
+            if let Value::Str(vv) = v {
+                *vv = Str::from(vv.to_string() + "-hello");
+            }
+        }
+        let actual = dict.into_iter().collect::<Vec<_>>();
+        let expect = vec![
+            (Value::from(1i64), Value::from("123-hello")),
+            (Value::from(2i64), Value::from("456-hello")),
+        ];
+        assert_eq!(actual, expect);
 
         #[cfg(feature = "gvariant")]
         {


### PR DESCRIPTION
This change aims to partially solve #281 to expose an API for `zvariant::Dict` to iterate via a tuple of key and value, aka. (Value, Value) type.

However, because we have migrated to use `BTreeMap<K, V>` for `zvariant::Dict`'s internal representation, we still cannot use `f64` as keys based on the restrictions of `Ord` required by `BTreeMap::<K, V>::insert()` function signature.

```rust
pub fn insert(&mut self, key: K, value: V) -> Option<V>
where
    K: Ord;
```

Since all `Basic` types are allowed in D-Bus specification, we still need to think of a way to allow users to correctly build up a `zvariant::Dict` whose signature is similar to `a{dv}`.