### PR TITLE
🩹 zb: Fix missing cfg(blocking-api)

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -154,3 +154,8 @@ bench = false
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[[example]]
+name = "screen-brightness"
+path = "examples/screen-brightness.rs"
+required-features = ["blocking-api"]

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -24,6 +24,7 @@ mod doctests {
     doc_comment::doctest!("../../book/src/contributors.md");
     doc_comment::doctest!("../../book/src/introduction.md");
     doc_comment::doctest!("../../book/src/service.md");
+    #[cfg(feature = "blocking-api")]
     doc_comment::doctest!("../../book/src/blocking.md");
     doc_comment::doctest!("../../book/src/faq.md");
 }


### PR DESCRIPTION
"cargo build" in zbus/zbus (with default features) fails, there are missing cfg conditions.