### PR TITLE
➕ zb,zv: Add camino feature to impl `Type` for utf-8 path types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2401,7 @@ name = "zvariant"
 version = "4.2.0"
 dependencies = [
  "arrayvec",
+ "camino",
  "chrono",
  "criterion",
  "endi",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -21,6 +21,7 @@ chrono = ["zvariant/chrono"]
 heapless = ["zvariant/heapless"]
 # Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
 option-as-array = ["zvariant/option-as-array"]
+camino = ["zvariant/camino"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
 bus-impl = ["p2p"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -19,6 +19,7 @@ gvariant = ["zvariant_derive/gvariant", "zvariant_utils/gvariant"]
 ostree-tests = ["gvariant"]
 # Enables ser/de of `Option<T>` as an array of 0 or 1 elements.
 option-as-array = []
+camino = ["dep:camino"]
 
 [dependencies]
 zvariant_derive = { version = "=4.2.0", path = "../zvariant_derive" }
@@ -39,6 +40,7 @@ chrono = { version = "0.4.38", features = [
     "serde",
 ], default-features = false, optional = true }
 heapless = { version = "0.8.0", features = ["serde"], optional = true }
+camino = { version = "1.1.9", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.116"

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -559,6 +559,11 @@ macro_rules! static_str_type {
 static_str_type!(Path);
 static_str_type!(PathBuf);
 
+#[cfg(feature = "camino")]
+static_str_type!(camino::Utf8Path);
+#[cfg(feature = "camino")]
+static_str_type!(camino::Utf8PathBuf);
+
 #[cfg(feature = "uuid")]
 impl_type_with_repr! {
     uuid::Uuid => &[u8] {


### PR DESCRIPTION
This adds a crate feature to `zbus` and `variant` called `"camino"`, which adds a derivation of `Type` for `camino::Utf8Path` and `camino::Utf8PathBuf`. It also adds `camino` as a dependency of `zvariant`.
