### PR TITLE
💥 zm,zb: `proxy` macro respects visibility

### DIFF
--- a/zbus/src/fdo.rs
+++ b/zbus/src/fdo.rs
@@ -31,7 +31,7 @@ macro_rules! gen_introspectable_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait Introspectable {
+        pub trait Introspectable {
             /// Return an XML description of the object, including its interfaces (with signals and
             /// methods), objects below it in the object path tree, and its properties.
             fn introspect(&self) -> Result<String>;
@@ -73,7 +73,7 @@ macro_rules! gen_properties_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait Properties {
+        pub trait Properties {
             /// Get a property value.
             async fn get(
                 &self,
@@ -236,7 +236,7 @@ macro_rules! gen_object_manager_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait ObjectManager {
+        pub trait ObjectManager {
             /// The return value of this method is a dict whose keys are object paths. All returned object
             /// paths are children of the object path implementing this interface, i.e. their object paths
             /// start with the ObjectManager's object path plus '/'.
@@ -392,7 +392,7 @@ macro_rules! gen_monitoring_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait Monitoring {
+        pub trait Monitoring {
             /// Convert the connection into a monitor connection which can be used as a
             /// debugging/monitoring tool.
             ///
@@ -436,7 +436,7 @@ macro_rules! gen_stats_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait Stats {
+        pub trait Stats {
             /// GetStats (undocumented)
             fn get_stats(&self) -> Result<Vec<HashMap<String, OwnedValue>>>;
 
@@ -703,7 +703,7 @@ macro_rules! gen_dbus_proxy {
             gen_async = $gen_async,
             gen_blocking = $gen_blocking,
         )]
-        trait DBus {
+        pub trait DBus {
             /// Add a match rule to match messages going through the message bus.
             #[zbus(name = "AddMatch")]
             fn add_match_rule(&self, rule: crate::MatchRule<'_>) -> Result<()>;

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -94,7 +94,7 @@ enum MyIfaceError {
 
 #[interface(
     interface = "org.freedesktop.MyIface",
-    proxy(gen_blocking = true, assume_defaults = true)
+    proxy(gen_blocking = true, assume_defaults = true, visibility = "pub(self)")
 )]
 impl MyIface {
     #[instrument]

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -1428,7 +1428,7 @@ impl Proxy {
                 #gen_async
                 #gen_blocking
             )]
-            trait #ty {
+            pub trait #ty {
                 #methods
             }
         }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -260,7 +260,8 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `proxy` - Use this to specify the [`macro@proxy`]-specific method sub-attributes (e.g
 ///   `object`). The common sub-attributes (e.g `name`) are automatically forworded to the
-///   [`macro@proxy`] macro.
+///   [`macro@proxy`] macro. Moreover, you can use `visibility` sub-attribute to specify the
+///   visibility of the generated proxy type(s).
 ///
 ///   In such case, your method must return a tuple containing
 ///   your out arguments, in the same order as passed to `out_args`.

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -29,7 +29,7 @@ mod test {
         interface = "org.freedesktop.zbus_macros.Test",
         default_service = "org.freedesktop.zbus_macros"
     )]
-    trait Test {
+    pub(super) trait Test {
         /// comment for a_test()
         fn a_test(&self, val: &str) -> zbus::Result<u32>;
 


### PR DESCRIPTION
This includes all types generated by `proxy` macro. Also add a sub-attribute to `proxy` attribute of `interface` to control visibility of `interface`-generated proxy types.

Unfortunately this means that the existing code will have to set the visibility explicitly to `pub` if they were relying on the generated proxy to be public. Good that we're in API break.
