### PR TITLE
🔖  zvariant_utils release 3.0.1, and zvariant and zbus 5.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "arrayvec",
  "camino",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "enumflags2",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zbus"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "async-io",
  "futures-util",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zbus"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
 rust-version = "1.81"
@@ -44,7 +44,7 @@ blocking-api = ["zbus_macros/blocking-api"]
 serde_bytes = ["zvariant/serde_bytes"]
 
 [dependencies]
-zbus_macros = { path = "../zbus_macros", version = "=5.0.0" }
+zbus_macros = { path = "../zbus_macros", version = "=5.0.1" }
 zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, features = [
   "enumflags2",
 ] }

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zbus_macros"
 # Keep version in sync with zbus crate
-version = "5.0.0"
+version = "5.0.1"
 authors = [
     "Marc-André Lureau <marcandre.lureau@redhat.com>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "fold", "full"] }
 quote = "1.0.36"
 proc-macro-crate = "3.2.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=3.0.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "3.0.0" }
 
 [dev-dependencies]
 zbus = { path = "../zbus" }

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -23,7 +23,7 @@ camino = ["dep:camino"]
 
 [dependencies]
 zvariant_derive = { version = "=5.0.0", path = "../zvariant_derive" }
-zvariant_utils = { version = "=3.0.0", path = "../zvariant_utils" }
+zvariant_utils = { version = "3.0.0", path = "../zvariant_utils" }
 endi = "1.1.0"
 serde = { version = "1.0.200", features = ["derive"] }
 static_assertions = "1.1.0"

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
 rust-version = "1.81"
@@ -22,7 +22,7 @@ option-as-array = []
 camino = ["dep:camino"]
 
 [dependencies]
-zvariant_derive = { version = "=5.0.0", path = "../zvariant_derive" }
+zvariant_derive = { version = "=5.0.1", path = "../zvariant_derive" }
 zvariant_utils = { version = "3.0.0", path = "../zvariant_utils" }
 endi = "1.1.0"
 serde = { version = "1.0.200", features = ["derive"] }

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "full"] }
 quote = "1.0.36"
 proc-macro-crate = "3.2.0"
-zvariant_utils = { path = "../zvariant_utils", version = "=3.0.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "3.0.0" }
 
 [dev-dependencies]
 zvariant = { path = "../zvariant", features = ["enumflags2"] }

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zvariant_derive"
 # Keep major and minor version in sync with zvariant crate
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
 rust-version = "1.81"

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant_utils"
-version = "3.0.0"
+version = "3.0.1"
 authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",


### PR DESCRIPTION
Also release zvariant and zbus to stop pinning zvariant_utils version.