### PR TITLE
📝 book: Bring back `server.html` as symlink to `service.hmtl`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Books
         run: |
           mdbook build book
-          mkdir -p public/1.0
+          mkdir public
           cp -r ./book/book/* ./public
           # link to the old name for service
           ln -rs public/service.html public/server.html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
           mdbook build book
           mkdir -p public/1.0
           cp -r ./book/book/* ./public
+          # link to the old name for service
+          ln -rs public/service.html public/server.html
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.6.1
         with:


### PR DESCRIPTION
So old links to `server.html` will still work.