### PR TITLE
🚩 zb: Add `blocking-api` to default features

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io"]
+default = ["async-io", "blocking-api"]
 uuid = ["zvariant/uuid"]
 url = ["zvariant/url"]
 time = ["zvariant/time"]


### PR DESCRIPTION
This was supposed to be a default feature, I had just forgotten to add it.
