### PR TITLE
🚑️ zb: Use `assert!` instead of `debug_assert!`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,10 +55,17 @@ jobs:
   linux_test:
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
+    strategy:
+      matrix:
+        # Test in both debug and release mode
+        env:
+          - PROFILE: dev
+          - PROFILE: release
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
       RUST_LOG: trace
+      PROFILE: ${{ matrix.env.PROFILE }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -73,20 +80,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build and Test
         run: |
-          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --verbose -- basic_connection
+          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --profile "$PROFILE" --verbose -- basic_connection
           # All features except tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
+            cargo --locked test --profile "$PROFILE" --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
               -- --skip fdpass_systemd
           # check cookie-sha1 auth against dbus-daemon
           sed -i s/EXTERNAL/DBUS_COOKIE_SHA1/g /tmp/dbus-session.conf
-          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo --locked test --verbose -- basic_connection
+          dbus-run-session --config-file /tmp/dbus-session.conf -- cargo --locked test --profile "$PROFILE" --verbose -- basic_connection
           # Test tokio support.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --verbose --tests -p zbus --no-default-features \
+            cargo --locked test --profile "$PROFILE" --verbose --tests -p zbus --no-default-features \
               --features tokio-vsock -- --skip fdpass_systemd
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --verbose --doc --no-default-features connection::Connection::executor
+            cargo --locked test --profile "$PROFILE" --verbose --doc --no-default-features connection::Connection::executor
 
   windows_test:
     runs-on: windows-latest

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -194,9 +194,9 @@ impl Node {
             path,
             ..Default::default()
         };
-        debug_assert!(node.add_interface(Peer));
-        debug_assert!(node.add_interface(Introspectable));
-        debug_assert!(node.add_interface(Properties));
+        assert!(node.add_interface(Peer));
+        assert!(node.add_interface(Introspectable));
+        assert!(node.add_interface(Properties));
 
         node
     }


### PR DESCRIPTION
`debug_assert!` is removed in release builds, along with any values computed inside it. This meant that since the use of `debug_assert!` in commit 7fc3ab7b8f69e21822a0d569222baba4b72de13f, the fdo interfaces weren't getting added for nodes for release profile. Let's use `assert!` instead.
    
Fixes #764.
