### PR TITLE
🛂 zb: Only support one authentication method at a time

### DIFF
--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -15,8 +15,9 @@ use zvariant::ObjectPath;
 #[cfg(feature = "p2p")]
 use crate::Guid;
 use crate::{
-    address::ToAddresses, blocking::Connection, connection::socket::BoxedSplit,
-    names::WellKnownName, object_server::Interface, utils::block_on, AuthMechanism, Error, Result,
+    address::ToAddresses, blocking::Connection, conn::AuthMechanism,
+    connection::socket::BoxedSplit, names::WellKnownName, object_server::Interface,
+    utils::block_on, Error, Result,
 };
 
 /// A builder for [`zbus::blocking::Connection`].

--- a/zbus/src/connection/handshake/command.rs
+++ b/zbus/src/connection/handshake/command.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr};
 
-use crate::{AuthMechanism, Error, Guid, OwnedGuid, Result};
+use crate::{conn::AuthMechanism, Error, Guid, OwnedGuid, Result};
 
 // The plain-text SASL profile authentication protocol described here:
 // <https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol>

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -8,7 +8,7 @@ mod server;
 use async_trait::async_trait;
 #[cfg(unix)]
 use nix::unistd::Uid;
-use std::{collections::VecDeque, fmt::Debug};
+use std::fmt::Debug;
 use zbus_names::OwnedUniqueName;
 
 #[cfg(windows)]
@@ -51,10 +51,10 @@ impl Authenticated {
     pub async fn client(
         socket: BoxedSplit,
         server_guid: Option<OwnedGuid>,
-        mechanisms: Option<VecDeque<AuthMechanism>>,
+        mechanism: Option<AuthMechanism>,
         bus: bool,
     ) -> Result<Self> {
-        Client::new(socket, mechanisms, server_guid, bus)
+        Client::new(socket, mechanism, server_guid, bus)
             .perform()
             .await
     }
@@ -68,7 +68,7 @@ impl Authenticated {
         guid: OwnedGuid,
         #[cfg(unix)] client_uid: Option<u32>,
         #[cfg(windows)] client_sid: Option<String>,
-        auth_mechanisms: Option<VecDeque<AuthMechanism>>,
+        auth_mechanism: Option<AuthMechanism>,
         unique_name: Option<OwnedUniqueName>,
     ) -> Result<Self> {
         Server::new(
@@ -78,7 +78,7 @@ impl Authenticated {
             client_uid,
             #[cfg(windows)]
             client_sid,
-            auth_mechanisms,
+            auth_mechanism,
             unique_name,
         )?
         .perform()
@@ -250,7 +250,7 @@ mod tests {
             p1.into(),
             Guid::generate().into(),
             Some(Uid::effective().into()),
-            Some(vec![AuthMechanism::Anonymous].into()),
+            Some(AuthMechanism::Anonymous),
             None,
         )
         .unwrap();
@@ -267,7 +267,7 @@ mod tests {
             p1.into(),
             Guid::generate().into(),
             Some(Uid::effective().into()),
-            Some(vec![AuthMechanism::Anonymous].into()),
+            Some(AuthMechanism::Anonymous),
             None,
         )
         .unwrap();

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -41,6 +41,7 @@ mod socket_reader;
 use socket_reader::SocketReader;
 
 pub(crate) mod handshake;
+pub use handshake::AuthMechanism;
 use handshake::Authenticated;
 
 mod connect;
@@ -1528,7 +1529,7 @@ mod p2p_tests {
     use test_log::test;
     use zvariant::{Endian, NATIVE_ENDIAN};
 
-    use crate::{AuthMechanism, Guid};
+    use crate::{conn::AuthMechanism, Guid};
 
     use super::*;
 

--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use async_broadcast::{broadcast, Receiver, Sender};
 
-use crate::{fdo::ConnectionCredentials, AuthMechanism, Message};
+use crate::{conn::AuthMechanism, fdo::ConnectionCredentials, Message};
 
 /// An in-process channel-based socket.
 ///

--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use async_broadcast::{broadcast, Receiver, Sender};
 
-use crate::{fdo::ConnectionCredentials, Message};
+use crate::{fdo::ConnectionCredentials, AuthMechanism, Message};
 
 /// An in-process channel-based socket.
 ///
@@ -71,6 +71,10 @@ impl super::ReadHalf for Reader {
 
     async fn peer_credentials(&mut self) -> io::Result<ConnectionCredentials> {
         self_credentials().await
+    }
+
+    fn auth_mechanism(&self) -> AuthMechanism {
+        AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -18,12 +18,13 @@ use std::{io, mem};
 use tracing::trace;
 
 use crate::{
+    conn::AuthMechanism,
     fdo::ConnectionCredentials,
     message::{
         header::{MAX_MESSAGE_SIZE, MIN_MESSAGE_SIZE},
         PrimaryHeader,
     },
-    padding_for_8_bytes, AuthMechanism, Message,
+    padding_for_8_bytes, Message,
 };
 #[cfg(unix)]
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         header::{MAX_MESSAGE_SIZE, MIN_MESSAGE_SIZE},
         PrimaryHeader,
     },
-    padding_for_8_bytes, Message,
+    padding_for_8_bytes, AuthMechanism, Message,
 };
 #[cfg(unix)]
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
@@ -237,6 +237,13 @@ pub trait ReadHalf: std::fmt::Debug + Send + Sync + 'static {
     async fn peer_credentials(&mut self) -> io::Result<ConnectionCredentials> {
         Ok(ConnectionCredentials::default())
     }
+
+    /// The authentication mechanism to use for this socket on the target OS.
+    ///
+    /// Default is `AuthMechanism::External`.
+    fn auth_mechanism(&self) -> AuthMechanism {
+        AuthMechanism::External
+    }
 }
 
 /// The write half of a socket.
@@ -353,6 +360,10 @@ impl ReadHalf for Box<dyn ReadHalf> {
 
     async fn peer_credentials(&mut self) -> io::Result<ConnectionCredentials> {
         (**self).peer_credentials().await
+    }
+
+    fn auth_mechanism(&self) -> AuthMechanism {
+        (**self).auth_mechanism()
     }
 }
 

--- a/zbus/src/connection/socket/tcp.rs
+++ b/zbus/src/connection/socket/tcp.rs
@@ -48,6 +48,11 @@ impl ReadHalf for Arc<Async<TcpStream>> {
         )
         .await
     }
+
+    #[cfg(not(windows))]
+    fn auth_mechanism(&self) -> crate::AuthMechanism {
+        crate::AuthMechanism::Anonymous
+    }
 }
 
 #[cfg(not(feature = "tokio"))]
@@ -119,6 +124,11 @@ impl ReadHalf for tokio::net::tcp::OwnedReadHalf {
             "peer credentials",
         )
         .await
+    }
+
+    #[cfg(not(windows))]
+    fn auth_mechanism(&self) -> crate::AuthMechanism {
+        crate::AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/connection/socket/tcp.rs
+++ b/zbus/src/connection/socket/tcp.rs
@@ -50,8 +50,8 @@ impl ReadHalf for Arc<Async<TcpStream>> {
     }
 
     #[cfg(not(windows))]
-    fn auth_mechanism(&self) -> crate::AuthMechanism {
-        crate::AuthMechanism::Anonymous
+    fn auth_mechanism(&self) -> crate::conn::AuthMechanism {
+        crate::conn::AuthMechanism::Anonymous
     }
 }
 
@@ -127,8 +127,8 @@ impl ReadHalf for tokio::net::tcp::OwnedReadHalf {
     }
 
     #[cfg(not(windows))]
-    fn auth_mechanism(&self) -> crate::AuthMechanism {
-        crate::AuthMechanism::Anonymous
+    fn auth_mechanism(&self) -> crate::conn::AuthMechanism {
+        crate::conn::AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/connection/socket/vsock.rs
+++ b/zbus/src/connection/socket/vsock.rs
@@ -91,8 +91,8 @@ impl super::ReadHalf for tokio_vsock::ReadHalf {
         })
     }
 
-    fn auth_mechanism(&self) -> crate::AuthMechanism {
-        crate::AuthMechanism::Anonymous
+    fn auth_mechanism(&self) -> crate::conn::AuthMechanism {
+        crate::conn::AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/connection/socket/vsock.rs
+++ b/zbus/src/connection/socket/vsock.rs
@@ -26,6 +26,10 @@ impl super::ReadHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
             }
         }
     }
