### PR TITLE
✨ zb: Add support for `unixexec` transport

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -110,7 +110,7 @@ nix = { version = "0.29", default-features = false, features = [
   "user",
 ] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(target_family = "unix")'.dependencies]
 # FIXME: This should only be enabled if async-io feature is enabled but currently
 # Cargo doesn't provide a way to do that for only specific target OS: https://github.com/rust-lang/cargo/issues/1197.
 async-process = "2.2.2"

--- a/zbus/src/abstractions/mod.rs
+++ b/zbus/src/abstractions/mod.rs
@@ -8,6 +8,6 @@ mod async_drop;
 pub(crate) mod async_lock;
 pub use async_drop::*;
 
-// Not macOS-specific itself but only used on macOS.
-#[cfg(target_os = "macos")]
+// Not unix-specific itself but only used on unix.
+#[cfg(target_family = "unix")]
 pub(crate) mod process;

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -1,6 +1,8 @@
+#[cfg(target_os = "macos")]
 use std::{ffi::OsStr, io::Error, process::Output};
 
 /// An asynchronous wrapper around running and getting command output
+#[cfg(target_os = "macos")]
 pub async fn run<I, S>(program: S, args: I) -> Result<Output, Error>
 where
     I: IntoIterator<Item = S>,

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -1,5 +1,82 @@
+#[cfg(not(feature = "tokio"))]
+use async_process::{unix::CommandExt, Child};
 #[cfg(target_os = "macos")]
-use std::{ffi::OsStr, io::Error, process::Output};
+use std::process::Output;
+use std::{ffi::OsStr, io::Error, process::Stdio};
+#[cfg(feature = "tokio")]
+use tokio::process::Child;
+
+/// A wrapper around the command API of the underlying async runtime.
+pub struct Command(
+    #[cfg(not(feature = "tokio"))] async_process::Command,
+    #[cfg(feature = "tokio")] tokio::process::Command,
+);
+
+impl Command {
+    /// Constructs a new `Command` for launching the program at path `program`.
+    pub fn new<S>(program: S) -> Self
+    where
+        S: AsRef<OsStr>,
+    {
+        #[cfg(not(feature = "tokio"))]
+        return Self(async_process::Command::new(program));
+
+        #[cfg(feature = "tokio")]
+        return Self(tokio::process::Command::new(program));
+    }
+
+    /// Sets executable argument.
+    ///
+    /// Set the first process argument, `argv[0]`, to something other than the
+    /// default executable path.
+    pub fn arg0<S>(&mut self, arg: S) -> &mut Self
+    where
+        S: AsRef<OsStr>,
+    {
+        self.0.arg0(arg);
+        self
+    }
+
+    /// Adds multiple arguments to pass to the program.
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.0.args(args);
+        self
+    }
+
+    /// Executes the command as a child process, waiting for it to finish and
+    /// collecting all of its output.
+    #[cfg(target_os = "macos")]
+    pub async fn output(&mut self) -> Result<Output, Error> {
+        self.0.output().await
+    }
+
+    /// Sets configuration for the child process's standard input (stdin) handle.
+    pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.0.stdin(cfg);
+        self
+    }
+
+    /// Sets configuration for the child process's standard output (stdout) handle.
+    pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.0.stdout(cfg);
+        self
+    }
+
+    /// Sets configuration for the child process's standard error (stderr) handle.
+    pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.0.stderr(cfg);
+        self
+    }
+
+    /// Executes the command as a child process, returning a handle to it.
+    pub fn spawn(&mut self) -> Result<Child, Error> {
+        self.0.spawn()
+    }
+}
 
 /// An asynchronous wrapper around running and getting command output
 #[cfg(target_os = "macos")]
@@ -8,15 +85,5 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    #[cfg(not(feature = "tokio"))]
-    return async_process::Command::new(program)
-        .args(args)
-        .output()
-        .await;
-
-    #[cfg(feature = "tokio")]
-    return tokio::process::Command::new(program)
-        .args(args)
-        .output()
-        .await;
+    Command::new(program).args(args).output().await
 }

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -6,6 +6,8 @@ use std::{ffi::OsStr, io::Error, process::Stdio};
 #[cfg(feature = "tokio")]
 use tokio::process::Child;
 
