### PR TITLE
🚨 docs: Allow dead code in doc samples

### DIFF
--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]

--- a/zbus_names/src/lib.rs
+++ b/zbus_names/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
+    allow(dead_code),
     // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates),
 )))]


### PR DESCRIPTION
Otherwise, the docs test will fail on latest Rust release:

```rust
---- zbus/src/lib.rs - doctests (line 37) stdout ----
error: struct `DictionaryGiverInterface` is never constructed
  --> zbus/src/lib.rs:63:8
   |
31 | struct DictionaryGiverInterface;
   |        ^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> zbus/src/lib.rs:34:9
   |
2  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`

error: method `give_me` is never used
  --> zbus/src/lib.rs:67:8
   |
34 | impl DictionaryGiverInterface {
   | ----------------------------- method in this implementation
35 |     fn give_me(&self) -> Result<Dictionary> {
   |        ^^^^^^^

error: aborting due to 2 previous errors

Couldn't compile the test.

failures:
    zbus/src/lib.rs - doctests (line 37)
```

Fixes #766.