### PR TITLE
🔖 zu: Release 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.36"
 proc-macro-crate = "3.1.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.1.1" }
+zvariant_utils = { path = "../zvariant_utils", version = "=2.0.0" }
 
 [dev-dependencies]
 zbus = { path = "../zbus" }

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "full"] }
 quote = "1.0.36"
 proc-macro-crate = "3.1.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=1.1.1" }
+zvariant_utils = { path = "../zvariant_utils", version = "=2.0.0" }
 
 [dev-dependencies]
 zvariant = { path = "../zvariant", features = ["enumflags2"] }

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant_utils"
-version = "1.1.1"
+version = "2.0.0"
 authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",


### PR DESCRIPTION
`syn` upgraded to 2.x and zvariant_utils exposes that in its public API so major version needs to be bumped.