### PR TITLE
zm: Don't generate signals for interface const properties

### DIFF
--- a/zbus/tests/issue/issue_310.rs
+++ b/zbus/tests/issue/issue_310.rs
@@ -59,10 +59,6 @@ async fn issue_310() {
             {
                 let iface = iface_ref.get().await;
                 iface
-                    .connected_network_invalidate(iface_ref.signal_emitter())
-                    .await
-                    .unwrap();
-                iface
                     .connected_network_changed(iface_ref.signal_emitter())
                     .await
                     .unwrap();


### PR DESCRIPTION
Because they never change.

Currently the following
```rust
pub struct AccessInterface {}

#[zbus::interface(name = "org.freedesktop.impl.portal.Access")]
impl AccessInterface {
    #[zbus(property(emits_changed_signal = "const"), name = "version")]
    fn version(&self) -> u32 {
        1
    }
}
```

Would generate a `version_changed` and a `version_invalidate` even if the property never changes. 

This is current situation https://bilelmoussaoui.github.io/ashpd/ashpd/backend/account/struct.AccountInterface.html and with the changes proposed in this PR, the problem is fixed.