### PR TITLE
🚑️ zv: More lenient check for signature match

### DIFF
--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -1,0 +1,44 @@
+use ntest::timeout;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use zbus::{blocking::connection::Builder, zvariant::Type, ProxyDefault};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+struct SingleFieldStruct {
+    field: u32,
+}
+
+struct Iface;
+
+#[zbus::interface(
+    name = "org.zbus.Issue1015",
+    proxy(
+        default_path = "/org/zbus/Issue1015",
+        default_service = "org.zbus.Issue1015",
+    )
+)]
+impl Iface {
+    fn return_struct(&mut self) -> SingleFieldStruct {
+        SingleFieldStruct { field: 3 }
+    }
+}
+
+#[instrument]
+#[test]
+#[timeout(15000)]
+fn issue_1015() {
+    // Reproducer for issue #1015, where a regression from signature overhaul caused inconsistency
+    // between the client and server on how the body signature of a struct with a signle field is
+    // handled.
+    let conn = Builder::session()
+        .unwrap()
+        .serve_at(IfaceProxy::PATH.unwrap(), Iface)
+        .unwrap()
+        .name(IfaceProxy::DESTINATION.unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let proxy = IfaceProxyBlocking::new(&conn).unwrap();
+    let _ = proxy.return_struct().unwrap();
+}

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -1,3 +1,4 @@
+mod issue_1015;
 mod issue_104;
 mod issue_121;
 mod issue_122;

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -8,11 +8,9 @@ mod issue_68;
 mod issue_799;
 mod issue_81;
 
-// Issue specific to tokio runtime.
+// Issues specific to tokio runtime.
 #[cfg(all(unix, feature = "tokio", feature = "p2p"))]
 mod issue_279;
-
-// Issue specific to tokio runtime.
 #[cfg(all(unix, feature = "tokio"))]
 mod issue_310;
 

--- a/zvariant/src/type.rs
+++ b/zvariant/src/type.rs
@@ -235,7 +235,6 @@ where
         if expected == signature {
             Ok(PhantomData)
         } else {
-            let expected = <T as Type>::SIGNATURE;
             Err(zvariant::Error::SignatureMismatch(
                 signature.clone(),
                 format!("`{expected}`"),

--- a/zvariant_utils/src/signature/fields.rs
+++ b/zvariant_utils/src/signature/fields.rs
@@ -38,6 +38,14 @@ impl Fields {
             Self::Dynamic { fields } => Fields::Dynamic(fields.iter()),
         }
     }
+
+    /// The number of fields.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Static { fields } => fields.len(),
+            Self::Dynamic { fields } => fields.len(),
+        }
+    }
 }
 
 impl From<Box<[Signature]>> for Fields {

--- a/zvariant_utils/src/signature/fields.rs
+++ b/zvariant_utils/src/signature/fields.rs
@@ -46,6 +46,11 @@ impl Fields {
             Self::Dynamic { fields } => fields.len(),
         }
     }
+
+    /// Whether there are no fields.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl From<Box<[Signature]>> for Fields {


### PR DESCRIPTION
In `DynamicDeserialize` impl for `Type`, if the given signature doesn't match the expected signature and the expected signature is a struct with a single field, match against the field's signature instead. This is needed when D-Bus message body consists of a single type and it is being deserialized as a single-field struct.

Fixes #1015.