### PR TITLE
⚡️ zb: Drop unneeded boxing of a future

### DIFF
--- a/zbus/src/connection/connect/mod.rs
+++ b/zbus/src/connection/connect/mod.rs
@@ -1,4 +1,3 @@
-use std::{future::Future, pin::Pin};
 use tracing::debug;
 
 use crate::{
@@ -28,37 +27,33 @@ pub(crate) async fn connect_address(
     Err(Error::Address("No connectable address".into()))
 }
 
-fn connect(
-    addr: &Address<'_>,
-) -> Pin<Box<dyn Future<Output = ConnectResult> + Send + Sync + 'static>> {
+async fn connect(addr: &Address<'_>) -> ConnectResult {
     let addr = addr.to_owned();
-    Box::pin(async move {
-        let guid = match addr.guid() {
-            Some(g) => Some(Guid::try_from(g.as_ref())?.into()),
-            _ => None,
-        };
-        let split = match addr.transport()? {
-            Transport::Tcp(t) => socket::tcp::connect(&t).await?.into(),
-            Transport::NonceTcp(t) => socket::tcp::connect_nonce(&t).await?.into(),
-            #[cfg(any(unix, not(feature = "tokio")))]
-            Transport::Unix(u) => socket::unix::connect(&u).await?.into(),
-            #[cfg(any(
-                all(feature = "vsock", not(feature = "tokio")),
-                feature = "tokio-vsock"
-            ))]
-            Transport::Vsock(v) => socket::vsock::connect(&v).await?.into(),
-            #[cfg(target_os = "macos")]
-            Transport::Launchd(l) => macos::connect(&l).await?.into(),
-            #[cfg(target_os = "windows")]
-            Transport::Autolaunch(l) => {
-                return win32::connect(&l).await;
-            }
-            _ => {
-                return Err(Error::Address(format!("Unhandled address: {}", addr)));
-            }
-        };
-        Ok((split, guid))
-    })
+    let guid = match addr.guid() {
+        Some(g) => Some(Guid::try_from(g.as_ref())?.into()),
+        _ => None,
+    };
+    let split = match addr.transport()? {
+        Transport::Tcp(t) => socket::tcp::connect(&t).await?.into(),
+        Transport::NonceTcp(t) => socket::tcp::connect_nonce(&t).await?.into(),
+        #[cfg(any(unix, not(feature = "tokio")))]
+        Transport::Unix(u) => socket::unix::connect(&u).await?.into(),
+        #[cfg(any(
+            all(feature = "vsock", not(feature = "tokio")),
+            feature = "tokio-vsock"
+        ))]
+        Transport::Vsock(v) => socket::vsock::connect(&v).await?.into(),
+        #[cfg(target_os = "macos")]
+        Transport::Launchd(l) => macos::connect(&l).await?.into(),
+        #[cfg(target_os = "windows")]
+        Transport::Autolaunch(l) => {
+            return win32::connect(&l).await;
+        }
+        _ => {
+            return Err(Error::Address(format!("Unhandled address: {}", addr)));
+        }
+    };
+    Ok((split, guid))
 }
 
 type ConnectResult = Result<(BoxedSplit, Option<OwnedGuid>)>;

--- a/zbus/src/connection/connect/win32.rs
+++ b/zbus/src/connection/connect/win32.rs
@@ -1,28 +1,31 @@
 #![cfg(target_os = "windows")]
 
-use super::BoxedSplit;
+use super::ConnectResult;
 use crate::{
     address::{transport::Transport, Address},
     win32::autolaunch_bus_address,
-    Error, OwnedGuid, Result,
+    Error,
 };
+use std::{future::Future, pin::Pin};
 
-pub(crate) async fn connect(
-    l: &crate::address::transport::Autolaunch<'_>,
-) -> Result<(BoxedSplit, Option<OwnedGuid>)> {
-    if l.scope().is_some() {
-        return Err(Error::Address(
-            "autolaunch with scope isn't supported yet".into(),
-        ));
-    }
+pub(crate) fn connect<'l>(
+    l: &'l crate::address::transport::Autolaunch<'_>,
+) -> Pin<Box<dyn Future<Output = ConnectResult> + 'l>> {
+    Box::pin(async move {
+        if l.scope().is_some() {
+            return Err(Error::Address(
+                "autolaunch with scope isn't supported yet".into(),
+            ));
+        }
 
-    let addr: Address<'_> = autolaunch_bus_address()?.try_into()?;
+        let addr: Address<'_> = autolaunch_bus_address()?.try_into()?;
 
-    if let Transport::Autolaunch(_) = addr.transport()? {
-        return Err(Error::Address("Recursive autolaunch: address".into()));
-    }
+        if let Transport::Autolaunch(_) = addr.transport()? {
+            return Err(Error::Address("Recursive autolaunch: address".into()));
+        }
 
-    super::connect(&addr).await
+        super::connect(&addr).await
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Only box the internal future, where recursion happens and hence boxing is needed (only on Windows).