### PR TITLE
🥅 zm: interface-generated proxy should use the same error types

### DIFF
--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -84,7 +84,7 @@ impl MyIface {
 }
 
 /// Custom D-Bus error type.
-#[derive(Debug, DBusError)]
+#[derive(Debug, DBusError, PartialEq)]
 #[zbus(prefix = "org.freedesktop.MyIface.Error")]
 enum MyIfaceError {
     SomethingWentWrong(String),
@@ -569,6 +569,13 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
             bar: "TestString".into(),
         })
         .await?;
+
+    proxy.test_error().await.unwrap_err();
+    assert_eq!(
+        proxy.test_custom_error().await.unwrap_err(),
+        MyIfaceError::SomethingWentWrong("oops".to_string())
+    );
+
     check_hash_map(proxy.test_hashmap_return().await?);
     check_hash_map(proxy.hash_map().await?);
     proxy


### PR DESCRIPTION
If user specifies a Result type as return type of a method, the generated proxy should use the same error types. We might need to add an attribute to control in the future, as this as this may not always be what the user wants.
    
We should do this because if we hardcode the error type to be `zbus::Error`, the API will have to break if one decides to replace a `proxy` use with this new ability of `interface` and they had their `proxy` return a specific error type. This for example is the case for `zbus::fdo` API, which we want to convert in the future.
    
Speaking of API break, this change itself is an API break but practically speaking the chances of someone already making use of the newly added feature of generating proxy from interface is pretty low (on the Matrix channel people didn't even know it was added), let alone them using a custom error in interface methods while not in proxy as well.