### PR TITLE
⚡️ zv,zd,zn,zb,zm: `Type::parsed_signature` now a const

### DIFF
--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -205,6 +205,12 @@ impl From<VariantError> for Error {
     }
 }
 
+impl From<zvariant::parsed::Error> for Error {
+    fn from(e: zvariant::parsed::Error) -> Self {
+        zvariant::Error::from(e).into()
+    }
+}
+
 impl From<NamesError> for Error {
     fn from(val: NamesError) -> Self {
         match val {

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -354,7 +354,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == <&str>::signature()).unwrap());
+        assert!(body.signature().map(|s| <&str>::SIGNATURE == &s).unwrap());
         let id: &str = body.deserialize().unwrap();
         debug!("Unique ID of the bus: {}", id);
 
@@ -369,7 +369,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == bool::signature()).unwrap());
+        assert!(body.signature().map(|s| bool::SIGNATURE == &s).unwrap());
         assert!(body.deserialize::<bool>().unwrap());
 
         let reply = connection
@@ -383,7 +383,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == <&str>::signature()).unwrap());
+        assert!(body.signature().map(|s| <&str>::SIGNATURE == &s).unwrap());
         assert_eq!(
             body.deserialize::<UniqueName<'_>>().unwrap(),
             *connection.unique_name().unwrap(),
@@ -454,7 +454,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == <&str>::signature()).unwrap());
+        assert!(body.signature().map(|s| <&str>::SIGNATURE == &s).unwrap());
         let id: &str = body.deserialize().unwrap();
         debug!("Unique ID of the bus: {}", id);
 
@@ -470,7 +470,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == bool::signature()).unwrap());
+        assert!(body.signature().map(|s| bool::SIGNATURE == &s).unwrap());
         assert!(body.deserialize::<bool>().unwrap());
 
         let reply = connection
