### PR TITLE
🐛 zv: Fix de of recursive variants from JSON

### DIFF
--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -35,10 +35,10 @@ impl<'de, T: Type + Deserialize<'de>> Deserialize<'de> for DeserializeValue<'de,
     where
         D: Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["zvariant::Value::Signature", "zvariant::Value::Value"];
+        const FIELDS: &[&str] = &["signature", "value"];
         Ok(DeserializeValue(
             deserializer.deserialize_struct(
-                "zvariant::Value",
+                "Variant",
                 FIELDS,
                 DeserializeValueVisitor(PhantomData),
             )?,
@@ -53,7 +53,7 @@ impl<'de, T: Type + Deserialize<'de>> Visitor<'de> for DeserializeValueVisitor<T
     type Value = T;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("zvariant::Value")
+        formatter.write_str("Variant")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>

--- a/zvariant/src/serialize_value.rs
+++ b/zvariant/src/serialize_value.rs
@@ -26,11 +26,11 @@ impl<'a, T: Type + Serialize> Serialize for SerializeValue<'a, T> {
         S: Serializer,
     {
         // Serializer implementation needs to ensure padding isn't added for Value.
-        let mut structure = serializer.serialize_struct("zvariant::Value", 2)?;
+        let mut structure = serializer.serialize_struct("Variant", 2)?;
 
         let signature = T::signature();
-        structure.serialize_field("zvariant::Value::Signature", &signature)?;
-        structure.serialize_field("zvariant::Value::Value", self.0)?;
+        structure.serialize_field("signature", &signature)?;
+        structure.serialize_field("value", self.0)?;
 
         structure.end()
     }

--- a/zvariant/src/str.rs
+++ b/zvariant/src/str.rs
@@ -18,7 +18,6 @@ use crate::{Basic, Type};
 /// [`&str`]: https://doc.rust-lang.org/std/str/index.html
 /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
-#[serde(rename(serialize = "zvariant::Str", deserialize = "zvariant::Str"))]
 pub struct Str<'a>(#[serde(borrow)] Inner<'a>);
 
 #[derive(Eq, Clone)]

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -309,8 +309,7 @@ impl<'a> Serialize for Structure<'a> {
     where
         S: Serializer,
     {
-        let mut structure =
-            serializer.serialize_tuple_struct("zvariant::Structure", self.fields.len())?;
+        let mut structure = serializer.serialize_tuple_struct("Structure", self.fields.len())?;
         for field in &self.fields {
             field.serialize_value_as_tuple_struct_field(&mut structure)?;
         }

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -751,12 +751,22 @@ where
     }
 
     #[inline]
-    fn visit_variant<V>(self, visitor: V) -> Result<Value<'de>, V::Error>
+    fn visit_variant_as_seq<V>(self, visitor: V) -> Result<Value<'de>, V::Error>
     where
         V: SeqAccess<'de>,
     {
         ValueVisitor
             .visit_seq(visitor)
+            .map(|v| Value::Value(Box::new(v)))
+    }
+
+    #[inline]
+    fn visit_variant_as_map<V>(self, visitor: V) -> Result<Value<'de>, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        ValueVisitor
+            .visit_map(visitor)
             .map(|v| Value::Value(Box::new(v)))
     }
 }
@@ -850,7 +860,7 @@ where
             // For some reason rustc doesn't like us using ARRAY_SIGNATURE_CHAR const
             parsed::Signature::Array(_) => self.visit_array(visitor),
             parsed::Signature::Structure(_) => self.visit_struct(visitor),
-            parsed::Signature::Variant => self.visit_variant(visitor),
+            parsed::Signature::Variant => self.visit_variant_as_seq(visitor),
             s => Err(Error::invalid_value(
                 Unexpected::Str(&s.to_string()),
                 &"a Value signature",
@@ -866,6 +876,7 @@ where
             parsed::Signature::Dict { key, value } => {
                 (key.signature().clone(), value.signature().clone())
             }
+            parsed::Signature::Variant => return self.visit_variant_as_map(visitor),
             _ => {
                 return Err(Error::invalid_type(
                     Unexpected::Str(&self.signature.to_string()),

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -582,12 +582,12 @@ impl<'a> Serialize for Value<'a> {
         S: Serializer,
     {
         // Serializer implementation needs to ensure padding isn't added for Value.
-        let mut structure = serializer.serialize_struct("zvariant::Value", 2)?;
+        let mut structure = serializer.serialize_struct("Variant", 2)?;
 
         let signature = self.value_signature();
-        structure.serialize_field("zvariant::Value::Signature", &signature)?;
+        structure.serialize_field("signature", &signature)?;
 
-        self.serialize_value_as_struct_field("zvariant::Value::Value", &mut structure)?;
+        self.serialize_value_as_struct_field("value", &mut structure)?;
 
         structure.end()
     }


### PR DESCRIPTION
JSON will decode a variant as a map and our `Value`'s `Visitor` implementation wasn't handling that. This resulted in us not being able to decode back our own generated JSON in case of variants inside variants.

Fixes #549.
