### PR TITLE
🐛 zv: Fix dictionary entry serialization from Values

### DIFF
--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1195,6 +1195,15 @@ mod tests {
             assert_eq!(map["hi"], "1234");
             assert_eq!(map["world"], "561");
 
+            // Ensure SerializeValue produces the same result as Value
+            // Tests for https://github.com/dbus2/zbus/issues/868
+            let mut map = std::collections::HashMap::<&str, &str>::new();
+            map.insert("k", "v");
+            let gv_ser_value_encoded =
+                zvariant::to_bytes(ctxt, &zvariant::SerializeValue(&map)).unwrap();
+            let gv_value_encoded = to_bytes(ctxt, &zvariant::Value::new(map)).unwrap();
+            assert_eq!(gv_value_encoded.as_ref(), gv_ser_value_encoded.as_ref());
+
             // Check encoding against GLib
             let bytes = Bytes::from_owned(gv_encoded);
             let variant = Variant::from_bytes::<HashMap<&str, &str>>(&bytes);

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -12,7 +12,9 @@ use serde::{
         Deserialize, DeserializeSeed, Deserializer, Error, MapAccess, SeqAccess, Unexpected,
         Visitor,
     },
-    ser::{Serialize, SerializeSeq, SerializeStruct, SerializeTupleStruct, Serializer},
+    ser::{
+        Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeTupleStruct, Serializer,
+    },
 };
 use static_assertions::assert_impl_all;
 
@@ -336,6 +338,23 @@ impl<'a> Value<'a> {
         S: SerializeSeq,
     {
         serialize_value!(self serializer.serialize_element)
+    }
+
+    pub(crate) fn serialize_value_as_dict_key<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where
+        S: SerializeMap,
+    {
+        serialize_value!(self serializer.serialize_key)
+    }
+
+    pub(crate) fn serialize_value_as_dict_value<S>(
+        &self,
+        serializer: &mut S,
+    ) -> Result<(), S::Error>
+    where
+        S: SerializeMap,
+    {
+        serialize_value!(self serializer.serialize_value)
     }
 
     #[cfg(feature = "gvariant")]


### PR DESCRIPTION
Dictionaries with variable length keys require a framing offset. The SerializeMap implementation already handles this, the manual serialization of dict entries used by Value does not. We now call directly into SerializeMap when serializing Value to align these serializations.

Unfortunately this requires adding two new methods to Value, similar to `serialize_value_as_seq_element` et al. To balance it out, we can remove `DictEntry`.

Closes #868