### PR TITLE
zv: Multiple lists support for derive macros.

### DIFF
--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -159,7 +159,7 @@ mod value;
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
 /// [serde_repr]: https://crates.io/crates/serde_repr
-#[proc_macro_derive(Type, attributes(zvariant))]
+#[proc_macro_derive(Type, attributes(zbus, zvariant))]
 pub fn type_macro_derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
     r#type::expand_derive(ast)
@@ -227,7 +227,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// * `"kebab-case"`
 ///
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
-#[proc_macro_derive(SerializeDict, attributes(zvariant))]
+#[proc_macro_derive(SerializeDict, attributes(zbus, zvariant))]
 pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_serialize_derive(input)
@@ -296,7 +296,7 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// * `"kebab-case"`
 ///
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
-#[proc_macro_derive(DeserializeDict, attributes(zvariant))]
+#[proc_macro_derive(DeserializeDict, attributes(zbus, zvariant))]
 pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_deserialize_derive(input)

--- a/zvariant_derive/src/utils.rs
+++ b/zvariant_derive/src/utils.rs
@@ -16,7 +16,7 @@ pub fn zvariant_path() -> TokenStream {
 }
 
 def_attrs! {
-    crate zvariant;
+    crate zbus, zvariant;
 
     /// Attributes defined on structures.
     pub StructAttributes("struct") { signature str, rename_all str, deny_unknown_fields none };


### PR DESCRIPTION
This PR adds support for multiple attribute list identifiers to `def_attrs!` macro from `zvariant_utils` and uses this in `zvariant_derive` to avoid mentioning `zvariant` when using macros out of `zbus` (as described in #820).