+use crate::address::transport::Unixexec;
+
 /// A wrapper around the command API of the underlying async runtime.
 pub struct Command(
     #[cfg(not(feature = "tokio"))] async_process::Command,
@@ -23,6 +25,18 @@ impl Command {
 
         #[cfg(feature = "tokio")]
         return Self(tokio::process::Command::new(program));
+    }
+
+    /// Constructs a new `Command` from a `unixexec` address.
+    pub fn for_unixexec(unixexec: &Unixexec) -> Self {
+        let mut command = Self::new(unixexec.path());
+        command.args(unixexec.args());
+
+        if let Some(arg0) = unixexec.arg0() {
+            command.arg0(arg0);
+        }
+
+        command
     }
 
     /// Sets executable argument.

--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -182,6 +182,8 @@ mod tests {
     };
     #[cfg(target_os = "macos")]
     use crate::address::transport::Launchd;
+    #[cfg(unix)]
+    use crate::address::transport::Unixexec;
     #[cfg(windows)]
     use crate::address::transport::{Autolaunch, AutolaunchScope};
     use crate::{
@@ -232,6 +234,11 @@ mod tests {
             }
             _ => panic!(),
         }
+        #[cfg(unix)]
+        match Address::from_str("unixexec:foo=blah").unwrap_err() {
+            Error::Address(e) => assert_eq!(e, "unixexec address is missing `path`"),
+            _ => panic!(),
+        }
         assert_eq!(
             Address::from_str("unix:path=/tmp/dbus-foo").unwrap(),
             Transport::Unix(Unix::new(UnixSocket::File("/tmp/dbus-foo".into()))).into(),
@@ -253,6 +260,11 @@ mod tests {
                 .unwrap(),
             );
         }
+        #[cfg(unix)]
+        assert_eq!(
+            Address::from_str("unixexec:path=/tmp/dbus-foo").unwrap(),
+            Transport::Unixexec(Unixexec::new("/tmp/dbus-foo".into(), None, Vec::new())).into(),
+        );
         assert_eq!(
             Address::from_str("tcp:host=localhost,port=4142").unwrap(),
             Transport::Tcp(Tcp::new("localhost", 4142)).into(),

--- a/zbus/src/address/transport/mod.rs
+++ b/zbus/src/address/transport/mod.rs
@@ -1,6 +1,6 @@
 //! D-Bus transport Information module.
 //!
-//! This module provides the trasport information for D-Bus addresses.
+//! This module provides the transport information for D-Bus addresses.
 
 #[cfg(windows)]
 use crate::win32::autolaunch_bus_address;

--- a/zbus/src/address/transport/unixexec.rs
+++ b/zbus/src/address/transport/unixexec.rs
@@ -1,0 +1,115 @@
+use std::{
+    borrow::BorrowMut, ffi::OsString, fmt::Display, os::unix::ffi::OsStrExt, path::PathBuf,
+    process::Stdio,
+};
+
+use crate::process::Command;
+
+use super::encode_percents;
+
+/// `unixexec:` D-Bus transport.
+///
+/// <https://dbus.freedesktop.org/doc/dbus-specification.html#transports-exec>
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Unixexec {
+    path: PathBuf,
+    arg0: Option<OsString>,
+    args: Vec<OsString>,
+}
+
+impl Unixexec {
+    /// Create a new unixexec transport with the given path and arguments.
+    pub fn new(path: PathBuf, arg0: Option<OsString>, args: Vec<OsString>) -> Self {
+        Self { path, arg0, args }
+    }
+
+    pub(super) fn from_options(opts: std::collections::HashMap<&str, &str>) -> crate::Result<Self> {
+        let Some(path) = opts.get("path") else {
+            return Err(crate::Error::Address(
+                "unixexec address is missing `path`".to_owned(),
+            ));
+        };
+
+        let arg0 = opts.get("argv0").map(OsString::from);
+
+        let mut args: Vec<OsString> = Vec::new();
+        let mut arg_index = 1;
+        while let Some(arg) = opts.get(format!("argv{arg_index}").as_str()) {
+            args.push(OsString::from(arg));
+            arg_index += 1;
+        }
+
+        Ok(Self::new(PathBuf::from(path), arg0, args))
+    }
+
+    /// Binary to execute.
+    ///
+    /// Path of the binary to execute, either an absolute path or a binary name that is searched for
+    /// in the default search path of the OS. This corresponds to the first argument of execlp().
+    /// This key is mandatory.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    /// The executable argument.
+    ///
+    /// The program name to use when executing the binary. If omitted the same
+    /// value as specified for path will be used. This corresponds to the
+    /// second argument of execlp().
+    pub fn arg0(&self) -> Option<&OsString> {
+        self.arg0.as_ref()
+    }
+
+    /// Arguments.
+    ///
+    /// Arguments to pass to the binary.
+    pub fn args(&self) -> &[OsString] {
+        self.args.as_ref()
+    }
+
+    pub(super) async fn connect(&self) -> crate::Result<crate::connection::socket::Command> {
+        Command::for_unixexec(self)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?
+            .borrow_mut()
+            .try_into()
+    }
+}
+
+impl Display for Unixexec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unixexec:path=")?;
+        encode_percents(f, self.path.as_os_str().as_bytes())?;
+
+        if let Some(arg0) = self.arg0.as_ref() {
+            f.write_str(",argv0=")?;
+            encode_percents(f, arg0.as_bytes())?;
+        }
+
+        for (index, arg) in self.args.iter().enumerate() {
+            write!(f, ",argv{}=", index + 1)?;
+            encode_percents(f, arg.as_bytes())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::address::{transport::Transport, Address};
+
+    #[test]
+    fn connect() {
+        let addr: Address = "unixexec:path=echo,argv1=hello,argv2=world"
+            .try_into()
+            .unwrap();
+        let unixexec = match addr.transport() {
+            Transport::Unixexec(unixexec) => unixexec,
+            _ => unreachable!(),
+        };
+        crate::utils::block_on(unixexec.connect()).unwrap();
+    }
+}

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -492,6 +492,8 @@ impl<'a> Builder<'a> {
                 match address.connect().await? {
                     #[cfg(any(unix, not(feature = "tokio")))]
                     address::transport::Stream::Unix(stream) => stream.into(),
+                    #[cfg(unix)]
+                    address::transport::Stream::Unixexec(stream) => stream.into(),
                     address::transport::Stream::Tcp(stream) => stream.into(),
                     #[cfg(any(
                         all(feature = "vsock", not(feature = "tokio")),

--- a/zbus/src/connection/socket/command.rs
+++ b/zbus/src/connection/socket/command.rs
@@ -1,0 +1,137 @@
+use std::{io, os::fd::BorrowedFd};
+
+#[cfg(not(feature = "tokio"))]
+use async_process::{Child, ChildStdin, ChildStdout};
+
+#[cfg(feature = "tokio")]
+use tokio::{
+    io::{AsyncReadExt, ReadBuf},
+    process::{Child, ChildStdin, ChildStdout},
+};
+
+use super::{ReadHalf, RecvmsgResult, Socket, Split, WriteHalf};
+
+/// A Command stream socket.
+///
+/// This socket communicates with a spawned child process via its standard input
+/// and output streams.
+#[derive(Debug)]
+pub(crate) struct Command {
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+}
+
+impl Command {
+    fn into_split(self) -> (ChildStdout, ChildStdin) {
+        (self.stdout, self.stdin)
+    }
+}
+
+impl Socket for Command {
+    type ReadHalf = ChildStdout;
+    type WriteHalf = ChildStdin;
+
+    fn split(self) -> Split<Self::ReadHalf, Self::WriteHalf> {
+        let (read, write) = self.into_split();
+
+        Split { read, write }
+    }
+}
+
+impl TryFrom<&mut Child> for Command {
+    type Error = crate::Error;
+
+    fn try_from(child: &mut Child) -> Result<Self, Self::Error> {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(crate::Error::Failure("child stdin not found".into()))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(crate::Error::Failure("child stdout not found".into()))?;
+
+        Ok(Command { stdin, stdout })
+    }
+}
+
+#[cfg(not(feature = "tokio"))]
+#[async_trait::async_trait]
+impl ReadHalf for ChildStdout {
+    async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
+        match futures_util::AsyncReadExt::read(&mut self, buf).await {
+            Err(e) => Err(e),
+            Ok(len) => {
+                #[cfg(unix)]
+                let ret = (len, vec![]);
+                #[cfg(not(unix))]
+                let ret = len;
+                Ok(ret)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[async_trait::async_trait]
+impl ReadHalf for ChildStdout {
+    async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
+        let mut read_buf = ReadBuf::new(buf);
+        self.read_buf(&mut read_buf).await.map(|_| {
+            let ret = read_buf.filled().len();
+            #[cfg(unix)]
+            let ret = (ret, vec![]);
+
+            ret
+        })
+    }
+}
+
+#[cfg(not(feature = "tokio"))]
+#[async_trait::async_trait]
+impl WriteHalf for ChildStdin {
+    async fn sendmsg(
+        &mut self,
+        buf: &[u8],
+        #[cfg(unix)] fds: &[BorrowedFd<'_>],
+    ) -> io::Result<usize> {
+        #[cfg(unix)]
+        if !fds.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "fds cannot be sent with a command stream",
+            ));
+        }
+
+        futures_util::AsyncWriteExt::write(&mut self, buf).await
+    }
+
+    async fn close(&mut self) -> io::Result<()> {
+        futures_util::AsyncWriteExt::close(&mut self).await
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[async_trait::async_trait]
+impl WriteHalf for ChildStdin {
+    async fn sendmsg(
+        &mut self,
+        buf: &[u8],
+        #[cfg(unix)] fds: &[BorrowedFd<'_>],
+    ) -> io::Result<usize> {
+        #[cfg(unix)]
+        if !fds.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "fds cannot be sent with a command stream",
+            ));
+        }
+
+        tokio::io::AsyncWriteExt::write(&mut self, buf).await
+    }
+
+    async fn close(&mut self) -> io::Result<()> {
+        tokio::io::AsyncWriteExt::shutdown(&mut self).await
+    }
+}

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -6,6 +6,10 @@ pub use channel::Channel;
 mod split;
 pub use split::{BoxedSplit, Split};
 
+#[cfg(unix)]
+pub(crate) mod command;
+#[cfg(unix)]
+pub(crate) use command::Command;
 mod tcp;
 mod unix;
 mod vsock;

--- a/zbus/tests/unixexec.rs
+++ b/zbus/tests/unixexec.rs
@@ -1,0 +1,34 @@
+use ntest::timeout;
+use test_log::test;
+
+use zbus::{block_on, conn::Builder, Result};
+
+#[test]
+#[timeout(15000)]
+fn unixexec_connection_async() {
+    block_on(test_unixexec_connection()).unwrap();
+}
+
+async fn test_unixexec_connection() -> Result<()> {
+    let connection = Builder::address("unixexec:path=systemd-stdio-bridge")?
+        .build()
+        .await?;
+
+    match connection
+        .call_method(
+            Some("org.freedesktop.DBus"),
+            "/org/freedesktop/DBus",
+            Some("org.freedesktop.DBus"),
+            "Hello",
+            &(),
+        )
+        .await
+    {
+        Err(zbus::Error::MethodError(_, _, _)) => (),
+        Err(e) => panic!("{}", e),
+
+        _ => panic!(),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Add initial support for the [unixexec](https://dbus.freedesktop.org/doc/dbus-specification.html#transports-exec) transport (#325). ~~Currently this is **only implemented when the `tokio` feature is enabled**.~~ Edit: Support for the `async-io` runtime has also been implemented in later revisions.