### PR TITLE
✨ zv: Add more `Type` impls

### DIFF
--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -45,6 +45,7 @@ serde_repr = "0.1.19"
 glib = "0.20.0"
 rand = "0.8.5"
 criterion = "0.5.1"
+chrono = { version = "0.4.38", features = ["serde", "alloc"], default-features = false }
 
 [lib]
 bench = false

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -123,10 +123,7 @@ pub use endi::*;
 #[cfg(test)]
 #[allow(clippy::disallowed_names)]
 mod tests {
-    use std::{
-        collections::{BTreeMap, HashMap},
-        net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    };
+    use std::collections::{BTreeMap, HashMap};
 
     #[cfg(feature = "arrayvec")]
     use arrayvec::{ArrayString, ArrayVec};
@@ -2005,33 +2002,6 @@ mod tests {
         let _: ZVStruct<'_> = encoded.deserialize_for_signature(signature).unwrap().0;
     }
 
-    #[test]
-    fn ip_addr() {
-        let ctxt = Context::new_dbus(LE, 0);
-
-        // First the bare specific types.
-        let localhost_v4 = Ipv4Addr::new(127, 0, 0, 1);
-        let encoded = to_bytes(ctxt, &localhost_v4).unwrap();
-        let decoded: Ipv4Addr = encoded.deserialize().unwrap().0;
-        assert_eq!(localhost_v4, decoded);
-
-        let localhost_v6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
-        let encoded = to_bytes(ctxt, &localhost_v6).unwrap();
-        let decoded: Ipv6Addr = encoded.deserialize().unwrap().0;
-        assert_eq!(localhost_v6, decoded);
-
-        // Now wrapper under the generic IpAddr.
-        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        let encoded = to_bytes(ctxt, &localhost_v4).unwrap();
-        let decoded: IpAddr = encoded.deserialize().unwrap().0;
-        assert_eq!(localhost_v4, decoded);
-
-        let localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-        let encoded = to_bytes(ctxt, &localhost_v6).unwrap();
-        let decoded: IpAddr = encoded.deserialize().unwrap().0;
-        assert_eq!(localhost_v6, decoded);
-    }
-
     #[cfg(feature = "ostree-tests")]
     #[test]
     fn ostree_de() {
@@ -2050,45 +2020,6 @@ mod tests {
         let _: Summary<'_> = encoded.deserialize().unwrap().0;
         // If we're able to deserialize all the data successfully, don't bother checking the summary
         // data.
-    }
-
-    #[test]
-    #[cfg(feature = "time")]
-    fn time() {
-        // time::Date
-        let date = time::Date::from_calendar_date(2011, time::Month::June, 21).unwrap();
-        let ctxt = Context::new_dbus(LE, 0);
-        let encoded = to_bytes(ctxt, &date).unwrap();
-        let decoded: time::Date = encoded.deserialize().unwrap().0;
-        assert_eq!(date, decoded);
-
-        // time::Duration
-        let duration = time::Duration::new(42, 123456789);
-        let ctxt = Context::new_dbus(LE, 0);
-        let encoded = to_bytes(ctxt, &duration).unwrap();
-        let decoded: time::Duration = encoded.deserialize().unwrap().0;
-        assert_eq!(duration, decoded);
-
-        // time::OffsetDateTime
-        let offset = time::OffsetDateTime::now_utc();
-        let ctxt = Context::new_dbus(LE, 0);
-        let encoded = to_bytes(ctxt, &offset).unwrap();
-        let decoded: time::OffsetDateTime = encoded.deserialize().unwrap().0;
-        assert_eq!(offset, decoded);
-
-        // time::Time
-        let time = time::Time::from_hms(23, 42, 59).unwrap();
-        let ctxt = Context::new_dbus(LE, 0);
-        let encoded = to_bytes(ctxt, &time).unwrap();
-        let decoded: time::Time = encoded.deserialize().unwrap().0;
-        assert_eq!(time, decoded);
-
-        // time::PrimitiveDateTime
-        let date = time::PrimitiveDateTime::new(date, time);
-        let ctxt = Context::new_dbus(LE, 0);
-        let encoded = to_bytes(ctxt, &date).unwrap();
-        let decoded: time::PrimitiveDateTime = encoded.deserialize().unwrap().0;
-        assert_eq!(date, decoded);
     }
 
     #[test]

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -3,7 +3,7 @@ use serde::de::{Deserialize, DeserializeSeed};
 use std::{
     cmp::Reverse,
     marker::PhantomData,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     num::{Saturating, Wrapping},
     ops::{Range, RangeFrom, RangeInclusive, RangeTo},
     path::{Path, PathBuf},
@@ -513,6 +513,27 @@ impl_type_with_repr! {
         }
     }
 }
+
+impl_type_with_repr! {
+    SocketAddrV4 => (Ipv4Addr, u16) {
+        socket_addr_v4 {
+            samples = [SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080)],
+            repr(addr) = (*addr.ip(), addr.port()),
+        }
+    }
+}
+
+impl_type_with_repr! {
+    SocketAddrV6 => (Ipv6Addr, u16) {
+        socket_addr_v6 {
+            samples = [SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)],
+            // https://github.com/serde-rs/serde/blob/9b868ef831c95f50dd4bde51a7eb52e3b9ee265a/serde/src/ser/impls.rs#L966
+            repr(addr) = (*addr.ip(), addr.port()),
+        }
+    }
+}
+
+// TODO(bash): Implement DynamicType for SocketAddr
 
 // BitFlags
 #[cfg(feature = "enumflags2")]

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -7,6 +7,10 @@ use std::{
     num::{Saturating, Wrapping},
     path::{Path, PathBuf},
     rc::Rc,
+    sync::atomic::{
+        AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicU16, AtomicU32, AtomicU64,
+        AtomicU8,
+    },
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -763,5 +767,35 @@ macro_rules! impl_type_for_wrapper {
 }
 
 impl_type_for_wrapper!(Wrapping<T>, Saturating<T>, Reverse<T>);
+
+////////////////////////////////////////////////////////////////////////////////
+
+macro_rules! atomic_impl {
+    ($($ty:ident $size:expr => $primitive:ident)*) => {
+        $(
+            static_assertions::assert_impl_all!($ty: From<$primitive>);
+
+            #[cfg(target_has_atomic = $size)]
+            impl Type for $ty {
+                #[inline]
+                fn signature() -> Signature<'static> {
+                    <$primitive>::signature()
+                }
+            }
+        )*
+    }
+}
+
+atomic_impl! {
+    AtomicBool "8" => bool
+    AtomicI8 "8" => i8
+    AtomicI16 "16" => i16
+    AtomicI32 "32" => i32
+    AtomicI64 "64" => i64
+    AtomicU8 "8" => u8
+    AtomicU16 "16" => u16
+    AtomicU32 "32" => u32
+    AtomicU64 "64" => u64
+}
 
 // TODO: Blanket implementation for more types: https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -265,11 +265,33 @@ macro_rules! array_type {
 
 array_type!([T]);
 array_type!(Vec<T>);
