### PR TITLE
🩹 zx: Set visibility of generated proxy to pub

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -167,7 +167,7 @@ impl<'i> GenTrait<'i> {
             write!(w, ", assume_defaults = true")?;
         }
         writeln!(w, ")]")?;
-        writeln!(w, "trait {name} {{")?;
+        writeln!(w, "pub trait {name} {{")?;
 
         let mut methods = iface.methods().to_vec();
         methods.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -1,5 +1,5 @@
 #[proxy(interface = "com.example.SampleInterface0", assume_defaults = true)]
-trait SampleInterface0 {
+pub trait SampleInterface0 {
     /// BarplexSig method
     fn barplex_sig(
         &self,


### PR DESCRIPTION
This was the default visibility until `proxy` macro started to respect the visibility of the input trait. Let's set it to `pub` by default as that's what most folks will likely want. If not, they can easily modify it.