### PR TITLE
✨ zm: interface now provides convenience API to emit signals

### DIFF
--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -155,7 +155,7 @@ impl Greeter {
         #[zbus(signal_emitter)]
         emitter: SignalEmitter<'_>,
     ) -> fdo::Result<()> {
-        Self::greeted_everyone(&emitter).await?;
+        emitter.greeted_everyone().await?;
         self.done.notify(1);
 
         Ok(())

--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -134,7 +134,7 @@ the beginning of this chapter for details on why and a possible workaround.
 
 ```rust,no_run
 # use std::error::Error;
-# use zbus::{blocking::connection, interface, fdo, SignalContext};
+# use zbus::{blocking::connection, interface, fdo, object_server::SignalEmitter};
 #
 use event_listener::{Event, Listener};
 
@@ -152,10 +152,10 @@ impl Greeter {
     // Rude!
     async fn go_away(
         &self,
-        #[zbus(signal_context)]
-        ctxt: SignalContext<'_>,
+        #[zbus(signal_emitter)]
+        emitter: SignalEmitter<'_>,
     ) -> fdo::Result<()> {
-        Self::greeted_everyone(&ctxt).await?;
+        Self::greeted_everyone(&emitter).await?;
         self.done.notify(1);
 
         Ok(())
@@ -179,7 +179,7 @@ impl Greeter {
 
     /// A signal; the implementation is provided by the macro.
     #[zbus(signal)]
-    async fn greeted_everyone(ctxt: &SignalContext<'_>) -> zbus::Result<()>;
+    async fn greeted_everyone(emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/book/src/service.md
+++ b/book/src/service.md
@@ -230,7 +230,7 @@ impl Greeter {
         #[zbus(signal_emitter)]
         emitter: SignalEmitter<'_>,
     ) -> fdo::Result<()> {
-        Self::greeted_everyone(&emitter).await?;
+        emitter.greeted_everyone().await?;
         self.done.notify(1);
 
         Ok(())
@@ -265,13 +265,21 @@ async fn main() -> Result<()> {
         done: event_listener::Event::new(),
     };
     let done_listener = greeter.done.listen();
-    let _connection = Builder::session()?
+    let connection = Builder::session()?
         .name("org.zbus.MyGreeter")?
         .serve_at("/org/zbus/MyGreeter", greeter)?
         .build()
         .await?;
 
     done_listener.wait();
+
+    // Let's emit the signal again, just for the fun of it.
+    connection
+        .object_server()
+        .interface("/org/zbus/MyGreeter")
+        .await?
+        .greeted_everyone()
+        .await?;
 
     Ok(())
 }
@@ -318,13 +326,24 @@ want to use [`zbus::fdo::Error::UnknownProperty`] variant.
 ### Sending signals
 
 As you might have noticed in the previous example, the signal methods don't take a `&self` argument
-but a `SignalEmitter` reference. This allows to emit signals whether from inside or outside of the
-`interface` methods' context. To make things simpler, `interface` methods can receive a
-`SignalEmitter` passed to them using the special `zbus(signal_emitter)` attribute, as demonstrated
-in the previous example.
+but a `SignalEmitter` reference. While this allows to emit signals whether from inside or outside of
+the `interface` methods' context, it does make it a bit inconvenient to use. To make things easier
+`interface` generates a trait, `GreeterSignals` that provides the same signal methods but
+without the `SignalEmitter` argument. The macro provides two implementations of this trait for:
+
+* `zbus::object_server::InterfaceRef<Greeter>`
+* `zbus::object_server::SignalEmitter`
+
+The former is useful for emitting signals from outside the context of an `interface` method and the
+latter is useful for emitting signals from inside of it. To make it possible to emit signals from
+inside of an `interface` method, methods can ask to receive a `SignalEmitter` passed to them using
+the special `zbus(signal_emitter)` attribute.
 
 Please refer to [`interface` documentation][didoc] for more examples and list of other special
 attributes you can make use of.
+
+We saw examples of signal emission in action, from both inside and outside an `interface` method, in
+the previous example.
 
 ### Notifying property changes
 

--- a/book/src/service.md
+++ b/book/src/service.md
@@ -209,7 +209,7 @@ synchronize with the interface handlers from outside, thanks to the `event_liste
 (this is just one of the many ways).
 
 ```rust,no_run
-# use zbus::{object_server::SignalContext, connection::Builder, interface, fdo, Result};
+# use zbus::{object_server::SignalEmitter, connection::Builder, interface, fdo, Result};
 #
 use event_listener::{Event, Listener};
 
@@ -227,10 +227,10 @@ impl Greeter {
     // Rude!
     async fn go_away(
         &self,
-        #[zbus(signal_context)]
-        ctxt: SignalContext<'_>,
+        #[zbus(signal_emitter)]
+        emitter: SignalEmitter<'_>,
     ) -> fdo::Result<()> {
-        Self::greeted_everyone(&ctxt).await?;
+        Self::greeted_everyone(&emitter).await?;
         self.done.notify(1);
 
         Ok(())
@@ -254,7 +254,7 @@ impl Greeter {
 
     /// A signal; the implementation is provided by the macro.
     #[zbus(signal)]
-    async fn greeted_everyone(ctxt: &SignalContext<'_>) -> Result<()>;
+    async fn greeted_everyone(emitter: &SignalEmitter<'_>) -> Result<()>;
 }
 
 // Although we use `tokio` here, you can use any async runtime of choice.
@@ -318,9 +318,9 @@ want to use [`zbus::fdo::Error::UnknownProperty`] variant.
 ### Sending signals
 
 As you might have noticed in the previous example, the signal methods don't take a `&self` argument
-but a `SignalContext` reference. This allows to emit signals whether from inside or outside of the
+but a `SignalEmitter` reference. This allows to emit signals whether from inside or outside of the
 `interface` methods' context. To make things simpler, `interface` methods can receive a
-`SignalContext` passed to them using the special `zbus(signal_context)` attribute, as demonstrated
+`SignalEmitter` passed to them using the special `zbus(signal_emitter)` attribute, as demonstrated
 in the previous example.
 
 Please refer to [`interface` documentation][didoc] for more examples and list of other special
@@ -360,7 +360,7 @@ example code:
 let iface_ref = object_server.interface::<_, Greeter>("/org/zbus/MyGreeter").await?;
 let mut iface = iface_ref.get_mut().await;
 iface.name = String::from("👋");
-iface.greeter_name_changed(iface_ref.signal_context()).await?;
+iface.greeter_name_changed(iface_ref.signal_emitter()).await?;
 # Ok(())
 # }
 ```

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -4,12 +4,12 @@ use static_assertions::assert_impl_all;
 use zvariant::ObjectPath;
 
 use crate::{
-    object_server::{Interface, InterfaceDeref, InterfaceDerefMut, SignalContext},
+    object_server::{Interface, InterfaceDeref, InterfaceDerefMut, SignalEmitter},
     utils::block_on,
     Error, Result,
 };
 
-/// Wrapper over an interface, along with its corresponding `SignalContext`
+/// Wrapper over an interface, along with its corresponding `SignalEmitter`
 /// instance. A reference to the underlying interface may be obtained via
 /// [`InterfaceRef::get`] and [`InterfaceRef::get_mut`].
 pub struct InterfaceRef<I> {
@@ -67,7 +67,7 @@ where
     /// let iface_ref = object_server.interface::<_, MyIface>(path)?;
     /// let mut iface = iface_ref.get_mut();
     /// iface.0 = 42;
-    /// block_on(iface.count_changed(iface_ref.signal_context()))?;
+    /// block_on(iface.count_changed(iface_ref.signal_emitter()))?;
     /// #
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
@@ -75,8 +75,8 @@ where
         block_on(self.azync.get_mut())
     }
 
-    pub fn signal_context(&self) -> &SignalContext<'static> {
-        self.azync.signal_context()
+    pub fn signal_emitter(&self) -> &SignalEmitter<'static> {
+        self.azync.signal_emitter()
     }
 }
 
