### PR TITLE
🚸 zb: Message body signature now mandatory

### DIFF
--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -12,12 +12,12 @@ use crate::{Error, Message, Result};
 pub struct Body {
     data: Data<'static, 'static>,
     msg: Message,
-    signature: Option<Signature>,
+    signature: Signature,
 }
 
 impl Body {
     pub(super) fn new(data: Data<'static, 'static>, msg: Message) -> Self {
-        let body_sig = msg.header().signature().cloned();
+        let body_sig = msg.header().signature().clone();
 
         Self {
             data,
@@ -31,15 +31,11 @@ impl Body {
     where
         B: zvariant::DynamicDeserialize<'s>,
     {
-        let body_sig = self
-            .msg
-            .header()
-            .signature()
-            .cloned()
-            .unwrap_or(Signature::Unit);
+        let header = self.msg.header();
+        let body_sig = header.signature();
 
         self.data
-            .deserialize_for_dynamic_signature(&body_sig)
+            .deserialize_for_dynamic_signature(body_sig)
             .map_err(Error::from)
             .map(|b| b.0)
     }
@@ -53,8 +49,8 @@ impl Body {
     }
 
     /// The signature of the body.
-    pub fn signature(&self) -> Option<&Signature> {
-        self.signature.as_ref()
+    pub fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     /// The length of the body in bytes.

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -231,9 +231,7 @@ impl<'a> Builder<'a> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 
-        if !matches!(signature, Signature::Unit) {
-            header.fields_mut().signature = Some(signature);
-        }
+        header.fields_mut().signature = signature;
 
         let body_len_u32 = body_size.size().try_into().map_err(|_| Error::ExcessData)?;
         header.primary_mut().set_body_len(body_len_u32);
@@ -287,7 +285,7 @@ impl<'m> From<Header<'m>> for Builder<'m> {
     fn from(mut header: Header<'m>) -> Self {
         // Signature and Fds are added by body* methods.
         let fields = header.fields_mut();
-        fields.signature = None;
+        fields.signature = Signature::Unit;
         fields.unix_fds = None;
 
         Self { header }

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -313,8 +313,8 @@ impl<'m> Header<'m> {
     }
 
     /// The signature of the message body.
-    pub fn signature(&self) -> Option<&Signature> {
-        self.fields.signature.as_ref()
+    pub fn signature(&self) -> &Signature {
+        &self.fields.signature
     }
 
     /// The number of Unix file descriptors that accompany the message.
@@ -332,7 +332,7 @@ mod tests {
     use std::error::Error;
     use test_log::test;
     use zbus_names::{InterfaceName, MemberName};
-    use zvariant::ObjectPath;
+    use zvariant::{ObjectPath, Signature};
 
     #[test]
     fn header() -> Result<(), Box<dyn Error>> {
@@ -354,14 +354,14 @@ mod tests {
         assert_eq!(h.destination(), None);
         assert_eq!(h.reply_serial(), None);
         assert_eq!(h.sender().unwrap(), ":1.84");
-        assert_eq!(h.signature(), None);
+        assert_eq!(h.signature(), &Signature::Unit);
         assert_eq!(h.unix_fds(), None);
 
         let mut f = Fields::new();
         f.error_name = Some("org.zbus.Error".try_into()?);
         f.destination = Some(":1.11".try_into()?);
         f.reply_serial = Some(88.try_into()?);
-        f.signature = Some("say".try_into().unwrap());
+        f.signature = "say".try_into().unwrap();
         f.unix_fds = Some(12);
         let h = Header::new(PrimaryHeader::new(Type::MethodReturn, 77), f);
 
@@ -373,7 +373,7 @@ mod tests {
         assert_eq!(h.destination().unwrap(), ":1.11");
         assert_eq!(h.reply_serial().map(Into::into), Some(88));
         assert_eq!(h.sender(), None);
-        assert_eq!(h.signature(), Some(&"say".try_into().unwrap()));
+        assert_eq!(h.signature(), &Signature::try_from("say").unwrap());
         assert_eq!(h.unix_fds(), Some(12));
 
         Ok(())

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -176,7 +176,7 @@ impl Message {
             reply_serial: quick_fields.reply_serial(),
             destination: quick_fields.destination(self),
             sender: quick_fields.sender(self),
-            signature: quick_fields.signature().cloned(),
+            signature: quick_fields.signature().clone(),
             unix_fds: quick_fields.unix_fds(),
         };
 
@@ -271,8 +271,11 @@ impl fmt::Debug for Message {
         if let Some(member) = h.member() {
             msg.field("member", &member);
         }
-        if let Some(s) = self.body().signature() {
-            msg.field("body", &s);
+        match self.body().signature() {
+            zvariant::Signature::Unit => (),
+            s => {
+                msg.field("body", &s);
+            }
         }
         #[cfg(unix)]
         {
@@ -358,7 +361,7 @@ mod tests {
             .unwrap();
         #[cfg(unix)]
         assert_eq!(
-            m.body().signature().unwrap(),
+            m.body().signature(),
             &Signature::static_structure(&[&Signature::Fd, &Signature::Str]),
         );
         #[cfg(not(unix))]

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -144,7 +144,7 @@ fn freedesktop_api() {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| s == "u").unwrap());
+    assert_eq!(body.signature(), u32::SIGNATURE);
     let reply: RequestNameReply = body.deserialize().unwrap();
     assert_eq!(reply, RequestNameReply::PrimaryOwner);
 
@@ -159,7 +159,7 @@ fn freedesktop_api() {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| <&str>::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), <&str>::SIGNATURE);
     let id: &str = body.deserialize().unwrap();
     debug!("Unique ID of the bus: {}", id);
 
@@ -174,7 +174,7 @@ fn freedesktop_api() {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| bool::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), bool::SIGNATURE);
     assert!(body.deserialize::<bool>().unwrap());
 
     let reply = connection
@@ -188,7 +188,7 @@ fn freedesktop_api() {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| <&str>::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), <&str>::SIGNATURE);
     assert_eq!(
         body.deserialize::<UniqueName<'_>>().unwrap(),
         *connection.unique_name().unwrap(),
@@ -205,7 +205,7 @@ fn freedesktop_api() {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| s == "a{sv}").unwrap());
+    assert_eq!(body.signature(), "a{sv}");
     let hashmap: HashMap<&str, OwnedValue> = body.deserialize().unwrap();
 
     let pid: u32 = (&hashmap["ProcessID"]).try_into().unwrap();
@@ -243,7 +243,7 @@ async fn test_freedesktop_api() -> Result<()> {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| s == "u").unwrap());
+    assert_eq!(body.signature(), u32::SIGNATURE);
     let reply: RequestNameReply = body.deserialize().unwrap();
     assert_eq!(reply, RequestNameReply::PrimaryOwner);
 
@@ -259,7 +259,7 @@ async fn test_freedesktop_api() -> Result<()> {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| <&str>::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), <&str>::SIGNATURE);
     let id: &str = body.deserialize().unwrap();
     debug!("Unique ID of the bus: {}", id);
 
@@ -275,7 +275,7 @@ async fn test_freedesktop_api() -> Result<()> {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| bool::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), bool::SIGNATURE);
     assert!(body.deserialize::<bool>().unwrap());
 
     let reply = connection
@@ -290,7 +290,7 @@ async fn test_freedesktop_api() -> Result<()> {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| <&str>::SIGNATURE == s).unwrap());
+    assert_eq!(body.signature(), <&str>::SIGNATURE);
     assert_eq!(
         body.deserialize::<UniqueName<'_>>().unwrap(),
         *connection.unique_name().unwrap(),
@@ -308,7 +308,7 @@ async fn test_freedesktop_api() -> Result<()> {
         .unwrap();
 
     let body = reply.body();
-    assert!(body.signature().map(|s| s == "a{sv}").unwrap());
+    assert_eq!(body.signature(), "a{sv}");
     let hashmap: HashMap<&str, OwnedValue> = body.deserialize().unwrap();
 
     let pid: u32 = (&hashmap["ProcessID"]).try_into().unwrap();

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -144,7 +144,7 @@ impl MyIface {
         #[zbus(header)] header: Header<'_>,
     ) -> zbus::fdo::Result<()> {
         debug!("`TestSingleStructArg` called.");
-        assert_eq!(header.signature().unwrap(), "(is)");
+        assert_eq!(header.signature(), "(is)");
         assert_eq!(arg.foo, 1);
         assert_eq!(arg.bar, "TestString");
 

--- a/zvariant_utils/src/signature/mod.rs
+++ b/zvariant_utils/src/signature/mod.rs
@@ -38,7 +38,7 @@ use crate::serialized::Format;
 /// ```
 ///
 /// [`zvariant::Signature`]: https://docs.rs/zvariant/latest/zvariant/struct.Signature.html
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum Signature {
     // Basic types
     /// The signature for the unit type (`()`). This is not a valid D-Bus signature, but is used to
@@ -50,6 +50,7 @@ pub enum Signature {
     /// This variant only exists for convenience and must only be used as a top-level signature. If
     /// used inside container signatures, it will cause errors and in somce cases, panics. It's
     /// best to not use it directly.
+    #[default]
     Unit,
     /// The signature for an 8-bit unsigned integer (AKA a byte).
     U8,


### PR DESCRIPTION
We have a Signature variant the represents empty body, Unit and since the spec says:
    
> If omitted, it is assumed to be the empty signature "" (i.e. the body
> must be 0-length).
    
it makes sense to simply assume `Signature::Unit` when the signature is missing from the message headers.
    
We do ensure that we don't serialize `Signature::Unit`.
