### PR TITLE
🎨 zb: Ensure all messsage bytes received during handshake are used

### DIFF
--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -2,11 +2,14 @@
 use async_io::Async;
 use event_listener::Event;
 use static_assertions::assert_impl_all;
-use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
 #[cfg(all(unix, not(feature = "tokio")))]
 use std::os::unix::net::UnixStream;
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    vec,
+};
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
 #[cfg(all(unix, feature = "tokio"))]
@@ -404,7 +407,7 @@ impl<'a> Builder<'a> {
                 socket_write,
                 // SAFETY: `server_guid` is provided as arg of `Builder::authenticated_socket`.
                 server_guid: server_guid.unwrap(),
-                already_received_bytes: None,
+                already_received_bytes: vec![],
                 unique_name,
             }
         } else {
@@ -448,7 +451,7 @@ impl<'a> Builder<'a> {
 
         // SAFETY: `Authenticated` is always built with these fields set to `Some`.
         let socket_read = auth.socket_read.take().unwrap();
-        let already_received_bytes = auth.already_received_bytes.take();
+        let already_received_bytes = auth.already_received_bytes.drain(..).collect();
 
         let mut conn = Connection::new(auth, is_bus_conn, executor).await?;
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -44,7 +44,7 @@ pub struct Authenticated {
     pub(crate) cap_unix_fd: bool,
 
     pub(crate) socket_read: Option<Box<dyn ReadHalf>>,
-    pub(crate) already_received_bytes: Option<Vec<u8>>,
+    pub(crate) already_received_bytes: Vec<u8>,
     pub(crate) unique_name: Option<OwnedUniqueName>,
 }
 

--- a/zbus/src/connection/handshake/server.rs
+++ b/zbus/src/connection/handshake/server.rs
@@ -302,7 +302,7 @@ impl Handshake for Server<'_> {
             server_guid: self.guid,
             #[cfg(unix)]
             cap_unix_fd,
-            already_received_bytes: Some(recv_buffer),
+            already_received_bytes: recv_buffer,
             unique_name: self.unique_name,
         })
     }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1209,7 +1209,7 @@ impl Connection {
     pub(crate) fn init_socket_reader(
         &self,
         socket_read: Box<dyn socket::ReadHalf>,
-        already_read: Option<Vec<u8>>,
+        already_read: Vec<u8>,
     ) {
         let inner = &self.inner;
         inner

--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -61,7 +61,7 @@ impl super::ReadHalf for Reader {
     async fn receive_message(
         &mut self,
         _seq: u64,
-        _already_received_bytes: Option<Vec<u8>>,
+        _already_received_bytes: &mut Vec<u8>,
     ) -> crate::Result<Message> {
         self.0.recv().await.map_err(|e| {
             crate::Error::InputOutput(io::Error::new(io::ErrorKind::BrokenPipe, e).into())

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -13,7 +13,7 @@ use super::socket::ReadHalf;
 pub(crate) struct SocketReader {
     socket: Box<dyn ReadHalf>,
     senders: Arc<Mutex<HashMap<Option<OwnedMatchRule>, MsgBroadcaster>>>,
-    already_received_bytes: Option<Vec<u8>>,
+    already_received_bytes: Vec<u8>,
     prev_seq: u64,
     activity_event: Arc<Event>,
 }
@@ -22,7 +22,7 @@ impl SocketReader {
     pub fn new(
         socket: Box<dyn ReadHalf>,
         senders: Arc<Mutex<HashMap<Option<OwnedMatchRule>, MsgBroadcaster>>>,
-        already_received_bytes: Option<Vec<u8>>,
+        already_received_bytes: Vec<u8>,
         activity_event: Arc<Event>,
     ) -> Self {
         Self {
@@ -96,7 +96,7 @@ impl SocketReader {
         let seq = self.prev_seq + 1;
         let msg = self
             .socket
-            .receive_message(seq, self.already_received_bytes.take())
+            .receive_message(seq, &mut self.already_received_bytes)
             .await?;
         self.prev_seq = seq;
 


### PR DESCRIPTION
Don't assume that only a single full message could be received at the end of the client handshake process. We may receive other messages too if the server is very quick in sending them (or batches them). Worst case scenario, we could also end up receiving partial messages, which would currently completely break the connection state.

Let's be a bit smart about this and ensure that we consume all the bytes that are received during the handshake process.

We are changing the type of the `already_received_bytes` arg of `connection::socket::ReadHalf::receive_message` and theoretically, this is an API break but given this is very new API, it's very unlikely that anyone implements Socket anyway and this change is needed to fix the issue at hand, let's not worry about it.