### PR TITLE
✨ zv: support ser/de of values directly

### DIFF
--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -75,6 +75,11 @@ impl<'k, 'v> Dict<'k, 'v> {
         Ok(())
     }
 
+    /// Remove the first entry
+    pub fn remove(&mut self) -> Option<(Value<'k>, Value<'v>)> {
+        self.map.pop_first()
+    }
+
     /// Get the value for the given key.
     pub fn get<'d, K, V>(&'d self, key: &'k K) -> Result<Option<V>, Error>
     where

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -38,7 +38,6 @@ impl fmt::Display for MaxDepthExceeded {
 pub enum Error {
     /// Generic error. All serde errors gets transformed into this variant.
     Message(String),
-
     /// Wrapper for [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html)
     InputOutput(Arc<io::Error>),
     /// Type conversions errors.

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -164,6 +164,11 @@ pub struct Structure<'a> {
 assert_impl_all!(Structure<'_>: Send, Sync, Unpin);
 
 impl<'a> Structure<'a> {
+    pub fn new(fields: Vec<Value<'a>>) -> Self {
+        let signature = create_signature_from_fields(&fields);
+        Self { fields, signature }
+    }
+
     /// Get a reference to all the fields of `self`.
     pub fn fields(&self) -> &[Value<'a>] {
         &self.fields

--- a/zvariant/src/value/value_de.rs
+++ b/zvariant/src/value/value_de.rs
@@ -1,0 +1,380 @@
+use std::os::fd::AsRawFd;
+
+use serde::de::IntoDeserializer;
+use serde::de::MapAccess;
+use serde::de::SeqAccess;
+use serde::de::Visitor;
+use serde::Deserializer;
+use crate::Array;
+use crate::Dict;
+use crate::ObjectPath;
+use crate::Signature;
+use crate::Structure;
+use crate::Value;
+
+macro_rules! deserialize_method {
+    ($method:ident($($arg:ident: $type:ty),*)) => {
+        #[inline]
+        fn $method<V>(self, $($arg: $type,)* visitor: V) -> Result<V::Value, crate::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.value {
+                Value::Value(value) => value.into_deserializer().$method($($arg,)* visitor),
+                _ => self.deserialize_any(visitor)
+            }
+        }
+    }
+}
+
+pub struct ValueDeserializer<'de> {
+    value: Value<'de>
+}
+
+impl<'de> ValueDeserializer<'de> {
+    pub fn new(value: Value<'de>) -> Self {
+        Self {
+            value
+        }
+    }
+}
+
+impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
+    type Error = crate::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de> {
+        match self.value {
+            Value::U8(v) => visitor.visit_u8(v),
+            Value::Bool(v) => visitor.visit_bool(v),
+            Value::I16(v) => visitor.visit_i16(v),
+            Value::U16(v) => visitor.visit_u16(v),
+            Value::I32(v) => visitor.visit_i32(v),
+            Value::Fd(v) => visitor.visit_i32(v.as_raw_fd()),
+            Value::U32(v) => visitor.visit_u32(v),
+            Value::I64(v) => visitor.visit_i64(v),
+            Value::U64(v) => visitor.visit_u64(v),
+            Value::F64(v) => visitor.visit_f64(v),
+            Value::Str(v) => visitor.visit_str(v.as_str()),
+            Value::Signature(sig) => visitor.visit_str(sig.as_str()),
+            Value::ObjectPath(path) => visitor.visit_str(path.as_str()),
+            Value::Value(value) => visitor.visit_map(ValueAccess::new(*value)),
+            Value::Array(array) => visitor.visit_seq(ArrayAccess::new(array)),
+            Value::Dict(dict) => visitor.visit_map(DictAccess::new(dict)),
+            Value::Structure(structure) => visitor.visit_seq(StructureAccess::new(structure)),
+            #[cfg(feature = "gvariant")]
+            Value::Maybe(value) => todo!()
+        }
+    }
+
+    deserialize_method!(deserialize_bool());
+    deserialize_method!(deserialize_i8());
+    deserialize_method!(deserialize_i16());
+    deserialize_method!(deserialize_i32());
+    deserialize_method!(deserialize_i64());
+    deserialize_method!(deserialize_u8());
+    deserialize_method!(deserialize_u16());
+    deserialize_method!(deserialize_u32());
+    deserialize_method!(deserialize_u64());
+    deserialize_method!(deserialize_f32());
+    deserialize_method!(deserialize_f64());
+    deserialize_method!(deserialize_char());
+    deserialize_method!(deserialize_str());
+    deserialize_method!(deserialize_string());
+    deserialize_method!(deserialize_bytes());
+    deserialize_method!(deserialize_byte_buf());
+    deserialize_method!(deserialize_option());
+    deserialize_method!(deserialize_unit());
+    deserialize_method!(deserialize_unit_struct(n: &'static str));
+    deserialize_method!(deserialize_newtype_struct(n: &'static str));
+    deserialize_method!(deserialize_seq());
+    deserialize_method!(deserialize_map());
+    deserialize_method!(deserialize_tuple(n: usize));
+    deserialize_method!(deserialize_tuple_struct(n: &'static str, l: usize));
+    deserialize_method!(deserialize_struct(n: &'static str, f: &'static [&'static str]));
+    deserialize_method!(deserialize_enum(n: &'static str, f: &'static [&'static str]));
+    deserialize_method!(deserialize_identifier());
+    deserialize_method!(deserialize_ignored_any());
+}
+
+enum ValueAccessState {
+    ReadingSignature,
+    ReadingValue,
+    Done
+}
+
+struct ValueAccess<'de> {
+    value: Value<'de>,
+    state: ValueAccessState
+}
+
+impl<'de> ValueAccess<'de> {
+    pub fn new(value: Value<'de>) -> Self {
+        Self {
+            value,
+            state: ValueAccessState::ReadingSignature
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for ValueAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de> {
+        match self.state {
+            ValueAccessState::ReadingSignature => {
+                seed.deserialize("zvariant::Value::Signature".into_deserializer()).map(Some)
+            },
+            ValueAccessState::ReadingValue => {
+                seed.deserialize("zvariant::Value::Value".into_deserializer()).map(Some)
+            },
+            ValueAccessState::Done => Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de> {
+        match self.state {
+            ValueAccessState::ReadingSignature => {
+                self.state = ValueAccessState::ReadingValue;
+                seed.deserialize(self.value.value_signature().into_deserializer())
+            },
+            ValueAccessState::ReadingValue => {
+                self.state = ValueAccessState::Done;
+                seed.deserialize(self.value.try_clone()?.into_deserializer())
+            },
+            ValueAccessState::Done => unreachable!()
+        }
+    }
+}
+
+struct ArrayAccess<'de> {
+    array: Array<'de>
+}
+
+impl<'de> ArrayAccess<'de> {
+    pub fn new(array: Array<'de>) -> Self {
+        Self {
+            array
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for ArrayAccess<'de> {
+    type Error = crate::Error;
+    
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de> {
+
+        if let Some(item) = self.array.remove() {
+            seed.deserialize(item.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+struct DictAccess<'de> {
+    dict: Dict<'de, 'de>,
+    next_value: Option<Value<'de>>
+}
+
+impl<'de> DictAccess<'de> {
+    pub fn new(dict: Dict<'de, 'de>) -> Self {
+        Self {
+            dict,
+            next_value: None
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for DictAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de> {
+        
+        if let Some((key, value)) = self.dict.remove() {
+            self.next_value = Some(value);
+            seed.deserialize(key.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de> {
+        if let Some(value) = self.next_value.take() {
+            seed.deserialize(value.into_deserializer())
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+struct StructureAccess<'de> {
+    fields: Vec<Value<'de>>
+}
+
+impl<'de> StructureAccess<'de> {
+    pub fn new(structure: Structure<'de>) -> Self {
+        Self {
+            fields: structure.into_fields()
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for StructureAccess<'de> {
+    type Error = crate::Error;
+    
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de> {
+
+        if let Some(item) = self.fields.pop() {
+            seed.deserialize(item.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::OwnedObjectPath;
+    use crate::OwnedSignature;
+    use super::*;
+    use serde::Deserialize;
+    use serde::Serialize;
+
+    #[test]
+    fn deserialize_i16() {
+        let de = Value::I16(42).into_deserializer();
+        let result: i16 = i16::deserialize(de).expect("Should find an i16");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_i32() {
+        let de = Value::I32(42).into_deserializer();
+        let result: i32 = i32::deserialize(de).expect("Should find an i32");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_i64() {
+        let de = Value::I64(42).into_deserializer();
+        let result: i64 = i64::deserialize(de).expect("Should find an i32");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u8() {
+        let de = Value::U8(42).into_deserializer();
+        let result: u8 = u8::deserialize(de).expect("Should find an u8");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u16() {
+        let de = Value::U16(42).into_deserializer();
+        let result: u16 = u16::deserialize(de).expect("Should find an u16");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u32() {
+        let de = Value::U32(42).into_deserializer();
+        let result: u32 = u32::deserialize(de).expect("Should find an u32");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u64() {
+        let de = Value::U64(42).into_deserializer();
+        let result: u64 = u64::deserialize(de).expect("Should find an u64");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_f64() {
+        let de = Value::F64(3.14).into_deserializer();
+        let result: f64 = f64::deserialize(de).expect("Should find an f64");
+        assert_eq!(result, 3.14);
+    }
+
+    #[test]
+    fn deserialize_str() {
+        let de = Value::Str("hello".into()).into_deserializer();
+        let result: String = String::deserialize(de).expect("Should find a string");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn deserialize_signature() {
+        let de = Value::Signature(Signature::from_str_unchecked("a{sv}")).into_deserializer();
+        let result: Signature<'_> = Signature::deserialize(de).expect("Should find a signature");
+        assert_eq!(result.as_str(), "a{sv}");
+    }
+
+    #[test]
+    fn deserialize_object_path() {
+        let de = Value::ObjectPath(ObjectPath::from_str_unchecked("/hello")).into_deserializer();
+        let result: ObjectPath<'_> = ObjectPath::deserialize(de).expect("Should find an object path");
+        assert_eq!(result.as_str(), "/hello");
+    }
+
+    #[test]
+    fn deserialize_array() {
+        let array = Array::from(vec![42, 43]);
+        let de = Value::Array(array).into_deserializer();
+        let result: Vec<u32> = Vec::deserialize(de).expect("Should find an array");
+        assert_eq!(result, vec![42, 43]);
+    }
+
+    #[test]
+    fn deserialize_dict() {
+        let mut dict = Dict::new(
+            Signature::from_str_unchecked("s"),
+            Signature::from_str_unchecked("i")
+        );
+
+        dict.add("hello", 42).expect("Should append");
+        dict.add("world", 43).expect("Should append");
+
+
+        let de = Value::Dict(dict).into_deserializer();
+        let result: std::collections::HashMap<String, u32> = std::collections::HashMap::deserialize(de).expect("Should find a dict");
+        assert_eq!(result.get("hello"), Some(&42));
+        assert_eq!(result.get("world"), Some(&43));
+    }
+
+    #[test]
+    fn deserialize_dict_struct() {
+        #[derive(Deserialize)]
+        struct MyStruct {
+            a: OwnedObjectPath,
+            b: OwnedSignature
+        }
+
+        let mut dict = Dict::new(
+            Signature::from_str_unchecked("s"),
+            Signature::from_str_unchecked("v")
+        );
+
+        dict.add("a", Value::new(ObjectPath::from_static_str_unchecked("/hello"))).expect("Should append");
+        dict.add("b", Value::new(Signature::from_static_str_unchecked("s"))).expect("Should append");
+
+        let de = Value::Dict(dict).into_deserializer();
+        let result: MyStruct = MyStruct::deserialize(de).expect("Should find a dict");
+        assert_eq!(result.a.as_str(), "/hello");
+        assert_eq!(result.b.as_str(), "s");
+    }
+}

--- a/zvariant/src/value/value_ser.rs
+++ b/zvariant/src/value/value_ser.rs
@@ -1,0 +1,707 @@
+use std::marker::PhantomData;
+use serde::ser::SerializeMap;
+use serde::ser::SerializeSeq;
+use serde::ser::SerializeStruct;
+use serde::ser::SerializeStructVariant;
+use serde::ser::SerializeTuple;
+use serde::ser::SerializeTupleStruct;
+use serde::ser::SerializeTupleVariant;
+use serde::Serializer;
+use crate::signature_parser::SignatureParser;
+use crate::Array;
+use crate::Dict;
+use crate::ObjectPath;
+use crate::Signature;
+use crate::Str;
+use crate::Structure;
+use crate::Value;
+use crate::basic::Basic;
+use crate::r#type::Type;
+use crate::ARRAY_SIGNATURE_CHAR;
+use crate::DICT_ENTRY_SIG_END_CHAR;
+use crate::DICT_ENTRY_SIG_START_CHAR;
+use crate::STRUCT_SIG_END_CHAR;
+use crate::STRUCT_SIG_START_CHAR;
+use crate::VARIANT_SIGNATURE_CHAR;
+
+pub struct ValueSerializer<'a> {
+    sig_parser: SignatureParser<'a>
+}
+
+impl<'a> ValueSerializer<'a> {
+    pub fn new(signature: Signature<'a>) -> Self {
+        Self {
+            sig_parser: SignatureParser::new(signature)
+        }
+    }
+}
+
+impl<'a> Serializer for ValueSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+    type SerializeSeq = ValueSeqSerializer<'a>;
+    type SerializeTuple = ValueTupleSerializer<'a>;
+    type SerializeTupleStruct = ValueTupleStructSerializer<'a>;
+    type SerializeTupleVariant = ValueTupleVariantSerializer<'a>;
+    type SerializeMap = ValueMapSerializer<'a>;
+    type SerializeStruct = ValueStructSerializer<'a>;
+    type SerializeStructVariant = ValueStructVariantSerializer<'a>;
+
+    fn serialize_bool(mut self, v: bool) -> Result<Self::Ok, Self::Error> {
+        let next_sig_char = self.sig_parser.next_char()?;
+        self.sig_parser.skip_char()?;
+
+        match next_sig_char {
+            bool::SIGNATURE_CHAR => Ok(Value::Bool(v)),
+            i16::SIGNATURE_CHAR => Ok(Value::I16(if v { 1 } else { 0 })),
+            i32::SIGNATURE_CHAR => Ok(Value::I32(if v { 1 } else { 0 })),
+            i64::SIGNATURE_CHAR => Ok(Value::I64(if v { 1 } else { 0 })),
+            u8::SIGNATURE_CHAR => Ok(Value::U8(if v { 1 } else { 0 })),
+            u16::SIGNATURE_CHAR => Ok(Value::U16(if v { 1 } else { 0 })),
+            u32::SIGNATURE_CHAR => Ok(Value::U32(if v { 1 } else { 0 })),
+            u64::SIGNATURE_CHAR => Ok(Value::U64(if v { 1 } else { 0 })),
+            String::SIGNATURE_CHAR => Ok(Value::Str(Str::from(if v { "true" } else { "false" }))),
+            _ => Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned().into_owned(), "b, n, i, x, y, q, u, t, x".to_string()))
+        }
+    }
+
+    fn serialize_i8(mut self, v: i8) -> Result<Self::Ok, Self::Error> {
+        let next_sig_char = self.sig_parser.next_char()?;
+        self.sig_parser.skip_char()?;
+         
+        match next_sig_char {
+            i16::SIGNATURE_CHAR => Ok(Value::I16(v as i16)),
+            i32::SIGNATURE_CHAR => Ok(Value::I32(v as i32)),
+            i64::SIGNATURE_CHAR => Ok(Value::I64(v as i64)),
+            u16::SIGNATURE_CHAR => Ok(Value::U16(v as u16)),
+            u32::SIGNATURE_CHAR => Ok(Value::U32(v as u32)),
+            u64::SIGNATURE_CHAR => Ok(Value::U64(v as u64)),
+            String::SIGNATURE_CHAR => Ok(Value::Str(Str::from(v.to_string()))),
+            f64::SIGNATURE_CHAR => Ok(Value::F64(v as f64)),
+            _ => Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned().into_owned(), "i, n, x, q, u, t, x, d".to_string()))
+        }
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::I16(v))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::I32(v))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::I64(v))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::U8(v))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::U16(v))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::U32(v))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::U64(v))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::F64(v as f64))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::F64(v))
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::U8(v as u8))
+    }
+
+    fn serialize_str(mut self, v: &str) -> Result<Self::Ok, Self::Error> {
+        let next_sig_char = self.sig_parser.next_char()?;
+        self.sig_parser.skip_char()?;
+         
+        match next_sig_char {
+            ObjectPath::SIGNATURE_CHAR => Ok(Value::ObjectPath(ObjectPath::try_from(v.to_string())?)),
+            _ => Ok(Value::Str(Str::from(v.to_string()))),
+        }
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Array(Array::from(v)))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!("serializing none")
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        unimplemented!("serializing some")
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!("serializing unit")
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Str(Str::from(variant.to_string())))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+
+        match name {
+            "zvariant::ObjectPath" => {
+                match value.serialize(self)? {
+                    Value::Str(s) => Ok(Value::ObjectPath(ObjectPath::try_from(s.to_string())?)),
+                    _ => Err(crate::Error::IncorrectType)
+                }
+            },
+            "zvariant::Signature" => {
+                match value.serialize(self)? {
+                    Value::Str(s) => Ok(Value::Signature(Signature::try_from(s.to_string())?)),
+                    _ => Err(crate::Error::IncorrectType)
+                }
+            },
+            _ => value.serialize(self)
+        }
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        Ok(Value::Structure(Structure::new(vec![
+            Value::Str(Str::from(variant.to_string())),
+            value.serialize(self)?
+        ])))
+    }
+
+    fn serialize_seq(mut self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        if self.sig_parser.next_char()? == ARRAY_SIGNATURE_CHAR {
+            let struct_signature = self.sig_parser.parse_next_signature()?;
+            Ok(ValueSeqSerializer::new(struct_signature))
+        } else {
+            Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned().into_owned(), "an array".to_string()))
+        }
+    }
+
+    fn serialize_tuple(mut self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        if self.sig_parser.next_char()? == STRUCT_SIG_START_CHAR {
+            let struct_signature = self.sig_parser.parse_next_signature()?;
+            Ok(ValueTupleSerializer::new(struct_signature))
+        } else {
+            Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned().into_owned(), "an array".to_string()))
+        }
+    }
+
+    fn serialize_tuple_struct(
+        mut self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        if self.sig_parser.next_char()? == STRUCT_SIG_START_CHAR {
+            let struct_signature = self.sig_parser.parse_next_signature()?;
+            Ok(ValueTupleStructSerializer::new(name.to_string(), struct_signature))
+        } else {
+            Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned().into_owned(), "an array".to_string()))
+        }
+    }
+
+    fn serialize_tuple_variant(
+        mut self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        if self.sig_parser.next_char()? == STRUCT_SIG_START_CHAR {
+            let struct_signature = self.sig_parser.parse_next_signature()?;
+            Ok(ValueTupleVariantSerializer::new(variant.to_string(), struct_signature))
+        } else {
+            Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "an array".to_string()))
+        }
+    }
+
+    fn serialize_map(mut self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        if self.sig_parser.next_char()? == ARRAY_SIGNATURE_CHAR {
+            self.sig_parser.skip_char()?;
+
+            if self.sig_parser.next_char()? != DICT_ENTRY_SIG_START_CHAR {
+                return Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "a DictEntry".to_string()));
+            }
+
+            let dict_entry = self.sig_parser.parse_next_signature()?;
+            let mut dict_parser = SignatureParser::new(dict_entry);
+            let key_signature = dict_parser.parse_next_signature()?;
+            let value_signature = dict_parser.parse_next_signature()?;
+            Ok(ValueMapSerializer::new(key_signature, value_signature))
+        } else {
+            Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "an array".to_string()))
+        }
+    }
+
+    fn serialize_struct(
+        mut self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+
+        match self.sig_parser.next_char()? {
+            STRUCT_SIG_START_CHAR => {
+                let struct_signature = self.sig_parser.parse_next_signature()?;
+                Ok(ValueStructSerializer::new(struct_signature, false))
+            },
+            ARRAY_SIGNATURE_CHAR => {
+                self.sig_parser.skip_char()?;
+
+                if self.sig_parser.next_char()? != DICT_ENTRY_SIG_START_CHAR {
+                    return Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "a DictEntry".to_string()));
+                }
+
+                self.sig_parser.skip_char()?;
+
+                let mut start_counter = 0;
+                let mut signature_chars = Vec::new();
+
+                loop {
+                    let next_char = self.sig_parser.next_char()?;
+                    self.sig_parser.skip_char()?;
+
+                    if next_char == DICT_ENTRY_SIG_START_CHAR {
+                        start_counter += 1;
+                    } else if next_char == DICT_ENTRY_SIG_END_CHAR {
+                        if start_counter == 0 {
+                            break;
+                        } else {
+                            start_counter -= 1;
+                        }
+                    }
+
+                    signature_chars.push(next_char);
+                }
+
+                let key_signature = Signature::try_from(signature_chars[0].to_string())?;
+                let value_signature = Signature::try_from(signature_chars[1..].iter().collect::<String>())?;
+
+                if key_signature != String::signature() {
+                    return Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "a struct".to_string()))
+                }
+
+                Ok(ValueStructSerializer::new(value_signature, true))
+            },
+            _ => return Err(crate::Error::SignatureMismatch(self.sig_parser.signature().into_owned(), "a struct".to_string()))
+        }
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        todo!()
+    }
+}
+
+pub struct ValueSeqSerializer<'a> {
+    signature: Signature<'a>,
+    fields: Vec<Value<'a>>
+}
+
+impl<'a> ValueSeqSerializer<'a> {
+    pub fn new(signature: Signature<'a>) -> Self {
+        Self {
+            signature,
+            fields: Vec::new(),
+        }
+    }
+
+}
+
+impl<'a> SerializeSeq for ValueSeqSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.fields.push(value.serialize(ValueSerializer::new(self.signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Array(Array::from(self.fields)))
+    }
+}
+
+pub struct ValueTupleSerializer<'a> {
+    signature: Signature<'a>,
+    fields: Vec<Value<'a>>
+}
+
+impl<'a> ValueTupleSerializer<'a> {
+    pub fn new(signature: Signature<'a>) -> Self {
+        Self {
+            signature,
+            fields: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeTuple for ValueTupleSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.fields.push(value.serialize(ValueSerializer::new(self.signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Structure(Structure::new(self.fields)))
+    }
+}
+
+pub struct ValueTupleStructSerializer<'a> {
+    signature: Signature<'a>,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueTupleStructSerializer<'a> {
+    pub fn new(name: String, signature: Signature<'a>) -> Self {
+        Self {
+            signature,
+            fields: vec![
+                Value::Str(Str::from(name)),
+            ],
+        }
+    }
+
+}
+
+impl<'a> SerializeTupleStruct for ValueTupleStructSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.fields.push(value.serialize(ValueSerializer::new(self.signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Structure(Structure::new(self.fields)))
+    }
+}
+
+pub struct ValueTupleVariantSerializer<'a> {
+    signature: Signature<'a>,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueTupleVariantSerializer<'a> {
+    pub fn new(name: String, signature: Signature<'a>) -> Self {
+        Self {
+            signature,
+            fields: vec![
+                Value::Str(Str::from(name)),
+            ],
+        }
+    }
+}
+
+impl<'a> SerializeTupleVariant for ValueTupleVariantSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.fields.push(value.serialize(ValueSerializer::new(self.signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Structure(Structure::new(self.fields)))
+    }
+}
+
+pub struct ValueMapSerializer<'a> {
+    key_signature: Signature<'a>,
+    value_signature: Signature<'a>,
+    keys: Vec<Value<'a>>,
+    values: Vec<Value<'a>>,
+}
+
+impl<'a> ValueMapSerializer<'a> {
+    pub fn new(key_signature: Signature<'a>, value_signature: Signature<'a>) -> Self {
+        Self {
+            key_signature,
+            value_signature,
+            keys: Vec::new(),
+            values: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeMap for ValueMapSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.keys.push(key.serialize(ValueSerializer::new(self.key_signature.clone()))?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.values.push(value.serialize(ValueSerializer::new(self.value_signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut dict = Dict::new(self.key_signature, self.value_signature);
+
+        for (k,v) in self.keys.drain(..).zip(self.values.drain(..)) {
+            dict.append(k, v)?;
+        }
+
+        Ok(Value::Dict(dict))
+    }
+}
+
+pub struct ValueStructSerializer<'a> {
+    signature: Signature<'a>,
+    keys: Vec<&'static str>,
+    values: Vec<Value<'a>>,
+    dict: bool
+}
+
+impl<'a> ValueStructSerializer<'a> {
+    pub fn new(signature: Signature<'a>, dict: bool) -> Self {
+        Self {
+            signature,
+            keys: Vec::new(),
+            values: Vec::new(),
+            dict
+        }
+    }
+}
+
+impl<'a> SerializeStruct for ValueStructSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        self.keys.push(key);
+        self.values.push(value.serialize(ValueSerializer::new(self.signature.clone()))?);
+        Ok(())
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        if self.dict {
+            let mut dict = Dict::new(signature_string!("s"), self.signature);
+
+            for (k,v) in self.keys.drain(..).zip(self.values.drain(..)) {
+                dict.add(k, v)?;
+            }
+
+            Ok(Value::Dict(dict))
+        } else {
+            Ok(Value::Structure(Structure::new(self.values)))
+        }
+    }
+}
+
+
+
+pub struct ValueStructVariantSerializer<'a> {
+    phantom: PhantomData<&'a ()>
+}
+
+impl<'a> SerializeStructVariant for ValueStructVariantSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize {
+        todo!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ObjectPath;
+    use crate::OwnedObjectPath;
+    use crate::OwnedSignature;
+    use super::*;
+    use serde::Serialize;
+
+    #[test]
+    fn serialize_u8() {
+        let input = 42u8;
+        let output = input.serialize(ValueSerializer::new(u8::signature())).unwrap();
+        assert_eq!(output, Value::U8(42));
+    }
+
+    #[test]
+    fn serialize_u16() {
+        let input = 42u16;
+        let output = input.serialize(ValueSerializer::new(u16::signature())).unwrap();
+        assert_eq!(output, Value::U16(42));
+    }
+
+    #[test]
+    fn serialize_u32() {
+        let input = 42u32;
+        let output = input.serialize(ValueSerializer::new(u32::signature())).unwrap();
+        assert_eq!(output, Value::U32(42));
+    }
+
+    #[test]
+    fn serialize_u64() {
+        let input = 42u64;
+        let output = input.serialize(ValueSerializer::new(u64::signature())).unwrap();
+        assert_eq!(output, Value::U64(42));
+    }
+
+    #[test]
+    fn serialize_i8() {
+        let input = 42i8;
+        let output = input.serialize(ValueSerializer::new(i16::signature())).unwrap();
+        assert_eq!(output, Value::I16(42));
+    }
+
+    #[test]
+    fn serialize_i16() {
+        let input = 42i16;
+        let output = input.serialize(ValueSerializer::new(i16::signature())).unwrap();
+        assert_eq!(output, Value::I16(42));
+    }
+
+    #[test]
+    fn serialize_i32() {
+        let input = 42i32;
+        let output = input.serialize(ValueSerializer::new(signature_string!("i"))).unwrap();
+        assert_eq!(output, Value::I32(42));
+    }
+
+    #[test]
+    fn serialize_i64() {
+        let input = 42i64;
+        let output = input.serialize(ValueSerializer::new(signature_string!("x"))).unwrap();
+        assert_eq!(output, Value::I64(42));
+    }
+
+    #[test]
+    fn serialize_f32() {
+        let input = 42.0f32;
+        let output = input.serialize(ValueSerializer::new(signature_string!("d"))).unwrap();
+        assert_eq!(output, Value::F64(42.0));
+    }
+
+    #[test]
+    fn serialize_f64() {
+        let input = 42.0f64;
+        let output = input.serialize(ValueSerializer::new(signature_string!("d"))).unwrap();
+        assert_eq!(output, Value::F64(42.0));
+    }
+
+    #[test]
+    fn serialize_bool() {
+        let input = true;
+        let output = input.serialize(ValueSerializer::new(signature_string!("b"))).unwrap();
+        assert_eq!(output, Value::Bool(true));
+    }
+
+    #[test]
+    fn serialize_char() {
+        let input: char = 'a';
+        let output = input.serialize(ValueSerializer::new(signature_string!("y"))).unwrap();
+        assert_eq!(output, Value::U8(97));
+    }
+
+    #[test]
+    fn serialize_struct() {
+        #[derive(Serialize)]
+        struct MyStruct {
+            a: OwnedObjectPath,
+            b: OwnedSignature
+        }
+
+        let input = MyStruct {
+            a: ObjectPath::from_static_str_unchecked("/hello").into(),
+            b: Signature::try_from("s").unwrap().into()
+        };
+
+        let output = input.serialize(ValueSerializer::new(signature_string!("a{sv}"))).unwrap();
+        let mut expected = Dict::new(signature_string!("s"), signature_string!("v"));
+        expected.add("a", Value::ObjectPath(ObjectPath::from_static_str_unchecked("/hello"))).unwrap();
+        expected.add("b", Value::Signature(Signature::try_from("s").unwrap())).unwrap();
+
+        assert_eq!(output, Value::Dict(expected));
+    }
+
+    #[test]
+    fn serialize_unit_variant() {
+        #[derive(Serialize)]
+        enum SomeStuff {
+            A,
+            B,
+        }
+
+        {
+            let input = SomeStuff::A;
+            let output = input.serialize(ValueSerializer::new(signature_string!("s"))).unwrap();
+            assert_eq!(output, Value::Str(Str::from("A")));
+        }
+
+        {
+            let input = SomeStuff::B;
+            let output = input.serialize(ValueSerializer::new(signature_string!("s"))).unwrap();
+            assert_eq!(output, Value::Str(Str::from("B")));
+        }
+    }
+}
+

--- a/zvariant/tests/value_serde_roundtrip_test.rs
+++ b/zvariant/tests/value_serde_roundtrip_test.rs
@@ -1,0 +1,272 @@
+use serde::Deserialize;
+use serde::Serialize;
+use zvariant::ObjectPath;
+use zvariant::OwnedValue;
+use zvariant::Signature;
+use zvariant::Type;
+
+#[test]
+fn serde_i8() {
+    let value: i8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i16() {
+    let value: i16 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i16 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i32() {
+    let value: i32 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i32 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i64() {
+    let value: i64 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u8() {
+    let value: u8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u16() {
+    let value: u16 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u16 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u32() {
+    let value: u32 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u32 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u64() {
+    let value: u64 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_f64() {
+    let value: f64 = 3.14;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: f64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_bool() {
+    let value: bool = true;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: bool = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_string() {
+    let value: String = "Hello, world!".to_string();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: String = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_byte() {
+    let value: u8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_char() {
+    let value: char = 'a';
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: char = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_array() {
+    let value: Vec<i32> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_byte_array() {
+    let value: Vec<u8> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<u8> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_unit() {
+    let value: () = ();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: () = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_unit_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct UnitStruct;
+    let value = UnitStruct;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: UnitStruct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_unit_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum UnitVariant {
+        A,
+        B,
+    }
+    let value = UnitVariant::A;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: UnitVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_newtype_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct NewtypeStruct(i32);
+    let value = NewtypeStruct(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: NewtypeStruct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_newtype_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum NewtypeVariant {
+        A(i32),
+        B(i32),
+    }
+    let value = NewtypeVariant::A(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: NewtypeVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_seq() {
+    let value: Vec<i32> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple() {
+    let value: (i32, i32) = (1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: (i32, i32) = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct TupleStruct(i32, i32);
+    let value = TupleStruct(1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: TupleStruct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum TupleVariant {
+        A(i32, i32),
+        B(i32, i32),
+    }
+    let value = TupleVariant::A(1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: TupleVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_map() {
+    use std::collections::HashMap;
+    let mut value = HashMap::new();
+    value.insert("a".to_string(), 1);
+    value.insert("b".to_string(), 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: HashMap<String, i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct Struct {
+        a: i32,
+        b: i32,
+    }
+    let value = Struct { a: 1, b: 2 };
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Struct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_struct_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum StructVariant {
+        A { a: i32, b: i32 },
+        B { a: i32, b: i32 },
+    }
+    let value = StructVariant::A { a: 1, b: 2 };
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: StructVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_object_path() {
+    let value: ObjectPath = ObjectPath::try_from("/org/freedesktop/DBus").unwrap();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: zvariant::ObjectPath = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_signature() {
+    let value: Signature<'_> = Signature::try_from("a{sv}").unwrap();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Signature<'_> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}


### PR DESCRIPTION
This change is inspired by similiar functionality in serde-json which allows for types to be serialized/deserialized into an
AST directly. This is useful for a variety of reasons, and I think would be of benefit to zbus as well.

Luckily `zvariant` already has a type pretty close to this - the `zvariant::Value`. This thing can represent any value that
dbus can represent on the wire. It can also model any variant received from some other service. By serializing and deserializing directly to this thing - it gives clients stronger capability to deal with variants they receive.