### PR TITLE
✨ zm: interface can now generate proxy for you

### DIFF
--- a/book/src/server.md
+++ b/book/src/server.md
@@ -353,8 +353,81 @@ iface.greeter_name_changed(iface_ref.signal_context()).await?;
 # }
 ```
 
+## Proxy generation
+
+`interface` macro can also generate the client-side proxy code for you. It utilizes the [`proxy`]
+macro behind the scenes to achieve this. Here is how to use it:
+
+```rust
+use zbus::interface;
+
+struct Greeter {
+    name: String
+}
+
+#[interface(
+    name = "org.zbus.MyGreeter.WithProxy",
+    // Specifying the `proxy` attribute instructs `interface` to generate the
+    // client-side proxy. You can specify proxy-specific attributes
+    // (e.g `gen_blocking) here. All the attributes that are common between
+    // `proxy` and `interface` macros (e.g `name`) are automtically forwarded to
+    // the `proxy` macro.
+    proxy(
+        gen_blocking = false,
+        default_path = "/org/zbus/MyGreeter/WithProxy",
+        default_service = "org.zbus.MyGreeter.WithProxy",
+    ),
+)]
+impl Greeter {
+    #[zbus(property)]
+    async fn greeter_name(&self) -> String {
+        self.name.clone()
+    }
+
+    #[zbus(proxy(no_reply))]
+    async fn whatever(&self) {
+        println!("Whatever!");
+    }
+}
+
+# #[tokio::main]
+# async fn main() -> zbus::Result<()> {
+
+let greeter = Greeter { name: "GreeterName".to_string() };
+let connection = zbus::connection::Builder::session()?
+        .name("org.zbus.MyGreeter.WithProxy")?
+        .serve_at("/org/zbus/MyGreeter/WithProxy", greeter)?
+        .build()
+        .await?;
+let proxy = GreeterProxy::new(&connection).await?;
+assert_eq!(proxy.greeter_name().await?, "GreeterName");
+proxy.whatever().await?;
+
+# Ok(())
+# }
+```
+
+### Known Limitations
+
+While it's extremely useful to be able to generate the client-side proxy code directly from
+`interface` as it allows you to avoid duplicating code, there are some limitations to be aware of:
+
+* The trait bounds of the `proxy` macro methods' arguments and return value, now also apply to the
+  `interface` methods. For example, when only generating the server-side code, the method return
+  values need to implement `serde::Serialize` but when generating the client-side proxy code, the
+  method return values need to implement `serde::DeserializeOwned` as well.
+* Reference types in return values of `interface` methods won't work. As you may have noticed,
+  unlike the previous examples the `greeter_name` method in the example above returns a `String`
+  instead of a `&str`. This is because the methods in the `proxy` macro do not support reference
+  type to be returned from its methods.
+* Methods returning [`object_server::ResponseDispatchNotifier`] wrapper type will do the same for
+  proxy as well.
+* Only `interface` macro supports this feature, while the deprecated `dbus_interface` macro does
+  not. Still haven't switched to `interface` and want to use this feature? Time to switch!
+
 [D-Bus concepts]: concepts.html#bus-name--service-name
 [didoc]: https://docs.rs/zbus/4/zbus/attr.interface.html
 [`zbus::DBusError`]:https://docs.rs/zbus/4/zbus/trait.DBusError.html
 [`zbus::fdo::Error`]: https://docs.rs/zbus/4/zbus/fdo/enum.Error.html
 [`zbus::fdo::Error::UnknownProperty`]: https://docs.rs/zbus/4/zbus/fdo/enum.Error.html#variant.UnknownProperty
+[`proxy`]: https://docs.rs/zbus/4/zbus/attr.proxy.html

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -1,7 +1,7 @@
 //! The object server API.
 
 use event_listener::{Event, EventListener};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::Entry, HashMap},
     fmt::Write,
@@ -867,6 +867,21 @@ where
         S: serde::Serializer,
     {
         self.response.serialize(serializer)
+    }
+}
+
+impl<'de, R> Deserialize<'de> for ResponseDispatchNotifier<R>
+where
+    R: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self {
+            response: R::deserialize(deserializer)?,
+            event: None,
+        })
     }
 }
 

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -856,6 +856,11 @@ impl<R> ResponseDispatchNotifier<R> {
             listener,
         )
     }
+
+    /// Get the response.
+    pub fn response(&self) -> &R {
+        &self.response
+    }
 }
 
 impl<R> Serialize for ResponseDispatchNotifier<R>

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -92,19 +92,20 @@ impl<'a> Property<'a> {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 enum MethodType {
     Signal,
     Property(PropertyType),
     Other,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 enum PropertyType {
     Inputs,
     NoInputs,
 }
 
+#[derive(Debug, Clone)]
 struct MethodInfo {
     /// The type of method being parsed
     method_type: MethodType,

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -436,7 +436,7 @@ pub fn expand<T: AttrParse + Into<TraitAttrs>, M: AttrParse + Into<MethodAttrs>>
             ..
         } = &mut method.sig;
 
-        clean_input_args(inputs);
+        clear_input_arg_attrs(inputs);
 
         match method_type {
             MethodType::Signal => {
@@ -963,7 +963,8 @@ fn get_args_from_inputs(
     }
 }
 
-fn clean_input_args(inputs: &mut Punctuated<FnArg, Token![,]>) {
+// Removes all `zbus` and `dbus_interface` attributes from the given inputs.
+fn clear_input_arg_attrs(inputs: &mut Punctuated<FnArg, Token![,]>) {
     for input in inputs {
         if let FnArg::Typed(t) = input {
             t.attrs.retain(|attr| {

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -21,7 +21,7 @@ pub mod old {
     def_attrs! {
         crate dbus_interface;
 
-        pub TraitAttributes("trait") {
+        pub ImplAttributes("impl block") {
             interface str,
             name str,
             spawn bool
@@ -43,7 +43,7 @@ pub mod old {
 def_attrs! {
     crate zbus;
 
-    pub TraitAttributes("trait") {
+    pub ImplAttributes("impl block") {
         interface str,
         name str,
         spawn bool
@@ -68,7 +68,7 @@ def_attrs! {
     };
 }
 
-old_new!(TraitAttrs, old::TraitAttributes, TraitAttributes);
+old_new!(ImplAttrs, old::ImplAttributes, ImplAttributes);
 old_new!(MethodAttrs, old::MethodAttributes, MethodAttributes);
 
 #[derive(Debug)]
@@ -282,7 +282,7 @@ impl MethodInfo {
     }
 }
 
-pub fn expand<T: AttrParse + Into<TraitAttrs>, M: AttrParse + Into<MethodAttrs>>(
+pub fn expand<T: AttrParse + Into<ImplAttrs>, M: AttrParse + Into<MethodAttrs>>(
     args: Punctuated<Meta, Token![,]>,
     mut input: ItemImpl,
 ) -> syn::Result<TokenStream> {
@@ -313,8 +313,8 @@ pub fn expand<T: AttrParse + Into<TraitAttrs>, M: AttrParse + Into<MethodAttrs>>
 
     let (iface_name, with_spawn) = {
         let (name, interface, spawn) = match T::parse_nested_metas(args)?.into() {
-            TraitAttrs::New(new) => (new.name, new.interface, new.spawn),
-            TraitAttrs::Old(old) => (old.name, old.interface, old.spawn),
+            ImplAttrs::New(new) => (new.name, new.interface, new.spawn),
+            ImplAttrs::Old(old) => (old.name, old.interface, old.spawn),
         };
 
         let name =

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -197,7 +197,7 @@ mod utils;
 pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemTrait);
-    proxy::expand::<proxy::ImplAttributes, proxy::MethodAttributes>(args, input)
+    proxy::expand::<proxy::TraitAttributes, proxy::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
@@ -207,7 +207,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemTrait);
-    proxy::expand::<proxy::old::ImplAttributes, proxy::old::MethodAttributes>(args, input)
+    proxy::expand::<proxy::old::TraitAttributes, proxy::old::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
@@ -367,7 +367,7 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemImpl);
-    iface::expand::<iface::TraitAttributes, iface::MethodAttributes>(args, input)
+    iface::expand::<iface::ImplAttributes, iface::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
@@ -377,7 +377,7 @@ pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemImpl);
-    iface::expand::<iface::old::TraitAttributes, iface::old::MethodAttributes>(args, input)
+    iface::expand::<iface::old::ImplAttributes, iface::old::MethodAttributes>(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -237,6 +237,10 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   However, care must be taken to avoid making D-Bus method calls from within your interface
 ///   methods when this setting is false, as it may lead to deadlocks under certain conditions.
 ///
+/// * `proxy` - If specified, a proxy type will also be generated for the interface. This attribute
+///   supports all the [`macro@proxy`]-specific sub-attributes (e.g `gen_async`). The common
+///   sub-attributes (e.g `name`) are automatically forworded to the [`macro@proxy`] macro.
+///
 /// The methods accepts the `interface` attributes:
 ///
 /// * `name` - override the D-Bus name (pascal case form of the method by default)
@@ -263,6 +267,10 @@ pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `out_args` - When returning multiple values from a method, naming the out arguments become
 ///   important. You can use `out_args` to specify their names.
+///
+/// * `proxy` - Use this to specify the [`macro@proxy`]-specific method sub-attributes (e.g
+///   `object`). The common sub-attributes (e.g `name`) are automatically forworded to the
+///   [`macro@proxy`] macro.
 ///
 ///   In such case, your method must return a tuple containing
 ///   your out arguments, in the same order as passed to `out_args`.

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -12,7 +12,7 @@ pub mod old {
     def_attrs! {
         crate dbus_proxy;
 
-        pub ImplAttributes("impl block") {
+        pub TraitAttributes("trait") {
             interface str,
             name str,
             assume_defaults bool,
@@ -45,7 +45,7 @@ pub mod old {
 def_attrs! {
     crate zbus;
 
-    pub ImplAttributes("impl block") {
+    pub TraitAttributes("trait") {
         interface str,
         name str,
         assume_defaults bool,
@@ -74,7 +74,7 @@ def_attrs! {
     };
 }
 
-old_new!(ImplAttrs, old::ImplAttributes, ImplAttributes);
+old_new!(TraitAttrs, old::TraitAttributes, TraitAttributes);
 old_new!(MethodAttrs, old::MethodAttributes, MethodAttributes);
 
 struct AsyncOpts {
@@ -98,7 +98,7 @@ impl AsyncOpts {
     }
 }
 
-pub fn expand<I: AttrParse + Into<ImplAttrs>, M: AttrParse + Into<MethodAttrs>>(
+pub fn expand<I: AttrParse + Into<TraitAttrs>, M: AttrParse + Into<MethodAttrs>>(
     args: Punctuated<Meta, Token![,]>,
     input: ItemTrait,
 ) -> Result<TokenStream, Error> {
@@ -113,7 +113,7 @@ pub fn expand<I: AttrParse + Into<ImplAttrs>, M: AttrParse + Into<MethodAttrs>>(
         gen_async,
         gen_blocking,
     ) = match I::parse_nested_metas(args)?.into() {
-        ImplAttrs::Old(old) => (
+        TraitAttrs::Old(old) => (
             old.interface,
             old.name,
             old.assume_defaults,
@@ -124,7 +124,7 @@ pub fn expand<I: AttrParse + Into<ImplAttrs>, M: AttrParse + Into<MethodAttrs>>(
             old.gen_async,
             old.gen_blocking,
         ),
-        ImplAttrs::New(new) => (
+        TraitAttrs::New(new) => (
             new.interface,
             new.name,
             new.assume_defaults,

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -45,6 +45,7 @@ pub mod old {
 def_attrs! {
     crate zbus;
 
+    // Keep this in sync with interface's proxy method attributes.
     pub TraitAttributes("trait") {
         interface str,
         name str,
@@ -57,6 +58,7 @@ def_attrs! {
         gen_blocking bool
     };
 
+    // Keep this in sync with interface's proxy method attributes.
     pub MethodAttributes("method") {
         name str,
         property {


### PR DESCRIPTION
The common sub-attributes get proxied over and proxy-specific sub-attributes can be specified using `proxy` attribute (e.g `#[zbus(proxy(allow_interactive_auth))]`).
    
We are only adding this for `interface` and not the deprecated `dbus_interface`. Not only it saves us duplication, hopefully this will further encourage people to switch to `interface`.
    
Known limitations:
    
* Reference types in return values of `interface` methods won't work.
* Methods returning `object_server::ResponseDispatchNotifier` wrapper will do the same for proxy as well.
 
Fixes #236.