+
+    fn auth_mechanism(&self) -> crate::AuthMechanism {
+        crate::AuthMechanism::Anonymous
+    }
 }
 
 #[cfg(all(feature = "vsock", not(feature = "tokio")))]
@@ -85,6 +89,10 @@ impl super::ReadHalf for tokio_vsock::ReadHalf {
 
             ret
         })
+    }
+
+    fn auth_mechanism(&self) -> crate::AuthMechanism {
+        crate::AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -58,7 +58,12 @@ pub use message::Message;
 pub mod connection;
 /// Alias for `connection` module, for convenience.
 pub use connection as conn;
-pub use connection::{handshake::AuthMechanism, Connection};
+#[deprecated(
+    since = "5.0.0",
+    note = "Please use `connection::AuthMechanism` instead"
+)]
+pub use connection::handshake::AuthMechanism;
+pub use connection::Connection;
 
 mod message_stream;
 pub use message_stream::*;


### PR DESCRIPTION
Now that we're down to only two authentication mechanisms with one of them being no-authentication, this really makes sense since we can just autodetect what authentication method to use for a specific socket type on a specific platform.
    
This also simplifies the handshake logic and will allow us to pipeline the whole client-side handshake in the future, when we can drop the xdg-dbus-proxy [workarounds].
    
As they say in the famous Queen song:
    
    Hey! One man, one goal
    Ha, one mission
    One heart, one soul
    Just one solution
    One flash of light
    Yeah, one God, one vision
    
    One flesh, one bone, one true religion
    One voice, one hope, one real decision
    Whoa, whoa, whoa, whoa, whoa, whoa
    Give me one vision, yeah
    
Fixes #731.
    
[workarounds]: https://github.com/dbus2/zbus/issues/781
