### PR TITLE
🛂 zb: Use string type for auth mechanisms in Rejected cmd

### DIFF
--- a/zbus/src/connection/handshake/auth_mechanism.rs
+++ b/zbus/src/connection/handshake/auth_mechanism.rs
@@ -26,12 +26,18 @@ pub enum AuthMechanism {
     Anonymous,
 }
 
-impl fmt::Display for AuthMechanism {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mech = match self {
+impl AuthMechanism {
+    pub fn as_str(&self) -> &'static str {
+        match self {
             AuthMechanism::External => "EXTERNAL",
             AuthMechanism::Anonymous => "ANONYMOUS",
-        };
+        }
+    }
+}
+
+impl fmt::Display for AuthMechanism {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mech = self.as_str();
         write!(f, "{mech}")
     }
 }

--- a/zbus/src/connection/handshake/client.rs
+++ b/zbus/src/connection/handshake/client.rs
@@ -96,11 +96,7 @@ impl Client {
                 Ok(())
             }
             Command::Rejected(accepted) => {
-                let list = accepted
-                    .iter()
-                    .map(|m| m.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let list = accepted.replace(" ", ", ");
                 Err(Error::Handshake(format!(
                     "{mechanism} rejected by the server. Accepted mechanisms: [{list}]"
                 )))

--- a/zbus/src/connection/handshake/server.rs
+++ b/zbus/src/connection/handshake/server.rs
@@ -102,7 +102,7 @@ impl Server {
 
     #[instrument(skip(self))]
     async fn rejected_error(&mut self) -> Result<()> {
-        let cmd = Command::Rejected(vec![self.common.mechanism()]);
+        let cmd = Command::Rejected(self.common.mechanism().as_str().into());
         trace!("Sending authentication error");
         self.common.write_command(cmd).await?;
         self.step = ServerHandshakeStep::WaitingForAuth;


### PR DESCRIPTION
Now that we don't support all authentication mechanisms described in the spec, we'll get a parse error on receiving an unsupported mechanism. Let's use the raw string type for the mechanism field in the Rejected command to avoid this.

We do so in a way that limits allocations, especially on the server-side, which might need to reject a lot of connections and it will have more impact there.