### PR TITLE
⚡️ zu: Switch from `nom` to `winnow` for signature parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,12 +961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,16 +1004,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2247,7 +2231,6 @@ dependencies = [
 name = "zvariant_utils"
 version = "3.0.0"
 dependencies = [
- "nom",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -2253,5 +2253,6 @@ dependencies = [
  "serde",
  "static_assertions",
  "syn 2.0.82",
+ "winnow 0.6.20",
  "zvariant",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heapless"
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1209,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -1701,40 +1701,29 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -2064,15 +2053,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
@@ -2236,6 +2216,6 @@ dependencies = [
  "serde",
  "static_assertions",
  "syn 2.0.82",
- "winnow 0.6.20",
+ "winnow",
  "zvariant",
 ]

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -28,7 +28,7 @@ proc-macro = true
 proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.36"
-proc-macro-crate = "3.1.0"
+proc-macro-crate = "3.2.0"
 zvariant_utils = { path = "../zvariant_utils", version = "=3.0.0" }
 
 [dev-dependencies]

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1192,7 +1192,7 @@ mod tests {
             let gv_ser_value_encoded =
                 zvariant::to_bytes(ctxt, &zvariant::SerializeValue(&map)).unwrap();
             let gv_value_encoded = to_bytes(ctxt, &zvariant::Value::new(map)).unwrap();
-            assert_eq!(gv_value_encoded.as_ref(), gv_ser_value_encoded.as_ref());
+            assert_eq!(*gv_value_encoded, *gv_ser_value_encoded);
 
             // Check encoding against GLib
             let bytes = Bytes::from_owned(gv_encoded);

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -24,7 +24,7 @@ gvariant = ["zvariant_utils/gvariant", "zvariant/gvariant"]
 proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "full"] }
 quote = "1.0.36"
-proc-macro-crate = "3.1.0"
+proc-macro-crate = "3.2.0"
 zvariant_utils = { path = "../zvariant_utils", version = "=3.0.0" }
 
 [dev-dependencies]

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -26,6 +26,7 @@ quote = "1.0.36"
 static_assertions = "1.1.0"
 serde = "1.0.200"
 nom = "7"
+winnow = "0.6"
 
 [dev-dependencies]
 zvariant = { path = "../zvariant" }

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -25,7 +25,6 @@ syn = { version = "2.0.64", features = ["extra-traits", "full"] }
 quote = "1.0.36"
 static_assertions = "1.1.0"
 serde = "1.0.200"
-nom = "7"
 winnow = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
This brings in 2 benefits:
    
* The signature parsing code is now up to 30% faster. This directly translates to encoding/decoding speed of variants (used extensively in the D-Bus/gvariant world). This is the path that saw the least optimization in 5.0.0.
    
* Removal of `nom` and `minimal-lexical` deps (recently introduced in 5.0.0). Apparently `winnow` was already our indirect dependency so no new deps needed.