@@ -192,7 +192,7 @@ impl ObjectServer {
     /// # use std::error::Error;
     /// # use zbus::block_on;
     /// # use zbus::{
-    /// #    SignalContext,
+    /// #    object_server::SignalEmitter,
     /// #    blocking::Connection,
     /// #    interface,
     /// # };
@@ -201,7 +201,7 @@ impl ObjectServer {
     /// #[interface(name = "org.myiface.MyIface")]
     /// impl MyIface {
     ///     #[zbus(signal)]
-    ///     async fn emit_signal(ctxt: &SignalContext<'_>) -> zbus::Result<()>;
+    ///     async fn emit_signal(emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
     /// }
     ///
     /// # let connection = Connection::session()?;
@@ -211,7 +211,7 @@ impl ObjectServer {
     /// let iface_ref = connection
     ///     .object_server()
     ///     .interface::<_, MyIface>(path)?;
-    /// block_on(MyIface::emit_signal(iface_ref.signal_context()))?;
+    /// block_on(MyIface::emit_signal(iface_ref.signal_emitter()))?;
     /// #
     /// #
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -150,7 +150,7 @@ mod tests {
 
     use super::*;
 
-    use crate::{Guid, Socket};
+    use crate::{connection::Socket, Guid};
 
     fn create_async_socket_pair() -> (impl AsyncWrite + Socket, impl AsyncWrite + Socket) {
         // Tokio needs us to call the sync function from async context. :shrug:

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -144,7 +144,7 @@ mod tests {
         let conn = blocking::Connection::session().unwrap();
         let mut iterator = blocking::MessageIterator::for_match_rule(
             zbus::MatchRule::builder()
-                .msg_type(zbus::MessageType::Signal)
+                .msg_type(zbus::message::Type::Signal)
                 .interface("org.freedesktop.DBus.ObjectManager")
                 .unwrap()
                 .path("/org/zbus/NoObjectManagerSignalsBeforeHello")

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -9,7 +9,7 @@ use zbus_names::{InterfaceName, OwnedInterfaceName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
 use super::{Error, Result};
-use crate::{interface, message::Header, object_server::SignalContext, ObjectServer};
+use crate::{interface, message::Header, object_server::SignalEmitter, ObjectServer};
 
 /// The type returned by the [`ObjectManagerProxy::get_managed_objects`] method.
 pub type ManagedObjects =
@@ -61,7 +61,7 @@ impl ObjectManager {
     /// interfaces and properties (if any) that have been added to the given object path.
     #[zbus(signal)]
     pub async fn interfaces_added(
-        ctxt: &SignalContext<'_>,
+        emitter: &SignalEmitter<'_>,
         object_path: ObjectPath<'_>,
         interfaces_and_properties: HashMap<InterfaceName<'_>, HashMap<&str, Value<'_>>>,
     ) -> zbus::Result<()>;
@@ -70,7 +70,7 @@ impl ObjectManager {
     /// The `interfaces` parameters contains a list of the interfaces that were removed.
     #[zbus(signal)]
     pub async fn interfaces_removed(
-        ctxt: &SignalContext<'_>,
+        emitter: &SignalEmitter<'_>,
         object_path: ObjectPath<'_>,
         interfaces: Vec<InterfaceName<'_>>,
     ) -> zbus::Result<()>;

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -55,38 +55,10 @@ pub use guid::*;
 pub mod message;
 pub use message::Message;
 
-#[deprecated(since = "4.0.0", note = "Use `message::Builder` instead")]
-#[doc(hidden)]
-pub use message::Builder as MessageBuilder;
-#[deprecated(since = "4.0.0", note = "Use `message::EndianSig` instead")]
-#[doc(hidden)]
-pub use message::EndianSig;
-#[doc(hidden)]
-pub use message::Flags as MessageFlags;
-#[deprecated(since = "4.0.0", note = "Use `message::Header` instead")]
-#[doc(hidden)]
-pub use message::Header as MessageHeader;
-#[deprecated(since = "4.0.0", note = "Use `message::PrimaryHeader` instead")]
-#[doc(hidden)]
-pub use message::PrimaryHeader as MessagePrimaryHeader;
-#[deprecated(since = "4.0.0", note = "Use `message::Sequence` instead")]
-#[doc(hidden)]
-pub use message::Sequence as MessageSequence;
-#[deprecated(since = "4.0.0", note = "Use `message::Type` instead")]
-#[doc(hidden)]
-pub use message::Type as MessageType;
-#[deprecated(since = "4.0.0", note = "Use `message::NATIVE_ENDIAN_SIG` instead")]
-#[doc(hidden)]
-pub use message::NATIVE_ENDIAN_SIG;
-
 pub mod connection;
 /// Alias for `connection` module, for convenience.
 pub use connection as conn;
 pub use connection::{handshake::AuthMechanism, Connection};
-
-#[deprecated(since = "4.0.0", note = "Use `connection::Builder` instead")]
-#[doc(hidden)]
-pub use connection::Builder as ConnectionBuilder;
 
 mod message_stream;
 pub use message_stream::*;
@@ -96,78 +68,17 @@ pub use abstractions::*;
 pub mod match_rule;
 pub use match_rule::{MatchRule, OwnedMatchRule};
 
-#[deprecated(since = "4.0.0", note = "Use `match_rule::Builder` instead")]
-#[doc(hidden)]
-pub use match_rule::Builder as MatchRuleBuilder;
-#[deprecated(since = "4.0.0", note = "Use `match_rule::PathSpec` instead")]
-#[doc(hidden)]
-pub use match_rule::PathSpec as MatchRulePathSpec;
-
 pub mod proxy;
 pub use proxy::Proxy;
 
-#[deprecated(since = "4.0.0", note = "Use `proxy::Builder` instead")]
-#[doc(hidden)]
-pub use proxy::Builder as ProxyBuilder;
-#[deprecated(since = "4.0.0", note = "Use `proxy::CacheProperties` instead")]
-#[doc(hidden)]
-pub use proxy::CacheProperties;
-#[deprecated(since = "4.0.0", note = "Use `proxy::MethodFlags` instead")]
-#[doc(hidden)]
-pub use proxy::MethodFlags;
-#[deprecated(since = "4.0.0", note = "Use `proxy::OwnerChangedStream` instead")]
-#[doc(hidden)]
-pub use proxy::OwnerChangedStream;
-#[deprecated(since = "4.0.0", note = "Use `proxy::PropertyChanged` instead")]
-#[doc(hidden)]
-pub use proxy::PropertyChanged;
-#[deprecated(since = "4.0.0", note = "Use `proxy::PropertyStream` instead")]
-#[doc(hidden)]
-pub use proxy::PropertyStream;
-#[deprecated(since = "4.0.0", note = "Use `proxy::ProxyDefault` instead")]
-#[doc(hidden)]
-pub use proxy::ProxyDefault;
-
 pub mod object_server;
 pub use object_server::ObjectServer;
-
-#[deprecated(since = "4.0.0", note = "Use `object_server::DispatchResult` instead")]
-#[doc(hidden)]
-pub use object_server::DispatchResult;
-#[deprecated(since = "4.0.0", note = "Use `object_server::Interface` instead")]
-#[doc(hidden)]
-pub use object_server::Interface;
-#[deprecated(since = "4.0.0", note = "Use `object_server::InterfaceDeref` instead")]
-#[doc(hidden)]
-pub use object_server::InterfaceDeref;
-#[deprecated(
-    since = "4.0.0",
-    note = "Use `object_server::InterfaceDerefMut` instead"
-)]
-#[doc(hidden)]
-pub use object_server::InterfaceDerefMut;
-#[deprecated(since = "4.0.0", note = "Use `object_server::InterfaceRef` instead")]
-#[doc(hidden)]
-pub use object_server::InterfaceRef;
-#[deprecated(
-    since = "4.0.0",
-    note = "Use `object_server::ResponseDispatchNotifier` instead"
-)]
-#[doc(hidden)]
-pub use object_server::ResponseDispatchNotifier;
-#[deprecated(since = "4.0.0", note = "Use `object_server::SignalContext` instead")]
-#[doc(hidden)]
-pub use object_server::SignalContext;
 
 mod utils;
 pub use utils::*;
 
 #[macro_use]
 pub mod fdo;
-
-#[deprecated(since = "4.0.0", note = "Use `connection::Socket` instead")]
-#[doc(hidden)]
-pub use connection::Socket;
 
 pub mod blocking;
 

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -10,10 +10,10 @@ use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use zvariant::{serialized, Endian, Signature};
 
 use crate::{
-    message::{Fields, Flags, Header, Message, PrimaryHeader, Sequence, Type},
+    message::{EndianSig, Fields, Flags, Header, Message, PrimaryHeader, Sequence, Type},
     utils::padding_for_8_bytes,
     zvariant::{serialized::Context, DynamicType, ObjectPath},
-    EndianSig, Error, Result,
+    Error, Result,
 };
 
 use crate::message::header::MAX_MESSAGE_SIZE;

--- a/zbus/src/object_server/interface/interface_ref.rs
+++ b/zbus/src/object_server/interface/interface_ref.rs
@@ -1,13 +1,13 @@
 use std::{marker::PhantomData, sync::Arc};
 
-use super::{Interface, InterfaceDeref, InterfaceDerefMut, SignalContext};
+use super::{Interface, InterfaceDeref, InterfaceDerefMut, SignalEmitter};
 use crate::async_lock::RwLock;
 
-/// Wrapper over an interface, along with its corresponding `SignalContext`
+/// Wrapper over an interface, along with its corresponding `SignalEmitter`
 /// instance. A reference to the underlying interface may be obtained via
 /// [`InterfaceRef::get`] and [`InterfaceRef::get_mut`].
 pub struct InterfaceRef<I> {
-    pub(crate) ctxt: SignalContext<'static>,
+    pub(crate) emitter: SignalEmitter<'static>,
     pub(crate) lock: Arc<RwLock<dyn Interface>>,
     pub(crate) phantom: PhantomData<I>,
 }
@@ -73,7 +73,7 @@ where
     /// let iface_ref = object_server.interface::<_, MyIface>(path).await?;
     /// let mut iface = iface_ref.get_mut().await;
     /// iface.0 = 42;
-    /// iface.count_changed(iface_ref.signal_context()).await?;
+    /// iface.count_changed(iface_ref.signal_emitter()).await?;
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// # })?;
     /// #
@@ -95,15 +95,20 @@ where
         }
     }
 
-    pub fn signal_context(&self) -> &SignalContext<'static> {
-        &self.ctxt
+    pub fn signal_emitter(&self) -> &SignalEmitter<'static> {
+        &self.emitter
+    }
+
+    #[deprecated(since = "0.5.0", note = "Please use `signal_emitter` instead.")]
+    pub fn signal_context(&self) -> &SignalEmitter<'static> {
+        &self.emitter
     }
 }
 
 impl<I> Clone for InterfaceRef<I> {
     fn clone(&self) -> Self {
         Self {
-            ctxt: self.ctxt.clone(),
+            emitter: self.emitter.clone(),
             lock: self.lock.clone(),
             phantom: PhantomData,
         }

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -17,7 +17,7 @@ use zbus_names::{InterfaceName, MemberName};
 use zvariant::{OwnedValue, Value};
 
 use crate::{
-    async_lock::RwLock, fdo, message::Message, object_server::SignalContext, Connection,
+    async_lock::RwLock, fdo, message::Message, object_server::SignalEmitter, Connection,
     ObjectServer,
 };
 
@@ -59,9 +59,9 @@ pub trait Interface: Any + Send + Sync {
         &'call self,
         property_name: &'call str,
         value: &'call Value<'_>,
-        ctxt: &'call SignalContext<'_>,
+        emitter: &'call SignalEmitter<'_>,
     ) -> DispatchResult<'call> {
-        let _ = (property_name, value, ctxt);
+        let _ = (property_name, value, emitter);
         DispatchResult::RequiresMut
     }
 
@@ -74,7 +74,7 @@ pub trait Interface: Any + Send + Sync {
         &mut self,
         property_name: &str,
         value: &Value<'_>,
-        ctxt: &SignalContext<'_>,
+        emitter: &SignalEmitter<'_>,
     ) -> Option<fdo::Result<()>>;
 
     /// Call a method.

--- a/zbus/src/object_server/signal_context.rs
+++ b/zbus/src/object_server/signal_context.rs
@@ -1,4 +1,4 @@
-use zbus_names::BusName;
+use zbus_names::{BusName, InterfaceName, MemberName};
 
 use crate::{zvariant::ObjectPath, Connection, Error, Result};
 
@@ -38,6 +38,26 @@ impl<'s> SignalContext<'s> {
             path,
             destination: None,
         }
+    }
+
+    /// Emit a signal on the given interface with the given signal name and body.
+    pub async fn emit<'i, 'm, I, M, B>(&self, interface: I, signal_name: M, body: &B) -> Result<()>
+    where
+        I: TryInto<InterfaceName<'i>>,
+        I::Error: Into<Error>,
+        M: TryInto<MemberName<'m>>,
+        M::Error: Into<Error>,
+        B: serde::ser::Serialize + zvariant::DynamicType,
+    {
+        self.conn
+            .emit_signal(
+                self.destination.as_ref(),
+                &self.path,
+                interface,
+                signal_name,
+                body,
+            )
+            .await
     }
 
     /// Set the destination for the signal emission.

--- a/zbus/src/object_server/signal_emitter.rs
+++ b/zbus/src/object_server/signal_emitter.rs
@@ -2,20 +2,20 @@ use zbus_names::{BusName, InterfaceName, MemberName};
 
 use crate::{zvariant::ObjectPath, Connection, Error, Result};
 
-/// A signal emission context.
+/// A signal emitter.
 ///
 /// For signal emission using the high-level API, you'll need instances of this type.
 ///
-/// See [`crate::InterfaceRef::signal_context`] and [`crate::interface`]
+/// See [`crate::InterfaceRef::signal_emitter`] and [`crate::interface`]
 /// documentation for details and examples of this type in use.
 #[derive(Clone, Debug)]
-pub struct SignalContext<'s> {
+pub struct SignalEmitter<'s> {
     conn: Connection,
     path: ObjectPath<'s>,
     destination: Option<BusName<'s>>,
 }
 
