### PR TITLE
💥 zb,zm: Drop unnecessary lifetimes on genarated signal streams

### DIFF
--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -143,17 +143,17 @@ impl<'a> Proxy<'a> {
     }
 
     /// Get a reference to the destination service name.
-    pub fn destination(&self) -> &BusName<'_> {
+    pub fn destination(&self) -> &BusName<'a> {
         self.inner().destination()
     }
 
     /// Get a reference to the object path.
-    pub fn path(&self) -> &ObjectPath<'_> {
+    pub fn path(&self) -> &ObjectPath<'a> {
         self.inner().path()
     }
 
     /// Get a reference to the interface.
-    pub fn interface(&self) -> &InterfaceName<'_> {
+    pub fn interface(&self) -> &InterfaceName<'a> {
         self.inner().interface()
     }
 
@@ -350,7 +350,7 @@ impl<'a> Proxy<'a> {
     ///
     /// Note that zbus doesn't queue the updates. If the listener is slower than the receiver, it
     /// will only receive the last update.
-    pub fn receive_owner_changed(&self) -> Result<OwnerChangedIterator<'_>> {
+    pub fn receive_owner_changed(&self) -> Result<OwnerChangedIterator<'a>> {
         block_on(self.inner().receive_owner_changed()).map(OwnerChangedIterator)
     }
 
@@ -485,9 +485,9 @@ where
 /// Use [`Proxy::receive_owner_changed`] to create an instance of this type.
 pub struct OwnerChangedIterator<'a>(crate::proxy::OwnerChangedStream<'a>);
 
-impl OwnerChangedIterator<'_> {
+impl<'a> OwnerChangedIterator<'a> {
     /// The bus name being tracked.
-    pub fn name(&self) -> &BusName<'_> {
+    pub fn name(&self) -> &BusName<'a> {
         self.0.name()
     }
 }

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -330,7 +330,7 @@ impl PropertiesCache {
         interface: InterfaceName<'static>,
         uncached_properties: HashSet<zvariant::Str<'static>>,
     ) -> Result<(
-        PropertiesChangedStream<'static>,
+        PropertiesChangedStream,
         InterfaceName<'static>,
         HashSet<zvariant::Str<'static>>,
     )> {
@@ -394,7 +394,7 @@ impl PropertiesCache {
     #[instrument(skip_all)]
     async fn keep_updated(
         &self,
-        mut prop_changes: PropertiesChangedStream<'static>,
+        mut prop_changes: PropertiesChangedStream,
         interface: InterfaceName<'static>,
         uncached_properties: HashSet<zvariant::Str<'static>>,
     ) -> Result<()> {
@@ -1072,7 +1072,7 @@ impl From<MethodFlags> for Flags {
 }
 
 type OwnerChangedStreamMap = Map<
-    fdo::NameOwnerChangedStream<'static>,
+    fdo::NameOwnerChangedStream,
     Box<dyn FnMut(fdo::NameOwnerChanged) -> Option<UniqueName<'static>> + Send + Sync + Unpin>,
 >;
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -624,17 +624,17 @@ impl<'a> Proxy<'a> {
     }
 
     /// Get a reference to the destination service name.
-    pub fn destination(&self) -> &BusName<'_> {
+    pub fn destination(&self) -> &BusName<'a> {
         &self.inner.destination
     }
 
     /// Get a reference to the object path.
-    pub fn path(&self) -> &ObjectPath<'_> {
+    pub fn path(&self) -> &ObjectPath<'a> {
         &self.inner.path
     }
 
     /// Get a reference to the interface.
-    pub fn interface(&self) -> &InterfaceName<'_> {
+    pub fn interface(&self) -> &InterfaceName<'a> {
         &self.inner.interface
     }
 
@@ -1000,7 +1000,7 @@ impl<'a> Proxy<'a> {
     ///
     /// Note that zbus doesn't queue the updates. If the listener is slower than the receiver, it
     /// will only receive the last update.
-    pub async fn receive_owner_changed(&self) -> Result<OwnerChangedStream<'_>> {
+    pub async fn receive_owner_changed(&self) -> Result<OwnerChangedStream<'a>> {
         use futures_util::StreamExt;
         let dbus_proxy = fdo::DBusProxy::builder(self.connection())
             .cache_properties(CacheProperties::No)
@@ -1071,8 +1071,8 @@ impl From<MethodFlags> for Flags {
     }
 }
 
-type OwnerChangedStreamMap<'a> = Map<
-    fdo::NameOwnerChangedStream<'a>,
+type OwnerChangedStreamMap = Map<
+    fdo::NameOwnerChangedStream<'static>,
     Box<dyn FnMut(fdo::NameOwnerChanged) -> Option<UniqueName<'static>> + Send + Sync + Unpin>,
 >;
 
