### PR TITLE
:memo: zv: document serde_repr usage for enums

### DIFF
--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -100,8 +100,11 @@ let encoded = to_bytes(ctxt, &e).unwrap();
 let decoded: Enum = encoded.deserialize().unwrap().0;
 assert_eq!(decoded, e);
 
-#[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
-// W/o `repr` spec, `u32` is assumed.
+// Enum encoding can be adjusted by using the `serde_repr` crate
+// and by annotating the representation of the enum with `repr`.
+use serde_repr::{Serialize_repr, Deserialize_repr};
+
+#[derive(Deserialize_repr, Serialize_repr, Type, PartialEq, Debug)]
 #[repr(u8)]
 enum UnitEnum {
     Variant1,


### PR DESCRIPTION
Previously it was unclear that the `serde_repr` crate was required for unit enums to be serialized with the proper width as provided by a given `#[repr(_)]` annotation. Just adding a quick shout out to hopefully avoid confusion in the future.

Fixes #686