-impl<'s> SignalContext<'s> {
+impl<'s> SignalEmitter<'s> {
     /// Create a new signal context for the given connection and object path.
     pub fn new<P>(conn: &Connection, path: P) -> Result<Self>
     where
@@ -87,8 +87,8 @@ impl<'s> SignalContext<'s> {
     }
 
     /// Create an owned clone of `self`.
-    pub fn to_owned(&self) -> SignalContext<'static> {
-        SignalContext {
+    pub fn to_owned(&self) -> SignalEmitter<'static> {
+        SignalEmitter {
             conn: self.conn.clone(),
             path: self.path.to_owned(),
             destination: self.destination.as_ref().map(|d| d.to_owned()),
@@ -96,8 +96,8 @@ impl<'s> SignalContext<'s> {
     }
 
     /// Convert into an owned clone of `self`.
-    pub fn into_owned(self) -> SignalContext<'static> {
-        SignalContext {
+    pub fn into_owned(self) -> SignalEmitter<'static> {
+        SignalEmitter {
             conn: self.conn,
             path: self.path.into_owned(),
             destination: self.destination.map(|d| d.into_owned()),

--- a/zbus/src/object_server/signal_emitter.rs
+++ b/zbus/src/object_server/signal_emitter.rs
@@ -6,7 +6,7 @@ use crate::{zvariant::ObjectPath, Connection, Error, Result};
 ///
 /// For signal emission using the high-level API, you'll need instances of this type.
 ///
-/// See [`crate::InterfaceRef::signal_emitter`] and [`crate::interface`]
+/// See [`crate::object_server::InterfaceRef::signal_emitter`] and [`crate::interface`]
 /// documentation for details and examples of this type in use.
 #[derive(Clone, Debug)]
 pub struct SignalEmitter<'s> {

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1356,7 +1356,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{connection, interface, object_server::SignalContext, proxy, utils::block_on};
+    use crate::{connection, interface, object_server::SignalEmitter, proxy, utils::block_on};
     use futures_util::StreamExt;
     use ntest::timeout;
     use test_log::test;
@@ -1459,7 +1459,7 @@ mod tests {
         #[interface(name = "org.zbus.Test")]
         impl TestIface {
             #[zbus(signal)]
-            async fn my_signal(context: &SignalContext<'_>, msg: &'static str) -> Result<()>;
+            async fn my_signal(context: &SignalEmitter<'_>, msg: &'static str) -> Result<()>;
         }
 
         let test_iface = TestIface;
@@ -1501,7 +1501,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let context = iface_ref.signal_context();
+                let context = iface_ref.signal_emitter();
                 while !tx.is_closed() {
                     for _ in 0..10 {
                         TestIface::my_signal(context, "This is a test")

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -101,7 +101,8 @@ impl MyIface {
     async fn ping(&mut self, #[zbus(signal_emitter)] emitter: SignalEmitter<'_>) -> u32 {
         self.count += 1;
         if self.count % 3 == 0 {
-            MyIface::alert_count(&emitter, self.count)
+            emitter
+                .alert_count(self.count)
                 .await
                 .expect("Failed to emit signal");
             debug!("emitted `AlertCount` signal.");
@@ -974,9 +975,7 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
     debug!("`PropertiesChanged` emitted for `Count` property.");
 
     loop {
-        MyIface::alert_count(iface.signal_emitter(), 51)
-            .await
-            .unwrap();
+        iface.alert_count(51).await.unwrap();
         debug!("`AlertCount` signal emitted.");
 
         match next_rx.recv().await.unwrap() {

--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -1,7 +1,7 @@
 use ntest::timeout;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use zbus::{blocking::connection::Builder, zvariant::Type, ProxyDefault};
+use zbus::{blocking::connection::Builder, proxy::ProxyDefault, zvariant::Type};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
 struct SingleFieldStruct {

--- a/zbus/tests/issue/issue_173.rs
+++ b/zbus/tests/issue/issue_173.rs
@@ -4,7 +4,7 @@ use ntest::timeout;
 use test_log::test;
 use zbus::block_on;
 
-use zbus::{blocking, object_server::SignalContext};
+use zbus::{blocking, object_server::SignalEmitter};
 
 #[test]
 #[timeout(15000)]
@@ -41,7 +41,7 @@ fn issue_173() {
     #[zbus::interface(name = "org.freedesktop.zbus.ComeAndGo")]
     impl ComeAndGo {
         #[zbus(signal)]
-        async fn the_signal(signal_ctxt: &SignalContext<'_>) -> zbus::Result<()>;
+        async fn the_signal(signal_emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
     }
 
     rx.recv().unwrap();
@@ -59,7 +59,7 @@ fn issue_173() {
             .object_server()
             .interface::<_, ComeAndGo>("/org/freedesktop/zbus/ComeAndGo")
             .unwrap();
-        block_on(ComeAndGo::the_signal(iface_ref.signal_context())).unwrap();
+        block_on(ComeAndGo::the_signal(iface_ref.signal_emitter())).unwrap();
 
         rx.recv().unwrap();
 

--- a/zbus/tests/issue/issue_310.rs
+++ b/zbus/tests/issue/issue_310.rs
@@ -59,11 +59,11 @@ async fn issue_310() {
             {
                 let iface = iface_ref.get().await;
                 iface
-                    .connected_network_invalidate(iface_ref.signal_context())
+                    .connected_network_invalidate(iface_ref.signal_emitter())
                     .await
                     .unwrap();
                 iface
-                    .connected_network_changed(iface_ref.signal_context())
+                    .connected_network_changed(iface_ref.signal_emitter())
                     .await
                     .unwrap();
             }

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -446,9 +446,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 let signal_context = signal_context_arg.unwrap().pat;
 
                 method.block = parse_quote!({
-                    #signal_context.connection().emit_signal(
-                        #signal_context.destination(),
-                        #signal_context.path(),
+                    #signal_context.emit(
                         <#self_ty as #zbus::object_server::Interface>::name(),
                         #member_name,
                         &(#args_names),

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -250,7 +250,11 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `signal` - the method is a "signal". It must be a method declaration (without body). Its code
 ///   block will be expanded to emit the signal from the object path associated with the interface
-///   instance.
+///   instance. Moreover, `interface` will also generate a trait named `<Interface>Signals` that
+///   provides all the signal methods but without the `SignalEmitter` argument. The macro implements
+///   this trait for two types, `zbus::object_server::InterfaceRef<Interface>` and
+///   `SignalEmitter<'_>`. The former is useful for emitting signals from outside the context of an
+///   interface method and the latter is useful for emitting signals from inside interface methods.
 ///
 ///   You can call a signal method from a an interface method, or from an [`ObjectServer::with`]
 ///   function.
@@ -317,7 +321,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     ) -> zbus::fdo::Result<()> {
 ///         let path = hdr.path().unwrap();
 ///         let msg = format!("You are leaving me on the {} path?", path);
-///         Example::bye(&emitter, &msg).await?;
+///         emitter.bye(&msg).await?;
 ///
 ///         // Do some asynchronous tasks before quitting..
 ///

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -289,7 +289,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   which the method call was received.
 /// * `header` - This marks the method argument to receive the message header associated with the
 ///   D-Bus method call being handled.
-/// * `signal_context` - This marks the method argument to receive a [`SignalContext`] instance,
+/// * `signal_emitter` - This marks the method argument to receive a [`SignalEmitter`] instance,
 ///   which is needed for emitting signals the easy way.
 ///
 /// # Example
@@ -297,7 +297,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 /// # use std::error::Error;
 /// use zbus_macros::interface;
-/// use zbus::{ObjectServer, object_server::SignalContext, message::Header};
+/// use zbus::{ObjectServer, object_server::SignalEmitter, message::Header};
 ///
 /// struct Example {
 ///     _some_data: String,
@@ -310,14 +310,14 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///         &self,
 ///         #[zbus(header)]
 ///         hdr: Header<'_>,
-///         #[zbus(signal_context)]
-///         ctxt: SignalContext<'_>,
+///         #[zbus(signal_emitter)]
+///         emitter: SignalEmitter<'_>,
 ///         #[zbus(object_server)]
 ///         _server: &ObjectServer,
 ///     ) -> zbus::fdo::Result<()> {
 ///         let path = hdr.path().unwrap();
 ///         let msg = format!("You are leaving me on the {} path?", path);
-///         Example::bye(&ctxt, &msg).await?;
+///         Example::bye(&emitter, &msg).await?;
 ///
 ///         // Do some asynchronous tasks before quitting..
 ///
@@ -342,7 +342,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 ///     // "Bye" signal (note: no implementation body).
 ///     #[zbus(signal)]
-///     async fn bye(signal_ctxt: &SignalContext<'_>, message: &str) -> zbus::Result<()>;
+///     async fn bye(signal_emitter: &SignalEmitter<'_>, message: &str) -> zbus::Result<()>;
 ///
 ///     #[zbus(out_args("answer", "question"))]
 ///     fn meaning_of_life(&self) -> zbus::fdo::Result<(i32, String)> {
@@ -359,7 +359,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// [`ObjectServer::with`]: https://docs.rs/zbus/latest/zbus/object_server/struct.ObjectServer.html#method.with
 /// [`Connection`]: https://docs.rs/zbus/latest/zbus/connection/struct.Connection.html
 /// [`Connection::emit_signal()`]: https://docs.rs/zbus/latest/zbus/connection/struct.Connection.html#method.emit_signal
-/// [`SignalContext`]: https://docs.rs/zbus/latest/zbus/object_server/struct.SignalContext.html
+/// [`SignalEmitter`]: https://docs.rs/zbus/latest/zbus/object_server/struct.SignalEmitter.html
 /// [`Interface`]: https://docs.rs/zbus/latest/zbus/object_server/trait.Interface.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 #[proc_macro_attribute]

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -154,7 +154,7 @@ mod utils;
 /// // Use `builder` to override the default arguments, `new` otherwise.
 /// let proxy = SomeIfaceProxyBlocking::builder(&connection)
 ///                .destination("org.another.Service")?
-///                .cache_properties(zbus::CacheProperties::No)
+///                .cache_properties(zbus::proxy::CacheProperties::No)
 ///                .build()?;
 /// let _ = proxy.do_this("foo", 32, &Value::new(true));
 /// let _ = proxy.set_a_property("val");
@@ -166,7 +166,7 @@ mod utils;
 /// // Now the same again, but asynchronous.
 /// block_on(async move {
 ///     let proxy = SomeIfaceProxy::builder(&connection.into())
-///                    .cache_properties(zbus::CacheProperties::No)
+///                    .cache_properties(zbus::proxy::CacheProperties::No)
 ///                    .build()
 ///                    .await
 ///                    .unwrap();

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -247,7 +247,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///       signal.
 ///     * `"const"` - the property never changes, thus no signal is ever emitted for it.
 ///     * `"false"` - the change signal is not emitted if the property changes.
-
+///
 /// * `signal` - the method is a "signal". It must be a method declaration (without body). Its code
 ///   block will be expanded to emit the signal from the object path associated with the interface
 ///   instance.

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -3,7 +3,7 @@ use futures_util::{
     stream::StreamExt,
 };
 use std::future::ready;
-use zbus::{block_on, fdo, object_server::SignalContext, proxy::CacheProperties};
+use zbus::{block_on, fdo, object_server::SignalEmitter, proxy::CacheProperties};
 use zbus_macros::{interface, proxy, DBusError};
 
 mod param {
@@ -217,7 +217,7 @@ fn test_interface() {
 
         /// Emit a signal.
         #[zbus(signal)]
-        async fn signal(ctxt: &SignalContext<'_>, arg: u8, other: &str) -> zbus::Result<()>;
+        async fn signal(emitter: &SignalEmitter<'_>, arg: u8, other: &str) -> zbus::Result<()>;
     }
 
     const EXPECTED_XML: &str = r#"<interface name="org.freedesktop.zbus.Test">
@@ -285,7 +285,7 @@ fn test_interface() {
                 .build(&(42,))
                 .unwrap();
             let _ = t.call(&s, &c, &m, "StrU32".try_into().unwrap());
-            let ctxt = SignalContext::new(&c, "/does/not/matter").unwrap();
+            let ctxt = SignalEmitter::new(&c, "/does/not/matter").unwrap();
             block_on(Test::<u32>::signal(&ctxt, 23, "ergo sum")).unwrap();
         });
     }

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -286,7 +286,7 @@ fn test_interface() {
                 .unwrap();
             let _ = t.call(&s, &c, &m, "StrU32".try_into().unwrap());
             let ctxt = SignalEmitter::new(&c, "/does/not/matter").unwrap();
-            block_on(Test::<u32>::signal(&ctxt, 23, "ergo sum")).unwrap();
+            ctxt.signal(23, "ergo sum").await.unwrap();
         });
     }
 }


### PR DESCRIPTION
This PR first converts `SignalContext` to a `SignalEmitter`.

This it changes `interface` to generate a trait, `<InterfaceType>Signals`, that provides the same signal methods as user specifies but w/o the `SignalEmitter` argument. The macro also generates 2 implementations of this trait for:

* `InterfaceRef<InterfaceType>`
* `SignalEmitter`

The former is useful for emitting signals from outside the context of an interface method and the latter is useful for emitting signals from inside an interface methods.

Fixes #871.