### PR TITLE
🚑️ zb,zm: Don't invalidate all properties on change

### DIFF
--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -830,10 +830,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     let changed = props_changed.next().await.unwrap();
     let expected_property_key = "EmitsChangedDefault";
     let args = changed.args()?;
-    assert_eq!(
-        args.invalidated_properties(),
-        &vec![expected_property_key.to_string()]
-    );
+    assert!(args.invalidated_properties().is_empty());
 
     let changed_prop_key = *args.changed_properties().keys().next().unwrap();
     assert_eq!(changed_prop_key, expected_property_key);
@@ -850,10 +847,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     let changed = props_changed.next().await.unwrap();
     let expected_property_key = "EmitsChangedTrue";
     let args = changed.args()?;
-    assert_eq!(
-        args.invalidated_properties(),
-        &vec![expected_property_key.to_string()]
-    );
+    assert!(args.invalidated_properties().is_empty());
 
     let changed_prop_key = *args.changed_properties().keys().next().unwrap();
     assert_eq!(changed_prop_key, expected_property_key);

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -840,6 +840,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
         <&Value as TryInto<u32>>::try_into(changed_value).unwrap(),
         expected_property_value
     );
+    assert!(args.invalidated_properties().is_empty());
 
     proxy
         .set_emits_changed_true(expected_property_value)
@@ -857,6 +858,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
         <&Value as TryInto<u32>>::try_into(changed_value).unwrap(),
         expected_property_value
     );
+    assert!(args.invalidated_properties().is_empty());
 
     proxy
         .set_emits_changed_invalidates(expected_property_value)
@@ -887,6 +889,8 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
         args.invalidated_properties(),
         &vec![unexpected_property_key.to_string()]
     );
+    assert!(!args.changed_properties().is_empty());
+    assert!(args.invalidated_properties().is_empty());
 
     proxy
         .set_emits_changed_false(expected_property_value)
@@ -901,6 +905,8 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
         args.invalidated_properties(),
         &vec![unexpected_property_key.to_string()]
     );
+    assert!(!args.changed_properties().is_empty());
+    assert!(args.invalidated_properties().is_empty());
 
     proxy.quit().await?;
     Ok(val)

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -868,7 +868,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
         args.invalidated_properties(),
         &vec![expected_property_key.to_string()]
     );
-    assert_eq!(args.changed_properties().keys().len(), 0);
+    assert!(args.changed_properties().is_empty());
 
     // First set a property for which we don't expect a signal
     // then set a property for which we do (and we checked above

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -632,7 +632,7 @@ pub fn expand<T: AttrParse + Into<TraitAttrs>, M: AttrParse + Into<MethodAttrs>>
                                 signal_context,
                                 #zbus::names::InterfaceName::from_static_str_unchecked(#iface_name),
                                 &changed,
-                                &[#member_name],
+                                &[],
                             ).await
                         }
                     );


### PR DESCRIPTION
 This fixes a regression in c1aa5c72cee6ba78f5b803f44418c3fc1826200b, where we started to invalidate properties in every `PropertyChanged` signal. This is wrong anyway but it also meant zbus interfaces breaking against gio.

Fixes #765.
