### PR TITLE
🚑️ zb: Gracefully handle serial number wrap

### DIFF
--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -134,13 +134,18 @@ assert_impl_all!(PrimaryHeader: Send, Sync, Unpin);
 impl PrimaryHeader {
     /// Create a new `PrimaryHeader` instance.
     pub fn new(msg_type: Type, body_len: u32) -> Self {
+        let mut serial_num = SERIAL_NUM.fetch_add(1, SeqCst);
+        if serial_num == 0 {
+            serial_num = SERIAL_NUM.fetch_add(1, SeqCst);
+        }
+
         Self {
             endian_sig: NATIVE_ENDIAN_SIG,
             msg_type,
             flags: BitFlags::empty(),
             protocol_version: 1,
             body_len,
-            serial_num: SERIAL_NUM.fetch_add(1, SeqCst).try_into().unwrap(),
+            serial_num: serial_num.try_into().unwrap(),
         }
     }
 
@@ -353,7 +358,7 @@ impl<'m> Header<'m> {
     }
 }
 
-static SERIAL_NUM: AtomicU32 = AtomicU32::new(1);
+static SERIAL_NUM: AtomicU32 = AtomicU32::new(0);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
When `SERIAL_NUM` wraps past `u32::MAX` back to zero, the conversion to `NonZeroU32` panics.

Fixes #946.
