### PR TITLE
🔥 zm,zb: Drop deprecated `dbus_interface` & `dbus_proxy` macros

### DIFF
--- a/book/src/service.md
+++ b/book/src/service.md
@@ -434,8 +434,6 @@ While it's extremely useful to be able to generate the client-side proxy code di
   type to be returned from its methods.
 * Methods returning [`object_server::ResponseDispatchNotifier`] wrapper type will do the same for
   proxy as well.
-* Only `interface` macro supports this feature, while the deprecated `dbus_interface` macro does
-  not. Still haven't switched to `interface` and want to use this feature? Time to switch!
 
 [D-Bus concepts]: concepts.html#bus-name--service-name
 [didoc]: https://docs.rs/zbus/4/zbus/attr.interface.html

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -9,9 +9,9 @@
 //!
 //! Since methods provided by these types run their own little runtime (`block_on`), you must not
 //! use them in async contexts because of the infamous [async sandwich footgun][asf]. This is
-//! an especially important fact to keep in mind for [`crate::interface`]. While
-//! `dbus_interface` allows non-async methods for convenience, these methods are called from an
-//! async context. The [`blocking` crate] provides an easy way around this problem though.
+//! an especially important fact to keep in mind for [`crate::interface`]. While `interface` allows
+//! non-async methods for convenience, these methods are called from an async context. The
+//! [`blocking` crate] provides an easy way around this problem though.
 //!
 //! [asf]: https://rust-lang.github.io/wg-async/vision/shiny_future/users_manual.html#caveat-beware-the-async-sandwich
 //! [`blocking` crate]: https://docs.rs/blocking/

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -501,7 +501,7 @@ impl<'a> std::iter::Iterator for OwnerChangedIterator<'a> {
 }
 
 /// This trait is implemented by all blocking proxies, which are generated with the
-/// [`dbus_proxy`](zbus::dbus_proxy) macro.
+/// [`proxy`](macro@zbus::proxy) macro.
 pub trait ProxyImpl<'p>
 where
     Self: Sized,

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -173,7 +173,7 @@ pub mod blocking;
 
 pub use zbus_macros::{interface, proxy, DBusError};
 // Old names used for backwards compatibility
-pub use zbus_macros::{dbus_interface, dbus_proxy};
+pub use zbus_macros::dbus_interface;
 
 // Required for the macros to function within this crate.
 extern crate self as zbus;

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -172,8 +172,6 @@ pub use connection::Socket;
 pub mod blocking;
 
 pub use zbus_macros::{interface, proxy, DBusError};
-// Old names used for backwards compatibility
-pub use zbus_macros::dbus_interface;
 
 // Required for the macros to function within this crate.
 extern crate self as zbus;

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -175,10 +175,10 @@ where
 
 /// Trait for the default associated values of a proxy.
 ///
-/// The trait is automatically implemented by the [`dbus_proxy`] macro on your behalf, and may be
-/// later used to retrieve the associated constants.
+/// The trait is automatically implemented by the [`proxy`] macro on your behalf, and may be later
+/// used to retrieve the associated constants.
 ///
-/// [`dbus_proxy`]: attr.dbus_proxy.html
+/// [`proxy`]: attr.proxy.html
 pub trait ProxyDefault {
     const INTERFACE: Option<&'static str>;
     const DESTINATION: Option<&'static str>;

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1338,7 +1338,7 @@ impl<'a> From<crate::blocking::Proxy<'a>> for Proxy<'a> {
 }
 
 /// This trait is implemented by all async proxies, which are generated with the
-/// [`dbus_proxy`](zbus::dbus_proxy) macro.
+/// [`proxy`](macro@zbus::proxy) macro.
 pub trait ProxyImpl<'c>
 where
     Self: Sized,

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -197,17 +197,7 @@ mod utils;
 pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemTrait);
-    proxy::expand::<proxy::TraitAttributes, proxy::MethodAttributes>(args, input)
-        .unwrap_or_else(|err| err.to_compile_error())
-        .into()
-}
-
-#[deprecated = "Use `#[proxy(...)]` proc macro with `#[zbus(...)]` item attributes instead."]
-#[proc_macro_attribute]
-pub fn dbus_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
-    let input = parse_macro_input!(item as ItemTrait);
-    proxy::expand::<proxy::old::TraitAttributes, proxy::old::MethodAttributes>(args, input)
+    proxy::expand(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -365,17 +365,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(item as ItemImpl);
-    iface::expand::<iface::ImplAttributes, iface::MethodAttributes>(args, input)
-        .unwrap_or_else(|err| err.to_compile_error())
-        .into()
-}
-
-#[deprecated = "Use `#[interface(...)]` proc macro with `#[zbus(...)]` item attributes instead."]
-#[proc_macro_attribute]
-pub fn dbus_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
-    let input = parse_macro_input!(item as ItemImpl);
-    iface::expand::<iface::old::ImplAttributes, iface::old::MethodAttributes>(args, input)
+    iface::expand(args, input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }


### PR DESCRIPTION
These were deprecated in 4.0, so we remove it now for 5.0.