### PR TITLE
add vsock connection tests

### DIFF
--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1785,6 +1785,7 @@ mod p2p_tests {
             Builder::vsock_stream(client).p2p().build(),
         )
     }
+
     #[cfg(any(unix, not(feature = "tokio")))]
     #[test]
     #[timeout(15000)]


### PR DESCRIPTION
The test fails with tokio-vsock, which doesn't seem to send or flush the BEGIN command. More investigation needed.