### PR TITLE
🐛 implement `Hash` and `Eq` property for Value::F64

### DIFF
--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -115,6 +115,9 @@ impl Hash for Value<'_> {
             Self::U32(inner) => inner.hash(state),
             Self::I64(inner) => inner.hash(state),
             Self::U64(inner) => inner.hash(state),
+            // To hold the +0.0 == -0.0 => hash(+0.0) == hash(-0.0) property.
+            // See https://doc.rust-lang.org/beta/std/hash/trait.Hash.html#hash-and-eq
+            Self::F64(inner) if *inner == 0. => 0f64.to_le_bytes().hash(state),
             Self::F64(inner) => inner.to_le_bytes().hash(state),
             Self::Str(inner) => inner.hash(state),
             Self::Signature(inner) => inner.hash(state),


### PR DESCRIPTION
the current implementation of `Hash` for `zvariant::Value` doesn't hold the property described in the rust rust standard library in [`Hash` and `Eq`](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq):

```rs
use std::hash::{DefaultHasher, Hash, Hasher};

fn main() {
    let v1 = zvariant::Value::F64(0.);
    let v2 = zvariant::Value::F64(-0.);
    println!("{} == {} : {}", v1, v2, v1 == v2);

    let mut hasher = DefaultHasher::new();
    v1.hash(&mut hasher);
    let h1 = hasher.finish();

    let mut hasher = DefaultHasher::new();
    v2.hash(&mut hasher);
    let h2 = hasher.finish();

    println!("{:#x} == {:#x} : {}", h1, h2, h1 == h2);
}
```

```txt
0. == -0. : true
0x3885e79ab4b1bb3a == 0xe3da94884cfc9c4 : false
```

implementing `Hash` for an `f64` comes with a host of annoying issues, like being able to insert multiple `Variant::F64(f64::NAN)` as keys into the map and not being able to retrieve them anymore, but it doesn't break this specific property, as `f64::NAN` never evaluates to `true` with an `==` operation, so it still (technically) holds the `k1 == k2 -> hash(k1) == hash(k2)` property.

this fixes the `Hash` and `Eq` property by hashing `0.` and `-0.` the same way.

```txt
0. == -0. : true
0x3885e79ab4b1bb3a == 0x3885e79ab4b1bb3a : true
```