### PR TITLE
🔨 zb: Add benchmarks for Message ser/de

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "async-task",
  "async-trait",
  "blocking",
+ "criterion",
  "doc-comment",
  "enumflags2",
  "event-listener",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -148,3 +148,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lints]
 workspace = true
 
+[lib]
+bench = false
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -139,6 +139,7 @@ tracing-subscriber = { version = "0.3.18", features = [
   "ansi",
 ], default-features = false }
 tempfile = "3.10.1"
+criterion = "0.5.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, vec};
+use zbus::Message;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use zvariant::{Type, Value};
+
+fn msg_ser(c: &mut Criterion) {
+    let mut g = c.benchmark_group("message-ser");
+    g.bench_function("small", |b| {
+        b.iter(|| {
+            let msg = empty_message();
+            black_box(msg);
+        })
+    });
+
+    let mut strings = Vec::new();
+    let big_boy = BigBoy::new(&mut strings);
+    g.measurement_time(std::time::Duration::from_secs(30));
+    g.bench_function("big", |b| {
+        b.iter(|| {
+            let msg = big_boy_message(&big_boy);
+            black_box(msg);
+        })
+    });
+}
+
+fn msg_de(c: &mut Criterion) {
+    let mut g = c.benchmark_group("message-de");
+    let msg = empty_message();
+    g.bench_function("header", |b| {
+        b.iter(|| {
+            let header = msg.header();
+            black_box(header);
+        })
+    });
+
+    g.measurement_time(std::time::Duration::from_secs(30));
+    let mut strings = Vec::new();
+    let big_boy = BigBoy::new(&mut strings);
+    let msg = big_boy_message(&big_boy);
+    g.bench_function("body", |b| {
+        b.iter(|| {
+            let body = msg.body();
+            let body: BigBoy<'_> = body.deserialize().unwrap();
+            black_box(body);
+        })
+    });
+}
+
+fn empty_message() -> Message {
+    Message::method("/org/freedesktop/DBus/Something", "Ping")
+        .unwrap()
+        .destination("org.freedesktop.DBus.Something")
+        .unwrap()
+        .interface("org.freedesktop.DBus.Something")
+        .unwrap()
+        .build(&())
+        .unwrap()
+}
+
+fn big_boy_message(big_boy: &BigBoy<'_>) -> Message {
+    Message::method("/org/freedesktop/DBus/Something", "Ping")
+        .unwrap()
+        .destination("org.freedesktop.DBus.Something")
+        .unwrap()
+        .interface("org.freedesktop.DBus.Something")
+        .unwrap()
+        .build(&big_boy)
+        .unwrap()
+}
+
+#[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
+struct BigBoy<'s> {
+    string1: &'s str,
+    int1: u64,
+    field: (u64, &'s str),
+    int_array: Vec<u64>,
+    string_array: Vec<&'s str>,
+    asv_dict: HashMap<&'s str, Value<'s>>,
+}
+
+impl<'s> BigBoy<'s> {
+    fn new(strings: &'s mut Vec<String>) -> Self {
+        let mut asv_dict = HashMap::new();
+        let int_array = vec![0u64; 1024 * 10];
+        let mut string_array: Vec<&str> = Vec::new();
+        for idx in 0..1024 * 10 {
+            strings.push(format!(
+                "{idx}{idx}{idx}{idx}{idx}{idx}{idx}{idx}{idx}{idx}{idx}{idx}"
+            ));
+        }
+        for s in strings {
+            string_array.push(s.as_str());
+            asv_dict.insert(s.as_str(), Value::from(s.as_str()));
+        }
+
+        BigBoy {
+            string1: "Testtest",
+            int1: 0xFFFFFFFFFFFFFFFFu64,
+            field: (0xFFFFFFFFFFFFFFFFu64, "TesttestTestest"),
+            int_array,
+            string_array,
+            asv_dict,
+        }
+    }
+}
+
+criterion_group!(benches, msg_ser, msg_de);
+criterion_main!(benches);


### PR DESCRIPTION
We add separate benchmarks for header and body ser and de. They show the following results when compared to the main branch before #966:

```
message-ser/small       time:   [3.0693 µs 3.0745 µs 3.0801 µs]
                        change: [-56.616% -55.888% -55.132%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe
message-ser/big         time:   [2.3432 ms 2.3506 ms 2.3576 ms]
                        change: [-14.648% -13.677% -12.583%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

message-de/header       time:   [164.90 ns 165.33 ns 165.83 ns]
                        change: [-7.5284% -6.5826% -5.1958%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
message-de/body         time:   [3.0474 ms 3.0522 ms 3.0578 ms]
                        change: [-27.527% -26.152% -24.655%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  6 (6.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe
```