### PR TITLE
💥 `proxy::ProxyDefault` overhaul

### DIFF
--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -4,7 +4,7 @@ use zvariant::ObjectPath;
 
 use crate::{blocking::Connection, proxy::CacheProperties, utils::block_on, Error, Result};
 
-pub use crate::proxy::ProxyDefault;
+pub use crate::proxy::Defaults;
 
 /// Builder for proxies.
 #[derive(Debug, Clone)]
@@ -67,7 +67,7 @@ impl<'a, T> Builder<'a, T> {
 
 impl<'a, T> Builder<'a, T>
 where
-    T: ProxyDefault,
+    T: Defaults,
 {
     /// Create a new [`Builder`] for the given connection.
     #[must_use]

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -10,7 +10,7 @@ use zvariant::{ObjectPath, OwnedValue, Value};
 use crate::{
     blocking::Connection,
     message::Message,
-    proxy::{MethodFlags, ProxyDefault},
+    proxy::{Defaults, MethodFlags},
     utils::block_on,
     Error, Result,
 };
@@ -365,7 +365,7 @@ impl<'a> Proxy<'a> {
     }
 }
 
-impl ProxyDefault for Proxy<'_> {
+impl Defaults for Proxy<'_> {
     const INTERFACE: Option<&'static str> = None;
     const DESTINATION: Option<&'static str> = None;
     const PATH: Option<&'static str> = None;

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -366,9 +366,9 @@ impl<'a> Proxy<'a> {
 }
 
 impl Defaults for Proxy<'_> {
-    const INTERFACE: Option<&'static str> = None;
-    const DESTINATION: Option<&'static str> = None;
-    const PATH: Option<&'static str> = None;
+    const INTERFACE: &'static Option<InterfaceName<'static>> = &None;
+    const DESTINATION: &'static Option<BusName<'static>> = &None;
+    const PATH: &'static Option<ObjectPath<'static>> = &None;
 }
 
 impl<'a> std::convert::AsRef<Proxy<'a>> for Proxy<'a> {

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -152,9 +152,13 @@ where
         Self {
             conn: conn.clone(),
             destination: T::DESTINATION
+                .as_ref()
                 .map(|d| BusName::from_static_str(d).expect("invalid bus name")),
-            path: T::PATH.map(|p| ObjectPath::from_static_str(p).expect("invalid default path")),
+            path: T::PATH
+                .as_ref()
+                .map(|p| ObjectPath::from_static_str(p).expect("invalid default path")),
             interface: T::INTERFACE
+                .as_ref()
                 .map(|i| InterfaceName::from_static_str(i).expect("invalid interface name")),
             cache: CacheProperties::default(),
             uncached_properties: None,

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -144,7 +144,7 @@ impl<'a, T> Builder<'a, T> {
 
 impl<'a, T> Builder<'a, T>
 where
-    T: super::ProxyDefault,
+    T: super::Defaults,
 {
     /// Create a new [`Builder`] for the given connection.
     #[must_use]

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -144,7 +144,7 @@ impl<'a, T> Builder<'a, T> {
 
 impl<'a, T> Builder<'a, T>
 where
-    T: ProxyDefault,
+    T: super::ProxyDefault,
 {
     /// Create a new [`Builder`] for the given connection.
     #[must_use]
@@ -171,24 +171,6 @@ where
     pub fn new_bare(conn: &Connection) -> Self {
         Self::new(conn)
     }
-}
-
-/// Trait for the default associated values of a proxy.
-///
-/// The trait is automatically implemented by the [`proxy`] macro on your behalf, and may be later
-/// used to retrieve the associated constants.
-///
-/// [`proxy`]: attr.proxy.html
-pub trait ProxyDefault {
-    const INTERFACE: Option<&'static str>;
-    const DESTINATION: Option<&'static str>;
-    const PATH: Option<&'static str>;
-}
-
-impl ProxyDefault for Proxy<'_> {
-    const INTERFACE: Option<&'static str> = None;
-    const DESTINATION: Option<&'static str> = None;
-    const PATH: Option<&'static str> = None;
 }
 
 #[cfg(test)]

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -4,13 +4,13 @@
 /// used to retrieve the associated constants.
 ///
 /// [`proxy`]: attr.proxy.html
-pub trait ProxyDefault {
+pub trait Defaults {
     const INTERFACE: Option<&'static str>;
     const DESTINATION: Option<&'static str>;
     const PATH: Option<&'static str>;
 }
 
-impl ProxyDefault for super::Proxy<'_> {
+impl Defaults for super::Proxy<'_> {
     const INTERFACE: Option<&'static str> = None;
     const DESTINATION: Option<&'static str> = None;
     const PATH: Option<&'static str> = None;

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -1,0 +1,17 @@
+/// Trait for the default associated values of a proxy.
+///
+/// The trait is automatically implemented by the [`proxy`] macro on your behalf, and may be later
+/// used to retrieve the associated constants.
+///
+/// [`proxy`]: attr.proxy.html
+pub trait ProxyDefault {
+    const INTERFACE: Option<&'static str>;
+    const DESTINATION: Option<&'static str>;
+    const PATH: Option<&'static str>;
+}
+
+impl ProxyDefault for super::Proxy<'_> {
+    const INTERFACE: Option<&'static str> = None;
+    const DESTINATION: Option<&'static str> = None;
+    const PATH: Option<&'static str> = None;
+}

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -1,3 +1,6 @@
+use zbus_names::{BusName, InterfaceName};
+use zvariant::ObjectPath;
+
 /// Trait for the default associated values of a proxy.
 ///
 /// The trait is automatically implemented by the [`proxy`] macro on your behalf, and may be later
@@ -5,13 +8,13 @@
 ///
 /// [`proxy`]: attr.proxy.html
 pub trait Defaults {
-    const INTERFACE: Option<&'static str>;
-    const DESTINATION: Option<&'static str>;
-    const PATH: Option<&'static str>;
+    const INTERFACE: &'static Option<InterfaceName<'static>>;
+    const DESTINATION: &'static Option<BusName<'static>>;
+    const PATH: &'static Option<ObjectPath<'static>>;
 }
 
 impl Defaults for super::Proxy<'_> {
-    const INTERFACE: Option<&'static str> = None;
-    const DESTINATION: Option<&'static str> = None;
-    const PATH: Option<&'static str> = None;
+    const INTERFACE: &'static Option<InterfaceName<'static>> = &None;
+    const DESTINATION: &'static Option<BusName<'static>> = &None;
+    const PATH: &'static Option<ObjectPath<'static>> = &None;
 }

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -27,7 +27,10 @@ use crate::{
 };
 
 mod builder;
-pub use builder::{Builder, CacheProperties, ProxyDefault};
+pub use builder::{Builder, CacheProperties};
+
+mod defaults;
+pub use defaults::ProxyDefault;
 
 /// A client-side interface proxy.
 ///

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -30,7 +30,7 @@ mod builder;
 pub use builder::{Builder, CacheProperties};
 
 mod defaults;
-pub use defaults::ProxyDefault;
+pub use defaults::Defaults;
 
 /// A client-side interface proxy.
 ///

--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -32,9 +32,9 @@ fn issue_1015() {
     // handled.
     let conn = Builder::session()
         .unwrap()
-        .serve_at(IfaceProxy::PATH.unwrap(), Iface)
+        .serve_at(IfaceProxy::PATH.as_ref().unwrap(), Iface)
         .unwrap()
-        .name(IfaceProxy::DESTINATION.unwrap())
+        .name(IfaceProxy::DESTINATION.clone().unwrap())
         .unwrap()
         .build()
         .unwrap();

--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -1,7 +1,7 @@
 use ntest::timeout;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use zbus::{blocking::connection::Builder, proxy::ProxyDefault, zvariant::Type};
+use zbus::{blocking::connection::Builder, proxy::Defaults, zvariant::Type};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
 struct SingleFieldStruct {

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -334,7 +334,7 @@ pub fn create_proxy(
     };
 
     Ok(quote! {
-        impl<'a> #zbus::proxy::ProxyDefault for #proxy_name<'a> {
+        impl<'a> #zbus::proxy::Defaults for #proxy_name<'a> {
             const INTERFACE: Option<&'static str> = Some(#iface_name);
             const DESTINATION: Option<&'static str> = #default_service;
             const PATH: Option<&'static str> = #default_path;

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -226,6 +226,28 @@ impl<'s> TryFrom<Str<'s>> for BusName<'s> {
     }
 }
 
+impl<'s> TryFrom<BusName<'s>> for WellKnownName<'s> {
+    type Error = Error;
+
+    fn try_from(value: BusName<'s>) -> Result<Self> {
+        match value {
+            BusName::Unique(name) => Err(Error::InvalidWellKnownName(name.to_string())),
+            BusName::WellKnown(name) => Ok(name),
+        }
+    }
+}
+
+impl<'s> TryFrom<BusName<'s>> for UniqueName<'s> {
+    type Error = Error;
+
+    fn try_from(value: BusName<'s>) -> Result<Self> {
+        match value {
+            BusName::Unique(name) => Ok(name),
+            BusName::WellKnown(name) => Err(Error::InvalidUniqueName(name.to_string())),
+        }
+    }
+}
+
 impl<'s> TryFrom<&'s str> for BusName<'s> {
     type Error = Error;
 


### PR DESCRIPTION
Rename `proxy::ProxyDefault` to `proxy::Defaults` and make it's constants strongly-typed.