+array_type!(std::collections::VecDeque<T>);
+array_type!(std::collections::LinkedList<T>);
 
 impl<T, S> Type for std::collections::HashSet<T, S>
 where
     T: Type + Eq + Hash,
     S: BuildHasher,
+{
+    #[inline]
+    fn signature() -> Signature<'static> {
+        <[T]>::signature()
+    }
+}
+
+impl<T> Type for std::collections::BTreeSet<T>
+where
+    T: Type + Ord,
+{
+    #[inline]
+    fn signature() -> Signature<'static> {
+        <[T]>::signature()
+    }
+}
+
+impl<T> Type for std::collections::BinaryHeap<T>
+where
+    T: Type + Ord,
 {
     #[inline]
     fn signature() -> Signature<'static> {

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -7,12 +7,14 @@ use std::{
     num::{Saturating, Wrapping},
     ops::{Range, RangeFrom, RangeInclusive, RangeTo},
     path::{Path, PathBuf},
-    rc::Rc,
-    sync::atomic::{
-        AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicU16, AtomicU32, AtomicU64,
-        AtomicU8,
+    rc::{Rc, Weak as RcWeak},
+    sync::{
+        atomic::{
+            AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicU16, AtomicU32, AtomicU64,
+            AtomicU8,
+        },
+        Arc, Mutex, RwLock, Weak as ArcWeak,
     },
-    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -339,10 +341,12 @@ deref_impl!(T, <T: ?Sized + Type> Type for &T);
 deref_impl!(T, <T: ?Sized + Type> Type for &mut T);
 deref_impl!(T, <T: ?Sized + Type + ToOwned> Type for Cow<'_, T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Arc<T>);
+deref_impl!(T, <T: ?Sized + Type> Type for ArcWeak<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Mutex<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for RwLock<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Box<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Rc<T>);
+deref_impl!(T, <T: ?Sized + Type> Type for RcWeak<T>);
 
 #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
 impl<T> Type for Option<T>

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -596,8 +596,6 @@ impl_type_with_repr! {
     }
 }
 
-// FIXME: Ignoring the `serde-human-readable` feature of `time` crate in these impls:
-// https://github.com/time-rs/time/blob/f9398b9598757508ca3815694f23203843e0011b/src/serde/mod.rs#L110
 #[cfg(feature = "time")]
 impl_type_with_repr! {
     time::Date => (i32, u16) {

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -696,6 +696,26 @@ impl_type_with_repr! {
 
 #[cfg(feature = "chrono")]
 impl_type_with_repr! {
+    chrono::Month => &str {
+        chrono_month {
+            samples = [chrono::Month::January, chrono::Month::December],
+            repr(month) = month.name(),
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl_type_with_repr! {
+    chrono::NaiveDate => &str {
+        chrono_naive_date {
+            samples = [chrono::NaiveDate::from_ymd_opt(2016, 7, 8).unwrap()],
+            repr(d) = &format!("{d:?}"),
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl_type_with_repr! {
     chrono::NaiveDateTime => &str {
         chrono_naive_date_time {
             samples = [chrono::NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap()],
@@ -710,6 +730,17 @@ impl_type_with_repr! {
         chrono_naive_time {
             samples = [chrono::NaiveTime::from_hms_opt(9, 10, 11).unwrap()],
             repr(t) = &format!("{t:?}"),
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl_type_with_repr! {
+    chrono::Weekday => &str {
+        chrono_weekday {
+            samples = [chrono::Weekday::Mon, chrono::Weekday::Fri],
+            // Serialized as the weekday's name.
+            repr(weekday) = &weekday.to_string(),
         }
     }
 }

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -5,6 +5,7 @@ use std::{
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     num::{Saturating, Wrapping},
+    ops::{Range, RangeFrom, RangeInclusive, RangeTo},
     path::{Path, PathBuf},
     rc::Rc,
     sync::atomic::{
@@ -797,5 +798,46 @@ atomic_impl! {
     AtomicU32 "32" => u32
     AtomicU64 "64" => u64
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+impl_type_with_repr! {
+    Range<Idx: Type> => (Idx, Idx) {
+        range <Idx = u32> {
+            samples = [0..42, 17..100],
+            repr(range) = (range.start, range.end),
+        }
+    }
+}
+
+impl_type_with_repr! {
+    RangeFrom<Idx: Type> => (Idx,) {
+        range_from <Idx = u32> {
+            samples = [0.., 17..],
+            repr(range) = (range.start,),
+        }
+    }
+}
+
+impl_type_with_repr! {
+    RangeInclusive<Idx: Type> => (Idx, Idx) {
+        range_inclusive <Idx = u32> {
+            samples = [0..=42, 17..=100],
+            repr(range) = (*range.start(), *range.end()),
+        }
+    }
+}
+
+impl_type_with_repr! {
+    RangeTo<Idx: Type> => (Idx,) {
+        range_to <Idx = u32> {
+            samples = [..42, ..100],
+            repr(range) = (range.end,),
+        }
+    }
+}
+
+// serde::Serialize is not implemented for `RangeToInclusive` and `RangeFull`:
+// https://github.com/serde-rs/serde/issues/2685
 
 // TODO: Blanket implementation for more types: https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -1,8 +1,10 @@
 use crate::{utils::*, Signature};
 use serde::de::{Deserialize, DeserializeSeed};
 use std::{
+    cmp::Reverse,
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    num::{Saturating, Wrapping},
     path::{Path, PathBuf},
     rc::Rc,
     sync::{Arc, Mutex, RwLock},
@@ -744,5 +746,22 @@ impl_type_with_repr! {
         }
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+macro_rules! impl_type_for_wrapper {
+    ($($wrapper:ident<$T:ident>),+) => {
+        $(
+            impl<$T: Type> Type for $wrapper<$T> {
+                #[inline]
+                fn signature() -> Signature<'static> {
+                    <$T>::signature()
+                }
+            }
+        )+
+    };
+}
+
+impl_type_for_wrapper!(Wrapping<T>, Saturating<T>, Reverse<T>);
 
 // TODO: Blanket implementation for more types: https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -136,6 +136,19 @@ macro_rules! impl_type_with_repr {
             };
 
             #[test]
+            fn type_can_be_deserialized_from_encoded_type() {
+                let ctx = Context::new_dbus(LE, 0);
+                let samples = $samples;
+                let _: &[Ty] = &samples;
+
+                for $sample_ident in samples {
+                    let encoded = to_bytes(ctx, &$sample_ident).unwrap();
+                    let (decoded, _): (Ty, _) = encoded.deserialize().unwrap();
+                    assert_eq!($sample_ident, decoded);
+                }
+            }
+
+            #[test]
             fn repr_can_be_deserialized_from_encoded_type() {
                 let ctx = Context::new_dbus(LE, 0);
                 let samples = $samples;
@@ -651,7 +664,7 @@ impl_type_with_repr! {
 impl_type_with_repr! {
     time::Date => (i32, u16) {
         time_date {
-            samples = [time::Date::MIN, time::Date::MAX],
+            samples = [time::Date::MIN, time::Date::MAX, time::Date::from_calendar_date(2011, time::Month::June, 21).unwrap()],
             // https://github.com/time-rs/time/blob/f9398b9598757508ca3815694f23203843e0011b/src/serde/mod.rs#L92
             repr(d) = (d.year(), d.ordinal()),
         }
@@ -662,7 +675,7 @@ impl_type_with_repr! {
 impl_type_with_repr! {
     time::Duration => (i64, i32) {
         time_duration {
-            samples = [time::Duration::MIN, time::Duration::MAX],
+            samples = [time::Duration::MIN, time::Duration::MAX, time::Duration::new(42, 123456789)],
             // https://github.com/time-rs/time/blob/f9398b9598757508ca3815694f23203843e0011b/src/serde/mod.rs#L119
             repr(d) = (d.whole_seconds(), d.subsec_nanoseconds()),
         }
@@ -724,7 +737,7 @@ impl_type_with_repr! {
 impl_type_with_repr! {
     time::Time => (u8, u8, u8, u32) {
         time_time {
-            samples = [time::Time::MIDNIGHT, time::Time::from_hms_nano(15, 32, 43, 2_000).unwrap()],
+            samples = [time::Time::MIDNIGHT, time::Time::from_hms(23, 42, 59).unwrap(), time::Time::from_hms_nano(15, 32, 43, 2_000).unwrap()],
             // https://github.com/time-rs/time/blob/f9398b9598757508ca3815694f23203843e0011b/src/serde/mod.rs#L246
             repr(t) = (t.hour(), t.minute(), t.second(), t.nanosecond()),
         }

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -1,6 +1,7 @@
 use crate::{utils::*, Signature};
 use serde::de::{Deserialize, DeserializeSeed};
 use std::{
+    cell::{Cell, RefCell},
     cmp::Reverse,
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
@@ -369,6 +370,8 @@ deref_impl!(T, <T: ?Sized + Type> Type for RwLock<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Box<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for Rc<T>);
 deref_impl!(T, <T: ?Sized + Type> Type for RcWeak<T>);
+deref_impl!(T, <T: ?Sized + Type> Type for Cell<T>);
+deref_impl!(T, <T: ?Sized + Type> Type for RefCell<T>);
 
 #[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
 impl<T> Type for Option<T>


### PR DESCRIPTION
See also #98.

This PR implements `Type` on a bunch of types from the standard library and some chrono types.

I also added a helpful macro `impl_type!` that takes care of implementing `Type` and testing that the type and its repr are actually serialize-compatible.