@@ -485,7 +485,7 @@ mod tests {
             .unwrap();
 
         let body = reply.body();
-        assert!(body.signature().map(|s| s == <&str>::signature()).unwrap());
+        assert!(body.signature().map(|s| <&str>::SIGNATURE == &s).unwrap());
         assert_eq!(
             body.deserialize::<UniqueName<'_>>().unwrap(),
             *connection.unique_name().unwrap(),

--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -36,7 +36,7 @@ impl Body {
             .unwrap_or(parsed::Signature::Unit);
 
         self.data
-            .deserialize_for_dynamic_parsed_signature(body_sig)
+            .deserialize_for_dynamic_parsed_signature(&body_sig)
             .map_err(Error::from)
             .map(|b| b.0)
     }

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -7,7 +7,7 @@ use zvariant::OwnedFd;
 
 use enumflags2::BitFlags;
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
-use zvariant::{serialized, Endian};
+use zvariant::{parsed, serialized, Endian};
 
 use crate::{
     message::{Fields, Flags, Header, Message, PrimaryHeader, Sequence, Type},
@@ -206,7 +206,7 @@ impl<'a> Builder<'a> {
         // to efficient handling of ones that are complex to serialize.
         let body_size = zvariant::serialized_size(ctxt, body)?;
 
-        let signature = body.dynamic_signature().into();
+        let signature = body.dynamic_signature();
 
         self.build_generic(signature, body_size, move |cursor| {
             // SAFETY: build_generic puts FDs and the body in the same Message.
@@ -231,17 +231,17 @@ impl<'a> Builder<'a> {
     /// # Safety
     ///
     /// This method is unsafe because it can be used to build an invalid message.
-    pub unsafe fn build_raw_body<'b, S>(
+    pub unsafe fn build_raw_body<S>(
         self,
         body_bytes: &[u8],
         signature: S,
         #[cfg(unix)] fds: Vec<OwnedFd>,
     ) -> Result<Message>
     where
-        S: TryInto<Signature<'b>>,
+        S: TryInto<parsed::Signature>,
         S::Error: Into<Error>,
     {
-        let signature: Signature<'b> = signature.try_into().map_err(Into::into)?;
+        let signature = signature.try_into().map_err(Into::into)?;
         let body_size = serialized::Size::new(body_bytes.len(), dbus_context!(self, 0));
         #[cfg(unix)]
         let body_size = {
@@ -266,7 +266,7 @@ impl<'a> Builder<'a> {
 
     fn build_generic<WriteFunc>(
         self,
-        mut signature: Signature<'_>,
+        signature: parsed::Signature,
         body_size: serialized::Size,
         write_body: WriteFunc,
     ) -> Result<Message>
@@ -276,11 +276,10 @@ impl<'a> Builder<'a> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 
-        if !signature.is_empty() {
-            if signature.starts_with(zvariant::STRUCT_SIG_START_STR) {
-                // Remove leading and trailing STRUCT delimiters
-                signature = signature.slice(1..signature.len() - 1);
-            }
+        if !matches!(signature, parsed::Signature::Unit) {
+            let signature = signature.to_string_no_parens();
+            let signature = Signature::from_string_unchecked(signature);
+
             header.fields_mut().signature = Some(signature);
         }
 

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -206,7 +206,7 @@ impl<'a> Builder<'a> {
         // to efficient handling of ones that are complex to serialize.
         let body_size = zvariant::serialized_size(ctxt, body)?;
 
-        let signature = body.dynamic_signature();
+        let signature = body.dynamic_signature().into();
 
         self.build_generic(signature, body_size, move |cursor| {
             // SAFETY: build_generic puts FDs and the body in the same Message.

--- a/zbus/src/message/fields.rs
+++ b/zbus/src/message/fields.rs
@@ -38,16 +38,11 @@ impl Fields<'_> {
     }
 }
 
-const FIELDS_SIGNATURE: &parsed::Signature =
-    &parsed::Signature::static_array(&parsed::Signature::Structure(FieldsSignatures::Static {
-        fields: &[&parsed::Signature::U8, &parsed::Signature::Variant],
-    }));
-
 impl<'f> Type for Fields<'f> {
-    #[inline]
-    fn parsed_signature() -> parsed::Signature {
-        FIELDS_SIGNATURE.clone()
-    }
+    const SIGNATURE: &'static parsed::Signature =
+        &parsed::Signature::static_array(&parsed::Signature::Structure(FieldsSignatures::Static {
+            fields: &[&parsed::Signature::U8, &parsed::Signature::Variant],
+        }));
 }
 
 impl<'f> Serialize for Fields<'f> {

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -905,10 +905,7 @@ impl<R> Type for ResponseDispatchNotifier<R>
 where
     R: Type,
 {
-    #[inline]
-    fn parsed_signature() -> Signature {
-        R::parsed_signature()
-    }
+    const SIGNATURE: &'static Signature = R::SIGNATURE;
 }
 
 impl<T> Drop for ResponseDispatchNotifier<T> {

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -1098,7 +1098,7 @@ fn introspect_input_args<'i>(
             Some(quote!(
                 #(#cfg_attrs)*
                 ::std::writeln!(writer, "{:indent$}<arg name=\"{}\" type=\"{}\"{}/>", "",
-                         #arg_name, <#ty>::signature(), #dir, indent = level).unwrap();
+                         #arg_name, <#ty>::SIGNATURE, #dir, indent = level).unwrap();
             ))
         })
 }
@@ -1116,7 +1116,7 @@ fn introspect_output_arg(
     quote!(
         #(#cfg_attrs)*
         ::std::writeln!(writer, "{:indent$}<arg {}type=\"{}\" direction=\"out\"/>", "",
-                 #arg_name, <#ty>::signature(), indent = level).unwrap();
+                 #arg_name, <#ty>::SIGNATURE, indent = level).unwrap();
     )
 }
 
@@ -1230,7 +1230,7 @@ fn introspect_properties(
                 ::std::writeln!(
                     writer,
                     "{:indent$}<property name=\"{}\" type=\"{}\" access=\"{}\"/>",
-                    "", #name, <#ty>::signature(), #access, indent = level,
+                    "", #name, <#ty>::SIGNATURE, #access, indent = level,
                 ).unwrap();
             ));
         } else {
@@ -1240,7 +1240,7 @@ fn introspect_properties(
                 ::std::writeln!(
                     writer,
                     "{:indent$}<property name=\"{}\" type=\"{}\" access=\"{}\">",
-                    "", #name, <#ty>::signature(), #access, indent = level,
+                    "", #name, <#ty>::SIGNATURE, #access, indent = level,
                 ).unwrap();
                 ::std::writeln!(
                     writer,

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -496,10 +496,8 @@ pub fn create_proxy<M: AttrParse + Into<MethodAttrs>>(
         }
 
         impl<'p> #zbus::zvariant::Type for #proxy_name<'p> {
-            #[inline]
-            fn parsed_signature() -> #zbus::zvariant::parsed::Signature {
-                #zbus::zvariant::parsed::Signature::ObjectPath
-            }
+            const SIGNATURE: &'static #zbus::zvariant::parsed::Signature =
+                &#zbus::zvariant::parsed::Signature::ObjectPath;
         }
 
         impl<'p> #zbus::export::serde::ser::Serialize for #proxy_name<'p> {

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -195,10 +195,7 @@ impl<'de: 'name, 'name> Deserialize<'de> for BusName<'name> {
 }
 
 impl Type for BusName<'_> {
-    #[inline]
-    fn parsed_signature() -> zvariant::parsed::Signature {
-        zvariant::parsed::Signature::Str
-    }
+    const SIGNATURE: &'static zvariant::parsed::Signature = &zvariant::parsed::Signature::Str;
 }
 
 impl<'name> From<UniqueName<'name>> for BusName<'name> {

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -217,16 +217,14 @@ impl<'s> TryFrom<Str<'s>> for BusName<'s> {
     type Error = Error;
 
     fn try_from(value: Str<'s>) -> Result<Self> {
-        match UniqueName::try_from(value.clone()) {
-            Err(Error::InvalidUniqueName(unique_err)) => match WellKnownName::try_from(value) {
-                Err(Error::InvalidWellKnownName(well_known_err)) => {
-                    Err(Error::InvalidBusName(unique_err, well_known_err))
-                }
-                Err(e) => Err(e),
-                Ok(name) => Ok(BusName::WellKnown(name)),
-            },
-            Err(e) => Err(e),
-            Ok(name) => Ok(BusName::Unique(name)),
+        if value.starts_with(':') {
+            UniqueName::try_from(value).map(BusName::Unique)
+        } else if value == "org.freedesktop.DBus" {
+            Ok(BusName::Unique(UniqueName::from_static_str_unchecked(
+                "org.freedesktop.DBus",
+            )))
+        } else {
+            WellKnownName::try_from(value).map(BusName::WellKnown)
         }
     }
 }

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -66,7 +66,7 @@ struct Struct<'s> {
     field3: &'s str,
 }
 
-assert_eq!(Struct::signature(), "(qxs)");
+assert_eq!(Struct::SIGNATURE, "(qxs)");
 let s = Struct {
     field1: 42,
     field2: i64::max_value(),
@@ -90,7 +90,7 @@ enum Enum<'s> {
 // Enum encoding uses a `u32` to denote the variant index. For unit-type enums that's all that's
 // needed so the signature is just `u` but complex enums are encoded as a structure whose first
 // field is the variant index and the second one is the field(s).
-assert_eq!(Enum::signature(), "(u(qxs))");
+assert_eq!(Enum::SIGNATURE, "(u(qxs))");
 let e = Enum::Variant3 {
     f1: 42,
     f2: i64::max_value(),
@@ -112,7 +112,7 @@ enum UnitEnum {
     Variant3,
 }
 
-assert_eq!(UnitEnum::signature(), "y");
+assert_eq!(UnitEnum::SIGNATURE, "y");
 let encoded = to_bytes(ctxt, &UnitEnum::Variant2).unwrap();
 let e: UnitEnum = encoded.deserialize().unwrap().0;
 assert_eq!(e, UnitEnum::Variant2);
@@ -126,7 +126,7 @@ enum StrEnum {
     Variant3,
 }
 
-assert_eq!(StrEnum::signature(), "s");
+assert_eq!(StrEnum::SIGNATURE, "s");
 ```
 
 Apart from the obvious requirement of [`serialized::Context`] instance by the main serialization and

--- a/zvariant/src/array.rs
+++ b/zvariant/src/array.rs
@@ -222,13 +222,13 @@ impl ArraySeed<'static> {
 assert_impl_all!(ArraySeed<'_>: Unpin);
 
 impl<'a> DynamicType for Array<'a> {
-    fn dynamic_signature(&self) -> Signature<'_> {
-        self.signature.clone()
+    fn dynamic_signature(&self) -> parsed::Signature {
+        self.signature.clone().into()
     }
 }
 
 impl<'a> DynamicType for ArraySeed<'a> {
-    fn dynamic_parsed_signature(&self) -> parsed::Signature {
+    fn dynamic_signature(&self) -> parsed::Signature {
         self.signature.clone()
     }
 }
@@ -236,7 +236,7 @@ impl<'a> DynamicType for ArraySeed<'a> {
 impl<'a> DynamicDeserialize<'a> for Array<'a> {
     type Deserializer = ArraySeed<'static>;
 
-    fn deserializer_for_parsed_signature(
+    fn deserializer_for_signature(
         parsed_signature: &parsed::Signature,
     ) -> zvariant::Result<Self::Deserializer> {
         let signature = parsed_signature.into();
@@ -264,7 +264,7 @@ where
     T: Type + Into<Value<'a>>,
 {
     fn from(values: Vec<T>) -> Self {
-        let element_signature = T::signature();
+        let element_signature = T::SIGNATURE.into();
         let elements = values.into_iter().map(Value::new).collect();
         let signature = create_signature(&element_signature);
 
@@ -281,7 +281,7 @@ where
     T: Type + Into<Value<'a>> + Clone,
 {
     fn from(values: &[T]) -> Self {
-        let element_signature = T::signature();
+        let element_signature = T::SIGNATURE.into();
         let elements = values
             .iter()
             .map(|value| Value::new(value.clone()))

--- a/zvariant/src/basic.rs
+++ b/zvariant/src/basic.rs
@@ -11,30 +11,6 @@ pub trait Basic: Type {
     const SIGNATURE_CHAR: char;
     /// The type signature, as a string.
     const SIGNATURE_STR: &'static str;
-    /// The parsed signature.
-    ///
-    /// The default value is determined through the `SIGNATURE_CHAR` constant and in most cases, is
-    /// exactly what you want.
-    const SIGNATURE: &'static parsed::Signature = {
-        match Self::SIGNATURE_CHAR {
-            'y' => &parsed::Signature::U8,
-            'b' => &parsed::Signature::Bool,
-            'n' => &parsed::Signature::I16,
-            'q' => &parsed::Signature::U16,
-            'i' => &parsed::Signature::I32,
-            'u' => &parsed::Signature::U32,
-            'x' => &parsed::Signature::I64,
-            't' => &parsed::Signature::U64,
-            'd' => &parsed::Signature::F64,
-            's' => &parsed::Signature::Str,
-            'g' => &parsed::Signature::Signature,
-            'o' => &parsed::Signature::ObjectPath,
-            'v' => &parsed::Signature::Variant,
-            #[cfg(unix)]
-            'h' => &parsed::Signature::Fd,
-            _ => unreachable!(),
-        }
-    };
 
     /// The required padding alignment for the given format.
     ///
@@ -56,10 +32,26 @@ where
 macro_rules! impl_type {
     ($for:ty) => {
         impl Type for $for {
-            #[inline]
-            fn parsed_signature() -> parsed::Signature {
-                <$for as Basic>::SIGNATURE.clone()
-            }
+            const SIGNATURE: &'static parsed::Signature = {
+                match Self::SIGNATURE_CHAR {
+                    'y' => &parsed::Signature::U8,
+                    'b' => &parsed::Signature::Bool,
+                    'n' => &parsed::Signature::I16,
+                    'q' => &parsed::Signature::U16,
+                    'i' => &parsed::Signature::I32,
+                    'u' => &parsed::Signature::U32,
+                    'x' => &parsed::Signature::I64,
+                    't' => &parsed::Signature::U64,
+                    'd' => &parsed::Signature::F64,
+                    's' => &parsed::Signature::Str,
+                    'g' => &parsed::Signature::Signature,
+                    'o' => &parsed::Signature::ObjectPath,
+                    'v' => &parsed::Signature::Variant,
+                    #[cfg(unix)]
+                    'h' => &parsed::Signature::Fd,
+                    _ => unreachable!(),
+                }
+            };
         }
     };
 }

--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -63,7 +63,7 @@ impl<'de, T: Type + Deserialize<'de>> Visitor<'de> for DeserializeValueVisitor<T
         let sig: Signature<'_> = seq
             .next_element()?
             .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-        if sig != T::signature() {
+        if T::SIGNATURE != &sig {
             return Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&sig),
                 &"the value signature",
@@ -76,8 +76,5 @@ impl<'de, T: Type + Deserialize<'de>> Visitor<'de> for DeserializeValueVisitor<T
 }
 
 impl<'de, T: Type + Deserialize<'de>> Type for DeserializeValue<'de, T> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::Variant
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Variant;
 }

--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -67,7 +67,7 @@ impl<'k, 'v> Dict<'k, 'v> {
         K: Basic + Into<Value<'k>> + Ord,
         V: Into<Value<'v>> + DynamicType,
     {
-        check_child_value_signature!(self.key_signature, K::signature(), "key");
+        check_child_value_signature!(&self.key_signature, K::SIGNATURE, "key");
         check_child_value_signature!(self.value_signature, value.dynamic_signature(), "value");
 
         self.map.insert(Value::new(key), Value::new(value));
@@ -280,8 +280,8 @@ macro_rules! to_dict {
                     .into_iter()
                     .map(|(key, value)| (Value::new(key), Value::new(value)))
                     .collect();
-                let key_signature = K::signature();
-                let value_signature = V::signature();
+                let key_signature = K::SIGNATURE.into();
+                let value_signature = V::SIGNATURE.into();
                 let signature = create_signature(&key_signature, &value_signature);
 
                 Self {

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -62,6 +62,8 @@ pub enum Error {
     MaxDepthExceeded(MaxDepthExceeded),
     /// Error from parsing a signature.
     SignatureParse(crate::parsed::Error),
+    /// Attempted to create an empty structure (which is not allowed by the D-Bus specification).
+    EmptyStructure,
 }
 
 assert_impl_all!(Error: Send, Sync, Unpin);
@@ -119,6 +121,7 @@ impl fmt::Display for Error {
             ),
             Error::MaxDepthExceeded(max) => write!(f, "{max}"),
             Error::SignatureParse(e) => write!(f, "{e}"),
+            Error::EmptyStructure => write!(f, "Attempted to create an empty structure"),
         }
     }
 }
@@ -142,6 +145,7 @@ impl Clone for Error {
             Error::OutOfBounds => Error::OutOfBounds,
             Error::MaxDepthExceeded(max) => Error::MaxDepthExceeded(*max),
             Error::SignatureParse(e) => Error::SignatureParse(*e),
+            Error::EmptyStructure => Error::EmptyStructure,
         }
     }
 }

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -105,10 +105,7 @@ macro_rules! fd_impl {
         }
 
         impl Type for $i {
-            #[inline]
-            fn parsed_signature() -> crate::parsed::Signature {
-                crate::parsed::Signature::Fd
-            }
+            const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Fd;
         }
     };
 }

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -167,7 +167,7 @@ where
     V: Into<Value<'v>> + Type,
 {
     fn from(v: Option<V>) -> Value<'v> {
-        let mut array = Array::new(V::signature());
+        let mut array = Array::new(V::SIGNATURE.into());
         if let Some(v) = v {
             // We got the signature from the `Type` impl, so this should never panic.
             array.append(v.into()).expect("signature mismatch");

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1412,6 +1412,7 @@ mod tests {
             .add_field("value2")
             .append_field(zvariant::Value::new(value)) // let's try to get a variant
             .build()
+            .unwrap()
             .try_into()
             .unwrap();
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -670,7 +670,7 @@ mod tests {
         // Array of u8
         //
         // First a normal Rust array that is actually serialized as a struct (thank you Serde!)
-        assert_eq!(<[u8; 2]>::signature(), "(yy)");
+        assert_eq!(<[u8; 2]>::SIGNATURE, "(yy)");
         let ay = [77u8, 88];
         let ctxt = Context::new_dbus(LE, 0);
         let encoded = to_bytes(ctxt, &ay).unwrap();
@@ -1101,7 +1101,7 @@ mod tests {
         #[derive(Serialize, Deserialize, Type, PartialEq, Debug)]
         struct Unit;
 
-        assert_eq!(Unit::signature(), "");
+        assert_eq!(Unit::SIGNATURE, "");
         let encoded = to_bytes(ctxt, &Unit).unwrap();
         assert_eq!(encoded.len(), 0);
         let _decoded: Unit = encoded.deserialize().unwrap().0;
@@ -1110,7 +1110,7 @@ mod tests {
         #[derive(Serialize, Deserialize, Type, PartialEq, Debug)]
         struct NoFields {}
 
-        assert_eq!(NoFields::signature(), "y");
+        assert_eq!(NoFields::SIGNATURE, "y");
         let encoded = to_bytes(ctxt, &NoFields {}).unwrap();
         assert_eq!(encoded.len(), 1);
         let _decoded: NoFields = encoded.deserialize().unwrap().0;
@@ -1252,7 +1252,7 @@ mod tests {
         let ctxt = Context::new_dbus(LE, 0);
 
         // Now a hand-crafted Dict Value but with a Value as value
-        let mut dict = Dict::new(<&str>::signature(), Value::signature());
+        let mut dict = Dict::new(<&str>::SIGNATURE.into(), Value::SIGNATURE.into());
         dict.add("hello", Value::new("there")).unwrap();
         dict.add("bye", Value::new("now")).unwrap();
         let v: Value<'_> = dict.into();
@@ -1346,11 +1346,11 @@ mod tests {
     fn dict_compare() {
         // the order in which a dict has been constructed must not play a role
         // https://github.com/dbus2/zbus/issues/484
-        let mut dict1 = Dict::new(<&str>::signature(), Value::signature());
+        let mut dict1 = Dict::new(<&str>::SIGNATURE.into(), Value::SIGNATURE.into());
         dict1.add("first", Value::new("value")).unwrap();
         dict1.add("second", Value::new("value")).unwrap();
 
-        let mut dict2 = Dict::new(<&str>::signature(), Value::signature());
+        let mut dict2 = Dict::new(<&str>::SIGNATURE.into(), Value::SIGNATURE.into());
         dict2.add("second", Value::new("value")).unwrap();
         dict2.add("first", Value::new("value")).unwrap();
 
@@ -1564,7 +1564,7 @@ mod tests {
             field3: &'s str,
         }
 
-        assert_eq!(Struct::signature(), "(qxs)");
+        assert_eq!(Struct::SIGNATURE, "(qxs)");
         let s = Struct {
             field1: 0xFF_FF,
             field2: 0xFF_FF_FF_FF_FF_FF,
@@ -1579,7 +1579,7 @@ mod tests {
         #[derive(Deserialize, Serialize, Type)]
         struct UnitStruct;
 
-        assert_eq!(UnitStruct::signature(), <()>::signature());
+        assert_eq!(UnitStruct::SIGNATURE, <()>::SIGNATURE);
         let encoded = to_bytes(ctxt, &UnitStruct).unwrap();
         assert_eq!(encoded.len(), 0);
         let _: UnitStruct = encoded.deserialize().unwrap().0;
@@ -1592,7 +1592,7 @@ mod tests {
             Variant3,
         }
 
-        assert_eq!(Enum::signature(), u8::signature());
+        assert_eq!(Enum::SIGNATURE, u8::SIGNATURE);
         let encoded = to_bytes(ctxt, &Enum::Variant3).unwrap();
         assert_eq!(encoded.len(), 1);
         let decoded: Enum = encoded.deserialize().unwrap().0;
@@ -1606,7 +1606,7 @@ mod tests {
             Variant3,
         }
 
-        assert_eq!(Enum2::signature(), i64::signature());
+        assert_eq!(Enum2::SIGNATURE, i64::SIGNATURE);
         let encoded = to_bytes(ctxt, &Enum2::Variant2).unwrap();
         assert_eq!(encoded.len(), 8);
         let decoded: Enum2 = encoded.deserialize().unwrap().0;
@@ -1623,7 +1623,7 @@ mod tests {
         let encoded = to_bytes(ctxt, &(NoReprEnum::Variant2,)).unwrap();
         let _: (NoReprEnum,) = encoded.deserialize().unwrap().0;
 
-        assert_eq!(NoReprEnum::signature(), u32::signature());
+        assert_eq!(NoReprEnum::SIGNATURE, u32::SIGNATURE);
         let encoded = to_bytes(ctxt, &NoReprEnum::Variant2).unwrap();
         assert_eq!(encoded.len(), 4);
         let decoded: NoReprEnum = encoded.deserialize().unwrap().0;
@@ -1637,7 +1637,7 @@ mod tests {
             Variant3,
         }
 
-        assert_eq!(StrEnum::signature(), <&str>::signature());
+        assert_eq!(StrEnum::SIGNATURE, <&str>::SIGNATURE);
         let encoded = to_bytes(ctxt, &StrEnum::Variant2).unwrap();
         assert_eq!(encoded.len(), 13);
         let decoded: StrEnum = encoded.deserialize().unwrap().0;
@@ -1648,7 +1648,7 @@ mod tests {
             Variant1(f64),
             Variant2(f64),
         }
-        assert_eq!(NewType::signature(), "(ud)");
+        assert_eq!(NewType::SIGNATURE, "(ud)");
 
         #[derive(Deserialize, Serialize, Type)]
         enum StructFields {
@@ -1659,7 +1659,7 @@ mod tests {
                 field3: &'static str,
             },
         }
-        assert_eq!(StructFields::signature(), "(u(qxs))");
+        assert_eq!(StructFields::SIGNATURE, "(u(qxs))");
 
         #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
         struct AStruct<'s> {
@@ -1668,7 +1668,7 @@ mod tests {
             field3: &'s [u8],
             field4: i64,
         }
-        assert_eq!(AStruct::signature(), "(qayayx)");
+        assert_eq!(AStruct::SIGNATURE, "(qayayx)");
         let s = AStruct {
             field1: 0xFF_FF,
             field2: &[77u8; 8],
@@ -1723,7 +1723,7 @@ mod tests {
             field2: &'s [u8],
             field3: i64,
         }
-        assert_eq!(Struct::signature(), "(qayx)");
+        assert_eq!(Struct::SIGNATURE, "(qayx)");
         let s = Struct {
             field1: 0xFF_FF,
             field2: &[77u8; 512],
@@ -1755,7 +1755,7 @@ mod tests {
             field2: &'s [u8],
             field3: i64,
         }
-        assert_eq!(Struct::signature(), "(qayx)");
+        assert_eq!(Struct::SIGNATURE, "(qayx)");
         let s = Struct {
             field1: 0xFF_FF,
             field2: &[77u8; 512],
@@ -2019,7 +2019,7 @@ mod tests {
         }
 
         let foo = Foo { hmap };
-        assert_eq!(Foo::signature(), "(a{ss})");
+        assert_eq!(Foo::SIGNATURE, "(a{ss})");
 
         let ctxt = Context::new_dbus(LE, 0);
         let encoded = to_bytes(ctxt, &(&foo, 1)).unwrap();
@@ -2039,6 +2039,8 @@ mod tests {
     #[test]
     #[cfg(feature = "gvariant")]
     fn issue_99() {
+        use crate::to_bytes_for_parsed_signature;
+
         #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
         struct ZVStruct<'s>(#[serde(borrow)] HashMap<&'s str, Value<'s>>);
 
@@ -2049,10 +2051,13 @@ mod tests {
         let element = ZVStruct(dict);
 
         let ctxt = Context::new_gvariant(LE, 0);
-        let signature = ZVStruct::signature();
+        let signature = ZVStruct::SIGNATURE;
 
-        let encoded = to_bytes_for_signature(ctxt, &signature, &element).unwrap();
-        let _: ZVStruct<'_> = encoded.deserialize_for_signature(signature).unwrap().0;
+        let encoded = to_bytes_for_parsed_signature(ctxt, signature, &element).unwrap();
+        let _: ZVStruct<'_> = encoded
+            .deserialize_for_parsed_signature(signature)
+            .unwrap()
+            .0;
     }
 
     #[cfg(feature = "ostree-tests")]

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -175,7 +175,7 @@ where
     fn from(value: Option<T>) -> Self {
         value
             .map(|v| Self::just(Value::new(v)))
-            .unwrap_or_else(|| Self::nothing(T::signature()))
+            .unwrap_or_else(|| Self::nothing(T::SIGNATURE.into()))
     }
 }
 
@@ -187,7 +187,7 @@ where
         value
             .as_ref()
             .map(|v| Self::just(Value::new(v.clone())))
-            .unwrap_or_else(|| Self::nothing(T::signature()))
+            .unwrap_or_else(|| Self::nothing(T::SIGNATURE.into()))
     }
 }
 

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -126,10 +126,7 @@ impl<'a> Basic for ObjectPath<'a> {
 }
 
 impl<'a> Type for ObjectPath<'a> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::ObjectPath
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::ObjectPath;
 }
 
 impl<'a> TryFrom<&'a [u8]> for ObjectPath<'a> {

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -80,10 +80,7 @@ impl<T> Type for Optional<T>
 where
     T: Type,
 {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        T::parsed_signature()
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = T::SIGNATURE;
 }
 
 impl<T> Serialize for Optional<T>
@@ -95,7 +92,7 @@ where
     where
         S: Serializer,
     {
-        if T::signature() == bool::signature() {
+        if T::SIGNATURE == bool::SIGNATURE {
             panic!("`Optional<bool>` type is not supported");
         }
 
@@ -116,7 +113,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        if T::signature() == bool::signature() {
+        if T::SIGNATURE == bool::SIGNATURE {
             panic!("`Optional<bool>` type is not supported");
         }
 

--- a/zvariant/src/parsed.rs
+++ b/zvariant/src/parsed.rs
@@ -61,9 +61,7 @@ impl From<Signature> for crate::Signature<'static> {
 }
 
 impl Type for Signature {
-    fn parsed_signature() -> Signature {
-        Signature::Signature
-    }
+    const SIGNATURE: &'static Signature = &Signature::Signature;
 }
 
 impl Basic for Signature {

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -52,7 +52,7 @@ where
     T: ?Sized + Serialize + DynamicType,
 {
     let mut null = NullWriteSeek;
-    let signature = value.dynamic_parsed_signature();
+    let signature = value.dynamic_signature();
     #[cfg(unix)]
     let mut fds = FdList::Number(0);
 
@@ -124,7 +124,7 @@ where
     W: Write + Seek,
     T: ?Sized + Serialize + DynamicType,
 {
-    let signature = value.dynamic_parsed_signature();
+    let signature = value.dynamic_signature();
 
     to_writer_for_parsed_signature(writer, ctxt, &signature, value)
 }
@@ -136,7 +136,7 @@ pub fn to_bytes<T>(ctxt: Context, value: &T) -> Result<Data<'static, 'static>>
 where
     T: ?Sized + Serialize + DynamicType,
 {
-    to_bytes_for_parsed_signature(ctxt, &value.dynamic_parsed_signature(), value)
+    to_bytes_for_parsed_signature(ctxt, &value.dynamic_signature(), value)
 }
 
 /// Serialize `T` that has the given signature, to the given `writer`.

--- a/zvariant/src/serialize_value.rs
+++ b/zvariant/src/serialize_value.rs
@@ -28,8 +28,7 @@ impl<'a, T: Type + Serialize> Serialize for SerializeValue<'a, T> {
         // Serializer implementation needs to ensure padding isn't added for Value.
         let mut structure = serializer.serialize_struct("Variant", 2)?;
 
-        let signature = T::signature();
-        structure.serialize_field("signature", &signature)?;
+        structure.serialize_field("signature", T::SIGNATURE)?;
         structure.serialize_field("value", self.0)?;
 
         structure.end()
@@ -37,8 +36,5 @@ impl<'a, T: Type + Serialize> Serialize for SerializeValue<'a, T> {
 }
 
 impl<'a, T: Type + Serialize> Type for SerializeValue<'a, T> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::Variant
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Variant;
 }

--- a/zvariant/src/signature.rs
+++ b/zvariant/src/signature.rs
@@ -367,10 +367,7 @@ impl<'a> Basic for Signature<'a> {
 }
 
 impl<'a> Type for Signature<'a> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::Signature
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Signature;
 }
 
 impl<'a> From<&Signature<'a>> for Signature<'a> {

--- a/zvariant/src/str.rs
+++ b/zvariant/src/str.rs
@@ -126,10 +126,7 @@ impl<'a> Basic for Str<'a> {
 }
 
 impl<'a> Type for Str<'a> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::Str
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Str;
 }
 
 impl<'a> From<&'a str> for Str<'a> {

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -69,13 +69,16 @@ impl<'a> StructureBuilder<'a> {
     /// Build the `Structure`.
     ///
     /// [`Structure`]: struct.Structure.html
-    pub fn build(self) -> Structure<'a> {
+    pub fn build(self) -> crate::Result<Structure<'a>> {
+        if self.0.is_empty() {
+            return Err(crate::Error::EmptyStructure);
+        }
         let signature = create_signature_from_fields(&self.0);
 
-        Structure {
+        Ok(Structure {
             fields: self.0,
             signature,
-        }
+        })
     }
 
     /// Same as `build` except Signature is provided.
@@ -308,7 +311,7 @@ macro_rules! tuple_impls {
                     $(
                         .add_field(value. $n)
                     )+
-                    .build()
+                    .build().unwrap()
                 }
             }
 

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -252,17 +252,6 @@ pub(crate) fn structure_display_fmt(
     f.write_char(')')
 }
 
-impl<'a> Default for Structure<'a> {
-    fn default() -> Self {
-        let signature = Signature::from_static_str_unchecked("()");
-
-        Self {
-            fields: vec![],
-            signature,
-        }
-    }
-}
-
 impl<'a> DynamicType for Structure<'a> {
     fn dynamic_signature(&self) -> Signature<'_> {
         self.signature.as_ref()

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -256,13 +256,13 @@ pub(crate) fn structure_display_fmt(
 }
 
 impl<'a> DynamicType for Structure<'a> {
-    fn dynamic_signature(&self) -> Signature<'_> {
-        self.signature.as_ref()
+    fn dynamic_signature(&self) -> parsed::Signature {
+        self.signature.clone().into()
     }
 }
 
 impl<'a> DynamicType for StructureSeed<'a> {
-    fn dynamic_parsed_signature(&self) -> parsed::Signature {
+    fn dynamic_signature(&self) -> parsed::Signature {
         self.signature.clone()
     }
 }
@@ -270,7 +270,7 @@ impl<'a> DynamicType for StructureSeed<'a> {
 impl<'a> DynamicDeserialize<'a> for Structure<'a> {
     type Deserializer = StructureSeed<'static>;
 
-    fn deserializer_for_parsed_signature(
+    fn deserializer_for_signature(
         parsed_signature: &parsed::Signature,
     ) -> zvariant::Result<Self::Deserializer> {
         let parsed_signature = match parsed_signature {
@@ -400,13 +400,13 @@ pub struct OwnedStructure(pub Structure<'static>);
 pub struct OwnedStructureSeed(parsed::Signature);
 
 impl DynamicType for OwnedStructure {
-    fn dynamic_signature(&self) -> Signature<'_> {
+    fn dynamic_signature(&self) -> parsed::Signature {
         self.0.dynamic_signature()
     }
 }
 
 impl DynamicType for OwnedStructureSeed {
-    fn dynamic_parsed_signature(&self) -> parsed::Signature {
+    fn dynamic_signature(&self) -> parsed::Signature {
         self.0.clone()
     }
 }
@@ -414,10 +414,10 @@ impl DynamicType for OwnedStructureSeed {
 impl<'de> DynamicDeserialize<'de> for OwnedStructure {
     type Deserializer = OwnedStructureSeed;
 
-    fn deserializer_for_parsed_signature(
+    fn deserializer_for_signature(
         parsed_signature: &parsed::Signature,
     ) -> zvariant::Result<Self::Deserializer> {
-        Structure::deserializer_for_parsed_signature(parsed_signature)
+        Structure::deserializer_for_signature(parsed_signature)
             .map(|StructureSeed { signature, .. }| OwnedStructureSeed(signature))
     }
 }

--- a/zvariant/src/tuple.rs
+++ b/zvariant/src/tuple.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 pub struct DynamicTuple<T>(pub T);
 
 impl DynamicType for DynamicTuple<()> {
-    fn dynamic_parsed_signature(&self) -> parsed::Signature {
+    fn dynamic_signature(&self) -> parsed::Signature {
         parsed::Signature::Unit
     }
 }
@@ -43,7 +43,7 @@ pub struct TupleSeed<'a, T, S> {
 }
 
 impl<'a, T, S> DynamicType for TupleSeed<'a, T, S> {
-    fn dynamic_parsed_signature(&self) -> parsed::Signature {
+    fn dynamic_signature(&self) -> parsed::Signature {
         self.sig.clone()
     }
 }
@@ -60,11 +60,11 @@ macro_rules! tuple_impls {
             where
                 $($name: DynamicType,)+
             {
-                fn dynamic_parsed_signature(&self) -> parsed::Signature {
+                fn dynamic_signature(&self) -> parsed::Signature {
                     parsed::Signature::structure(
                         [
                             $(
-                                self.0.$n.dynamic_parsed_signature(),
+                                self.0.$n.dynamic_signature(),
                             )+
                         ]
                     )
@@ -112,7 +112,7 @@ macro_rules! tuple_impls {
             {
                 type Deserializer = TupleSeed<'de, ($($name,)+), ($(<$name as DynamicDeserialize<'de>>::Deserializer,)+)>;
 
-                fn deserializer_for_parsed_signature(
+                fn deserializer_for_signature(
                     parsed_signature: &parsed::Signature,
                 ) -> zvariant::Result<Self::Deserializer> {
                     let mut fields_iter = match &parsed_signature {
@@ -122,7 +122,7 @@ macro_rules! tuple_impls {
 
                     let seeds = ($({
                         let elt_sig = fields_iter.next().ok_or(zvariant::Error::IncorrectType)?;
-                        $name::deserializer_for_parsed_signature(elt_sig)?
+                        $name::deserializer_for_signature(elt_sig)?
                     },)+);
 
                     Ok(TupleSeed { sig: parsed_signature.clone(), seeds, markers: (PhantomData, PhantomData) })

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -252,18 +252,18 @@ impl<'a> Value<'a> {
     /// Get the signature of the enclosed value.
     pub fn value_signature(&self) -> Signature<'_> {
         match self {
-            Value::U8(_) => u8::signature(),
-            Value::Bool(_) => bool::signature(),
-            Value::I16(_) => i16::signature(),
-            Value::U16(_) => u16::signature(),
-            Value::I32(_) => i32::signature(),
-            Value::U32(_) => u32::signature(),
-            Value::I64(_) => i64::signature(),
-            Value::U64(_) => u64::signature(),
-            Value::F64(_) => f64::signature(),
-            Value::Str(_) => <&str>::signature(),
-            Value::Signature(_) => Signature::signature(),
-            Value::ObjectPath(_) => ObjectPath::signature(),
+            Value::U8(_) => u8::SIGNATURE.into(),
+            Value::Bool(_) => bool::SIGNATURE.into(),
+            Value::I16(_) => i16::SIGNATURE.into(),
+            Value::U16(_) => u16::SIGNATURE.into(),
+            Value::I32(_) => i32::SIGNATURE.into(),
+            Value::U32(_) => u32::SIGNATURE.into(),
+            Value::I64(_) => i64::SIGNATURE.into(),
+            Value::U64(_) => u64::SIGNATURE.into(),
+            Value::F64(_) => f64::SIGNATURE.into(),
+            Value::Str(_) => <&str>::SIGNATURE.into(),
+            Value::Signature(_) => Signature::SIGNATURE.into(),
+            Value::ObjectPath(_) => ObjectPath::SIGNATURE.into(),
             Value::Value(_) => Signature::from_static_str_unchecked("v"),
 
             // Container types
@@ -274,7 +274,7 @@ impl<'a> Value<'a> {
             Value::Maybe(value) => value.full_signature().as_ref(),
 
             #[cfg(unix)]
-            Value::Fd(_) => Fd::signature(),
+            Value::Fd(_) => Fd::SIGNATURE.into(),
         }
     }
 
@@ -969,10 +969,7 @@ where
 }
 
 impl<'a> Type for Value<'a> {
-    #[inline]
-    fn parsed_signature() -> crate::parsed::Signature {
-        crate::parsed::Signature::Variant
-    }
+    const SIGNATURE: &'static crate::parsed::Signature = &crate::parsed::Signature::Variant;
 }
 
 impl<'a> TryFrom<&Value<'a>> for Value<'a> {

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -1106,7 +1106,6 @@ mod tests {
             .iter()
             .any(|str| str.contains("100") && str.contains(": ") && str.contains("200")));
 
-        assert_eq!(Value::new(Structure::default()).to_string(), "()");
         assert_eq!(
             Value::new(((true,), (true, false), (true, true, false))).to_string(),
             "((true,), (true, false), (true, true, false))"

--- a/zvariant_derive/README.md
+++ b/zvariant_derive/README.md
@@ -20,7 +20,7 @@ struct Struct<'s> {
     field3: &'s str,
 }
 
-assert_eq!(Struct::signature(), "(qxs)");
+assert_eq!(Struct::SIGNATURE, "(qxs)");
 let s = Struct {
     field1: 42,
     field2: i64::max_value(),

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -36,7 +36,7 @@ mod value;
 ///     field3: &'s str,
 /// }
 ///
-/// assert_eq!(Struct::signature(), "(qxs)");
+/// assert_eq!(Struct::SIGNATURE, "(qxs)");
 /// let s = Struct {
 ///     field1: 42,
 ///     field2: i64::max_value(),
@@ -63,7 +63,7 @@ mod value;
 ///     Variant1,
 ///     Variant2,
 /// }
-/// assert_eq!(Enum::signature(), u8::signature());
+/// assert_eq!(Enum::SIGNATURE, u8::SIGNATURE);
 /// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &Enum::Variant2).unwrap();
 /// let decoded: Enum = encoded.deserialize().unwrap().0;
@@ -75,7 +75,7 @@ mod value;
 ///     Variant1,
 ///     Variant2,
 /// }
-/// assert_eq!(Enum2::signature(), i64::signature());
+/// assert_eq!(Enum2::SIGNATURE, i64::SIGNATURE);
 ///
 /// // w/o repr attribute, u32 representation is chosen
 /// #[derive(Deserialize, Serialize, Type)]
@@ -83,7 +83,7 @@ mod value;
 ///     Variant1,
 ///     Variant2,
 /// }
-/// assert_eq!(NoReprEnum::signature(), u32::signature());
+/// assert_eq!(NoReprEnum::SIGNATURE, u32::SIGNATURE);
 ///
 /// // Not-unit enums are represented as a structure, with the first field being a u32 denoting the
 /// // variant and the second as the actual value.
@@ -92,14 +92,14 @@ mod value;
 ///     Variant1(f64),
 ///     Variant2(f64),
 /// }
-/// assert_eq!(NewType::signature(), "(ud)");
+/// assert_eq!(NewType::SIGNATURE, "(ud)");
 ///
 /// #[derive(Deserialize, Serialize, Type)]
 /// enum StructFields {
 ///     Variant1(u16, i64, &'static str),
 ///     Variant2 { field1: u16, field2: i64, field3: &'static str },
 /// }
-/// assert_eq!(StructFields::signature(), "(u(qxs))");
+/// assert_eq!(StructFields::SIGNATURE, "(u(qxs))");
 /// ```
 ///
 /// # Custom signatures
@@ -121,7 +121,7 @@ mod value;
 ///     field3: String,
 /// }
 ///
-/// assert_eq!(Struct::signature(), "a{sv}");
+/// assert_eq!(Struct::SIGNATURE, "a{sv}");
 /// let s = Struct {
 ///     field1: 42,
 ///     field2: i64::max_value(),
@@ -147,7 +147,7 @@ mod value;
 ///     Variant3,
 /// }
 ///
-/// assert_eq!(StrEnum::signature(), "s");
+/// assert_eq!(StrEnum::SIGNATURE, "s");
 /// let ctxt = Context::new_dbus(LE, 0);
 /// let encoded = to_bytes(ctxt, &StrEnum::Variant2).unwrap();
 /// assert_eq!(encoded.len(), 13);

--- a/zvariant_derive/src/value.rs
+++ b/zvariant_derive/src/value.rs
@@ -164,7 +164,7 @@ fn impl_struct(
                         #(
                             .add_field(s.#field_names)
                         )*
-                        .build())
+                        .build().unwrap())
                         #into_value_error_transform
                     },
                 ),

--- a/zvariant_derive/tests/tests.rs
+++ b/zvariant_derive/tests/tests.rs
@@ -11,7 +11,7 @@ fn derive_unit_struct() {
     #[derive(Type)]
     struct FooF(f64);
 
-    assert_eq!(FooF::signature(), "d")
+    assert_eq!(FooF::SIGNATURE, "d")
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn derive_struct() {
         blob: Vec<u8>,
     }
 
-    assert_eq!(TestStruct::signature(), "(syay)")
+    assert_eq!(TestStruct::SIGNATURE, "(syay)")
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn derive_enum() {
         DoNotQueue = 0x04,
     }
 
-    assert_eq!(RequestNameFlags::signature(), "u")
+    assert_eq!(RequestNameFlags::SIGNATURE, "u")
 }
 
 #[test]
@@ -80,5 +80,5 @@ fn derive_dict() {
     assert_eq!(deserialized.field_b.as_str(), "foo");
     assert_eq!(deserialized.field_c.as_slice(), &[1u8, 2, 3][..]);
 
-    assert_eq!(Test::signature(), "a{sv}")
+    assert_eq!(Test::SIGNATURE, "a{sv}")
 }

--- a/zvariant_utils/src/parsed/signature.rs
+++ b/zvariant_utils/src/parsed/signature.rs
@@ -596,18 +596,17 @@ impl PartialEq<&str> for Signature {
             }
             Self::Structure(fields) => {
                 let string_len = self.string_len();
-                if string_len < other.len() {
-                    // self.string_len() will always take `()` into account so it can't be a smaller
-                    // number than `other.len()`.
+                // self.string_len() will always take `()` into account so it can't be a smaller
+                // number than `other.len()`.
+                if string_len < other.len()
+                    // Their length is either equal (i-e `other` has outer `()`) or `other` has no
+                    // outer `()`.
+                    || (string_len != other.len() && string_len != other.len() + 2)
+                {
                     return false;
                 }
 
                 let fields_str = if string_len == other.len() {
-                    // `other` has to have outer `()`.
-                    if other.len() < 3 {
-                        return false;
-                    }
-
                     &other[1..other.len() - 1]
                 } else {
                     // No outer `()`.
@@ -622,6 +621,9 @@ impl PartialEq<&str> for Signature {
                 for field in fields.iter() {
                     let len = field.string_len();
                     let end = start + len;
+                    if end > fields_str.len() {
+                        return false;
+                    }
                     if !field.eq(&fields_str[start..end]) {
                         return false;
                     }

--- a/zvariant_utils/src/parsed/signature.rs
+++ b/zvariant_utils/src/parsed/signature.rs
@@ -361,6 +361,14 @@ impl FromStr for Signature {
     }
 }
 
+impl TryFrom<&str> for Signature {
+    type Error = super::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Signature::from_str(value)
+    }
+}
+
 /// Validate the given signature string.
 pub fn validate(bytes: &[u8]) -> Result<(), super::Error> {
     parse(bytes, true).map(|_| ())


### PR DESCRIPTION
Convert `Type::parsed_signature` to a const, named `SIGNATURE`. We also remove `Type::signature` method, since `parsed::Signature` can be easily converted to a `crate::Signature`. This commit makes similar changes to `DynamicType` and `DynamicDeserialize` as well.

This is an API break that breaks all code that implements `Type` (manually), `DynamicType` and/or `DynamicDeserialize`. In return, we eliminate a lot of allocations, which can make a big difference when it comes to (de)serialization on low-end machines.

Fixes #882.