@@ -1080,15 +1080,15 @@ type OwnerChangedStreamMap<'a> = Map<
 ///
 /// Use [`Proxy::receive_owner_changed`] to create an instance of this type.
 pub struct OwnerChangedStream<'a> {
-    stream: OwnerChangedStreamMap<'a>,
+    stream: OwnerChangedStreamMap,
     name: BusName<'a>,
 }
 
 assert_impl_all!(OwnerChangedStream<'_>: Send, Sync, Unpin);
 
-impl OwnerChangedStream<'_> {
+impl<'a> OwnerChangedStream<'a> {
     /// The bus name being tracked.
-    pub fn name(&self) -> &BusName<'_> {
+    pub fn name(&self) -> &BusName<'a> {
         &self.name
     }
 }

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -868,7 +868,7 @@ fn gen_proxy_signal(
         quote! {
             #[doc = #receive_with_args_gen_doc]
             #(#other_attrs)*
-            pub #usage fn #receiver_with_args_name(&self, args: &[(u8, &str)]) -> #zbus::Result<#stream_name<'static>>
+            pub #usage fn #receiver_with_args_name(&self, args: &[(u8, &str)]) -> #zbus::Result<#stream_name>
             {
                 self.0.receive_signal_with_args(#signal_name, args)#wait.map(#stream_name)
             }
@@ -877,7 +877,7 @@ fn gen_proxy_signal(
     let receive_signal = quote! {
         #[doc = #receive_gen_doc]
         #(#other_attrs)*
-        pub #usage fn #receiver_name(&self) -> #zbus::Result<#stream_name<'static>>
+        pub #usage fn #receiver_name(&self) -> #zbus::Result<#stream_name>
         {
             self.0.receive_signal(#signal_name)#wait.map(#stream_name)
         }
@@ -1008,7 +1008,7 @@ fn gen_proxy_signal(
     };
     let stream_impl = if *blocking {
         quote! {
-            impl ::std::iter::Iterator for #stream_name<'_> {
+            impl ::std::iter::Iterator for #stream_name {
                 type Item = #signal_name_ident;
 
                 fn next(&mut self) -> ::std::option::Option<Self::Item> {
@@ -1019,7 +1019,7 @@ fn gen_proxy_signal(
         }
     } else {
         quote! {
-            impl #zbus::export::futures_core::stream::Stream for #stream_name<'_> {
+            impl #zbus::export::futures_core::stream::Stream for #stream_name {
                 type Item = #signal_name_ident;
 
                 fn poll_next(
@@ -1034,7 +1034,7 @@ fn gen_proxy_signal(
                 }
             }
 
-            impl #zbus::export::ordered_stream::OrderedStream for #stream_name<'_> {
+            impl #zbus::export::ordered_stream::OrderedStream for #stream_name {
                 type Data = #signal_name_ident;
                 type Ordering = #zbus::message::Sequence;
 
@@ -1052,14 +1052,14 @@ fn gen_proxy_signal(
                 }
             }
 
-            impl #zbus::export::futures_core::stream::FusedStream for #stream_name<'_> {
+            impl #zbus::export::futures_core::stream::FusedStream for #stream_name {
                 fn is_terminated(&self) -> bool {
                     self.0.is_terminated()
                 }
             }
 
             #[#zbus::export::async_trait::async_trait]
-            impl #zbus::AsyncDrop for #stream_name<'_> {
+            impl #zbus::AsyncDrop for #stream_name {
                 async fn async_drop(self) {
                     self.0.async_drop().await
                 }
@@ -1069,20 +1069,20 @@ fn gen_proxy_signal(
     let stream_types = quote! {
         #[doc = #stream_gen_doc]
         #[derive(Debug)]
-        #visibility struct #stream_name<'a>(#zbus::#signal_type<'a>);
+        #visibility struct #stream_name(#zbus::#signal_type<'static>);
 
         #zbus::export::static_assertions::assert_impl_all!(
-            #stream_name<'_>: ::std::marker::Send, ::std::marker::Unpin
+            #stream_name: ::std::marker::Send, ::std::marker::Unpin
         );
 
-        impl<'a> #stream_name<'a> {
+        impl #stream_name {
             /// Consumes `self`, returning the underlying `zbus::#signal_type`.
-            pub fn into_inner(self) -> #zbus::#signal_type<'a> {
+            pub fn into_inner(self) -> #zbus::#signal_type<'static> {
                 self.0
             }
 
             /// The reference to the underlying `zbus::#signal_type`.
-            pub fn inner(&self) -> & #zbus::#signal_type<'a> {
+            pub fn inner(&self) -> & #zbus::#signal_type<'static> {
                 &self.0
             }
         }


### PR DESCRIPTION
+ Fix some lifetimes in `Proxy` API.  