### PR TITLE
👷 CI: Update zbus version for book generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deployments
 on:
   push:
     tags:
-      - zbus-4.*
+      - zbus-5.*
     paths:
       - book/**/*
       - .github/workflows/deploy.yml

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -30,8 +30,6 @@ The [zbus crate] provides the main API you will use to interact with D-Bus from 
 of the establishment of a connection, the creation, sending and receiving of different kind of D-Bus
 messages (method calls, signals etc) for you.
 
-zbus crate is currently Unix-specific, with Linux as our main (and tested) target.
-
 [zbus]: https://github.com/dbus2/zbus
 [Rust]: https://www.rust-lang.org/
 [D-Bus]: https://dbus.freedesktop.org/


### PR DESCRIPTION
Also remove disclaimer about zbus being unix-specific as its not been true for a long time.