### PR TITLE
✨ zb: Add Connection::graceful_shutdown

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -126,6 +126,8 @@ tokio = { version = "1.37.0", features = [
   "io-util",
   "net",
   "sync",
+  "time",
+  "test-util",
 ] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -257,6 +257,14 @@ impl Connection {
     pub fn close(self) -> Result<()> {
         block_on(self.inner.close())
     }
+
+    /// Gracefully close the connection, waiting for all other references to be dropped.
+    ///
+    /// Blocking version of [`crate::Connection::graceful_shutdown`]. See docs there for
+    /// more details and caveats.
+    pub fn graceful_shutdown(self) {
+        block_on(self.inner.graceful_shutdown())
+    }
 }
 
 impl From<crate::Connection> for Connection {


### PR DESCRIPTION
Fixes #309.

I ended up naming it `Connection::graceful_shutdown` since `shutdown` felt too ambiguous with `close` to me. Happy to change if desired.

The included test is a little more tokio-integrated than most in the project, but since tokio was already a dev-dependency I'm hoping this is fine. I'm not aware of a different/better way to assert that an async function *doesn't* return.