### PR TITLE
`blocking` & `Guid::generate` now feature-gated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,6 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
  "futures-util",
  "hex",
  "nix 0.29.0",

--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -11,6 +11,10 @@ in panics and hangs. This is not a limitation of zbus but rather a
 [well-known general problem][wkgp] in the Rust async/await world. The [`blocking` crate],
 [`async-std`][assb] and [`tokio`][tsb] crates provide a easy way around this problem.
 
+**Note:** Since zbus 5.0, blocking API can be disabled through the `blocking-api` cargo feature. If
+you use this API, make sure you are not unintentionally disabling it by disabling the default
+features in your `Cargo.toml`.
+
 ## Establishing a connection
 
 The only difference to that of [asynchronous `Connection` API] is that you use

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -25,7 +25,7 @@ camino = ["zvariant/camino"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
 bus-impl = ["p2p"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
-p2p = []
+p2p = ["dep:rand"]
 async-io = [
   "dep:async-io",
   "async-executor",
@@ -56,7 +56,7 @@ futures-util = { version = "0.3.30", default-features = false, features = [
 async-broadcast = "0.7.0"
 hex = "0.4.3"
 ordered-stream = "0.2"
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 event-listener = "5.3.0"
 static_assertions = "1.1.0"
 async-trait = "0.1.80"

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -38,6 +38,8 @@ async-io = [
 tokio = ["dep:tokio"]
 vsock = ["dep:vsock", "dep:async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
+# Enable blocking API (default).
+blocking-api = ["zbus_macros/blocking-api"]
 
 [dependencies]
 zbus_macros = { path = "../zbus_macros", version = "=4.4.0" }

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -49,7 +49,6 @@ serde = { version = "1.0.200", features = ["derive"] }
 serde_repr = "0.1.19"
 enumflags2 = { version = "0.7.9", features = ["serde"] }
 futures-core = "0.3.30"
-futures-sink = "0.3.30"
 futures-util = { version = "0.3.30", default-features = false, features = [
   "sink",
   "std",

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -98,7 +98,8 @@ async fn main() -> Result<()> {
 ## Blocking API
 
 While zbus is primarily asynchronous (since 2.0), [blocking wrappers][bw] are provided for
-convenience.
+convenience. Since zbus 5.0, blocking API can be disabled by disabling the `blocking-api` cargo
+feature.
 
 ## Compatibility with async runtimes
 

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -224,7 +224,16 @@ impl Connection {
     ///
     /// The `ObjectServer` is created on-demand.
     pub fn object_server(&self) -> impl Deref<Target = ObjectServer> + '_ {
-        self.inner.sync_object_server(true, None)
+        struct Wrapper(ObjectServer);
+        impl Deref for Wrapper {
+            type Target = ObjectServer;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        Wrapper(ObjectServer::new(&self.inner))
     }
 
     /// Get a reference to the underlying async Connection.

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -5,6 +5,8 @@
 //! asynchronous counterparts on the underlying types and use [`async_io::block_on`] (or
 //! [`tokio::runtime::Runtime::block_on`]) to turn them into blocking calls.
 //!
+//! This module is only available when the `blocking-api` feature is enabled (default).
+//!
 //! # Caveats
 //!
 //! Since methods provided by these types run their own little runtime (`block_on`), you must not

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! This module hosts all our blocking API. All the types under this module are thin wrappers
 //! around the corresponding asynchronous types. Most of the method calls are simply calling their
-//! asynchronous counterparts on the underlying types and use [`async_io::block_on`] to turn them
-//! into blocking calls.
+//! asynchronous counterparts on the underlying types and use [`async_io::block_on`] (or
+//! [`tokio::runtime::Runtime::block_on`]) to turn them into blocking calls.
 //!
 //! # Caveats
 //!

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -138,7 +138,7 @@ impl ObjectServer {
     /// Create a new D-Bus `ObjectServer`.
     pub(crate) fn new(conn: &crate::Connection) -> Self {
         Self {
-            azync: crate::ObjectServer::new(conn),
+            azync: conn.object_server().clone(),
         }
     }
 

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -127,7 +127,7 @@ where
 /// quit_listener.wait();
 /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectServer {
     azync: crate::ObjectServer,
 }

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -423,11 +423,10 @@ impl<'a> Builder<'a> {
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));
 
         if !self.interfaces.is_empty() {
-            let object_server = conn.sync_object_server(false, None);
+            let object_server = conn.ensure_object_server(false);
             for (path, interfaces) in self.interfaces {
                 for (name, iface) in interfaces {
                     let added = object_server
-                        .inner()
                         .add_arc_interface(path.clone(), name.clone(), iface.clone())
                         .await?;
                     if !added {

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1304,6 +1304,7 @@ impl Connection {
     }
 }
 
+#[cfg(feature = "blocking-api")]
 impl From<crate::blocking::Connection> for Connection {
     fn from(conn: crate::blocking::Connection) -> Self {
         conn.into_inner()

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1332,7 +1332,7 @@ impl From<crate::blocking::Connection> for Connection {
 }
 
 // Internal API that allows keeping a weak connection ref around.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct WeakConnection {
     inner: Weak<ConnectionInner>,
 }

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -362,4 +362,5 @@ pub trait DBus {
 }
 
 assert_impl_all!(DBusProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(DBusProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -36,4 +36,5 @@ impl Introspectable {
 }
 
 assert_impl_all!(IntrospectableProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(IntrospectableProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/monitoring.rs
+++ b/zbus/src/fdo/monitoring.rs
@@ -36,4 +36,5 @@ pub trait Monitoring {
 }
 
 assert_impl_all!(MonitoringProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(MonitoringProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -77,4 +77,5 @@ impl ObjectManager {
 }
 
 assert_impl_all!(ObjectManagerProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(ObjectManagerProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -44,4 +44,5 @@ impl Peer {
 }
 
 assert_impl_all!(PeerProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(PeerProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -125,4 +125,5 @@ impl Properties {
 }
 
 assert_impl_all!(PropertiesProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(PropertiesProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -31,4 +31,5 @@ pub trait Stats {
 }
 
 assert_impl_all!(StatsProxy<'_>: Send, Sync, Unpin);
+#[cfg(feature = "blocking-api")]
 assert_impl_all!(StatsProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -1,10 +1,8 @@
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
-    iter::repeat_with,
     ops::Deref,
     str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use serde::{de, Deserialize, Serialize};
@@ -27,9 +25,14 @@ assert_impl_all!(Guid<'_>: Send, Sync, Unpin);
 impl Guid<'_> {
     /// Generate a D-Bus GUID that can be used with e.g.
     /// [`connection::Builder::server`](crate::connection::Builder::server).
+    ///
+    /// This method is only available when the `p2p` feature is enabled (disabled by default).
+    #[cfg(feature = "p2p")]
     pub fn generate() -> Guid<'static> {
-        let r: Vec<u32> = repeat_with(rand::random::<u32>).take(3).collect();
-        let r3 = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        let r: Vec<u32> = std::iter::repeat_with(rand::random::<u32>)
+            .take(3)
+            .collect();
+        let r3 = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
             Ok(n) => n.as_secs() as u32,
             Err(_) => rand::random::<u32>(),
         };
@@ -245,6 +248,7 @@ impl Display for OwnedGuid {
 }
 
 #[cfg(test)]
+#[cfg(feature = "p2p")]
 mod tests {
     use crate::Guid;
     use test_log::test;

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -85,6 +85,7 @@ pub use utils::*;
 #[macro_use]
 pub mod fdo;
 
+#[cfg(feature = "blocking-api")]
 pub mod blocking;
 
 pub use zbus_macros::{interface, proxy, DBusError};

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -447,6 +447,7 @@ impl ObjectServer {
     }
 }
 
+#[cfg(feature = "blocking-api")]
 impl From<crate::blocking::ObjectServer> for ObjectServer {
     fn from(server: crate::blocking::ObjectServer) -> Self {
         server.into_inner()

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -88,10 +88,10 @@ pub(crate) use node::Node;
 /// # })?;
 /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectServer {
     conn: WeakConnection,
-    root: RwLock<Node>,
+    root: Arc<RwLock<Node>>,
 }
 
 assert_impl_all!(ObjectServer: Send, Sync, Unpin);
@@ -101,7 +101,9 @@ impl ObjectServer {
     pub(crate) fn new(conn: &Connection) -> Self {
         Self {
             conn: conn.into(),
-            root: RwLock::new(Node::new("/".try_into().expect("zvariant bug"))),
+            root: Arc::new(RwLock::new(Node::new(
+                "/".try_into().expect("zvariant bug"),
+            ))),
         }
     }
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1334,6 +1334,7 @@ impl AsyncDrop for SignalStream<'_> {
     }
 }
 
+#[cfg(feature = "blocking-api")]
 impl<'a> From<crate::blocking::Proxy<'a>> for Proxy<'a> {
     fn from(proxy: crate::blocking::Proxy<'a>) -> Self {
         proxy.into_inner()

--- a/zbus/src/utils.rs
+++ b/zbus/src/utils.rs
@@ -38,15 +38,18 @@ pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
 #[doc(hidden)]
 pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
     use std::sync::OnceLock;
+
     static TOKIO_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    let runtime = TOKIO_RT.get_or_init(|| {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .enable_time()
-            .build()
-            .expect("launch of single-threaded tokio runtime")
-    });
-    runtime.block_on(future)
+
+    TOKIO_RT
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .expect("launch of single-threaded tokio runtime")
+        })
+        .block_on(future)
 }
 
 // If we're running inside a Flatpak sandbox.

--- a/zbus/tests/issue/issue_173.rs
+++ b/zbus/tests/issue/issue_173.rs
@@ -1,10 +1,11 @@
-use std::sync::mpsc::channel;
+use async_broadcast::{broadcast, Receiver};
 
+use futures_util::StreamExt;
 use ntest::timeout;
 use test_log::test;
 use zbus::block_on;
 
-use zbus::{blocking, object_server::SignalEmitter};
+use zbus::object_server::SignalEmitter;
 
 #[test]
 #[timeout(15000)]
@@ -13,30 +14,38 @@ fn issue_173() {
     //
     // The issue is caused by proxy not keeping track of its destination's owner changes
     // (service restart) and failing to receive signals as a result.
-    let (tx, rx) = channel();
+    let (tx, rx) = broadcast(16);
     let child = std::thread::spawn(move || {
-        let conn = blocking::Connection::session().unwrap();
-        #[zbus::proxy(
-            interface = "org.freedesktop.zbus.ComeAndGo",
-            default_service = "org.freedesktop.zbus.ComeAndGo",
-            default_path = "/org/freedesktop/zbus/ComeAndGo"
-        )]
-        trait ComeAndGo {
-            #[zbus(signal)]
-            fn the_signal(&self) -> zbus::Result<()>;
-        }
+        block_on(async move {
+            let conn = zbus::Connection::session().await.unwrap();
+            #[zbus::proxy(
+                interface = "org.freedesktop.zbus.ComeAndGo",
+                default_service = "org.freedesktop.zbus.ComeAndGo",
+                default_path = "/org/freedesktop/zbus/ComeAndGo"
+            )]
+            trait ComeAndGo {
+                #[zbus(signal)]
+                fn the_signal(&self) -> zbus::Result<()>;
+            }
 
-        let proxy = ComeAndGoProxyBlocking::new(&conn).unwrap();
-        let signals = proxy.receive_the_signal().unwrap();
-        tx.send(()).unwrap();
+            let proxy = ComeAndGoProxy::new(&conn).await.unwrap();
+            let mut signals = proxy.receive_the_signal().await.unwrap().take(2);
+            tx.broadcast_direct(()).await.unwrap();
 
-        // We receive two signals, each time from different unique names. W/o the fix for
-        // issue#173, the second iteration hangs.
-        for _ in signals.take(2) {
-            tx.send(()).unwrap();
-        }
+            // We receive two signals, each time from different unique names. W/o the fix for
+            // issue#173, the second iteration hangs.
+            while let Some(_) = signals.next().await {
+                tx.broadcast_direct(()).await.unwrap();
+            }
+        })
     });
 
+    zbus::block_on(issue_173_async(rx));
+
+    child.join().unwrap();
+}
+
+async fn issue_173_async(mut rx: Receiver<()>) {
     struct ComeAndGo;
     #[zbus::interface(name = "org.freedesktop.zbus.ComeAndGo")]
     impl ComeAndGo {
@@ -44,29 +53,33 @@ fn issue_173() {
         async fn the_signal(signal_emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
     }
 
-    rx.recv().unwrap();
+    rx.recv().await.unwrap();
     for _ in 0..2 {
-        let conn = blocking::connection::Builder::session()
+        let conn = zbus::connection::Builder::session()
             .unwrap()
             .serve_at("/org/freedesktop/zbus/ComeAndGo", ComeAndGo)
             .unwrap()
             .name("org.freedesktop.zbus.ComeAndGo")
             .unwrap()
             .build()
+            .await
             .unwrap();
 
         let iface_ref = conn
             .object_server()
             .interface::<_, ComeAndGo>("/org/freedesktop/zbus/ComeAndGo")
+            .await
             .unwrap();
-        block_on(ComeAndGo::the_signal(iface_ref.signal_emitter())).unwrap();
+        ComeAndGo::the_signal(iface_ref.signal_emitter())
+            .await
+            .unwrap();
 
-        rx.recv().unwrap();
+        rx.recv().await.unwrap();
 
         // Now we release the name ownership to use a different connection (i-e new unique
         // name).
-        conn.release_name("org.freedesktop.zbus.ComeAndGo").unwrap();
+        conn.release_name("org.freedesktop.zbus.ComeAndGo")
+            .await
+            .unwrap();
     }
-
-    child.join().unwrap();
 }

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -1,6 +1,7 @@
 mod issue_1015;
 mod issue_104;
 mod issue_121;
+#[cfg(feature = "blocking-api")]
 mod issue_122;
 mod issue_173;
 mod issue_260;

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -16,6 +16,11 @@ license = "MIT"
 categories = ["data-structures", "encoding", "parsing"]
 readme = "README.md"
 
+[features]
+default = []
+# Enable blocking API.
+blocking-api = ["zbus/blocking-api"]
+
 [lib]
 proc-macro = true
 

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -41,8 +41,8 @@ mod utils;
 ///
 /// * `gen_async` - Whether or not to generate the asynchronous Proxy type.
 ///
-/// * `gen_blocking` - Whether or not to generate the blocking Proxy type. If set to `false`, the
-///   asynchronous proxy type will take the name `TraitNameProxy` (i-e no `Async` prefix).
+/// * `gen_blocking` - Whether or not to generate the blocking Proxy type. If the `blocking-api`
+///   cargo feature is disabled, this attribute is ignored and blocking Proxy type is not generated.
 ///
 /// * `async_name` - Specify the exact name of the asynchronous proxy type.
 ///

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -74,7 +74,10 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, input: ItemTrait) -> Result<Tok
         )),
     }?;
     let gen_async = attrs.gen_async.unwrap_or(true);
+    #[cfg(feature = "blocking-api")]
     let gen_blocking = attrs.gen_blocking.unwrap_or(true);
+    #[cfg(not(feature = "blocking-api"))]
+    let gen_blocking = false;
 
     // Some sanity checks
     assert!(

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -25,7 +25,7 @@ name = "zbus-xmlgen"
 path = "src/main.rs"
 
 [dependencies]
-zbus = { path = "../zbus", version = "4.0.0" }
+zbus = { path = "../zbus", version = "4.0.0", features = ["blocking-api"] }
 zbus_xml = { path = "../zbus_xml", version = "4.0.0" }
 zvariant = { path = "../zvariant", version = "4" }
 snakecase = "0.1.0"


### PR DESCRIPTION
Since a lot of people don't need the `blocking` wrappers, let's provide a way to disable it through a new cargo feature, `blocking-api`. This feature is enabled by default.

Also, since `Guid::generate` is only useful for peer-to-peer and bus implementations, it is now gated behind the `p2p` feature. This essentially means that it's now disabled for most folks and we drop a dep on `rand` crate for them.