### PR TITLE
Use `winnow` for parsing all strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "time",
  "url",
  "uuid",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,6 +2141,7 @@ version = "4.0.0"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow",
  "zvariant",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
 name = "zbus_names"
 version = "4.0.0"
 dependencies = [
+ "criterion",
  "serde",
  "static_assertions",
  "winnow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "uds_windows",
  "vsock 0.5.1",
  "windows-sys 0.59.0",
+ "winnow",
  "xdg-home",
  "zbus_macros",
  "zbus_names",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -66,6 +66,7 @@ static_assertions = "1.1.0"
 async-trait = "0.1.80"
 xdg-home = "1.1.0"
 tracing = "0.1.40"
+winnow = "0.6"
 
 # Optional and target-specific dependencies.
 

--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -107,5 +107,28 @@ impl<'s> BigBoy<'s> {
     }
 }
 
-criterion_group!(benches, msg_ser, msg_de);
+fn address_parse(c: &mut Criterion) {
+    const UNIX_ADDRESS: &'static str = "unix:path=/tmp/dbus/long/loooooooong/path/to/socket\
+        /so/we/need/to/keeeeeeeeeep/going/where/no/man/has/gone/before,runtime=yes,\
+        guid=0123456789ABCDEF0123456789ABCDEF";
+    const TCP_ADDRESS: &'static str = "tcp:host=some.looong.name.so.we.must.keep.going.on.and.on.\
+        on,port=1234,family=ipv4,guid=0123456789ABCDEF0123456789ABCDEF";
+
+    let mut group = c.benchmark_group("parse_dbus_address");
+    group.sample_size(1000);
+
+    group.bench_function("unix", |b| {
+        b.iter(|| {
+            zbus::Address::try_from(black_box(UNIX_ADDRESS)).unwrap();
+        })
+    });
+
+    group.bench_function("tcp", |b| {
+        b.iter(|| {
+            zbus::Address::try_from(black_box(TCP_ADDRESS)).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, msg_ser, msg_de, address_parse);
 criterion_main!(benches);

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -248,12 +248,12 @@ impl Display for OwnedGuid {
 }
 
 #[cfg(test)]
-#[cfg(feature = "p2p")]
 mod tests {
     use crate::Guid;
     use test_log::test;
 
     #[test]
+    #[cfg(feature = "p2p")]
     fn generate() {
         let u1 = Guid::generate();
         let u2 = Guid::generate();
@@ -261,5 +261,15 @@ mod tests {
         assert_eq!(u2.as_str().len(), 32);
         assert_ne!(u1, u2);
         assert_ne!(u1.as_str(), u2.as_str());
+    }
+
+    #[test]
+    fn parse() {
+        let valid = "0123456789ABCDEF0123456789ABCDEF";
+        // Not 32 chars.
+        let invalid = "0123456789ABCDEF0123456789ABCD";
+
+        assert!(Guid::try_from(valid).is_ok());
+        assert!(Guid::try_from(invalid).is_err());
     }
 }

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -134,11 +134,12 @@ impl<'de> Deserialize<'de> for Guid<'de> {
 }
 
 fn validate_guid(value: &str) -> crate::Result<()> {
-    if value.as_bytes().len() != 32 || value.chars().any(|c| !char::is_ascii_hexdigit(&c)) {
-        return Err(crate::Error::InvalidGUID);
-    }
+    use winnow::{stream::AsChar, token::take_while, Parser};
 
-    Ok(())
+    take_while::<_, _, ()>(32, AsChar::is_hex_digit)
+        .map(|_| ())
+        .parse(value.as_bytes())
+        .map_err(|_| crate::Error::InvalidGUID)
 }
 
 impl From<Guid<'_>> for String {

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -25,4 +25,3 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true
-

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -18,6 +18,7 @@ zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, 
     "enumflags2",
 ] }
 static_assertions = "1.1.0"
+winnow = "0.6"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -20,6 +20,16 @@ zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, 
 static_assertions = "1.1.0"
 winnow = "0.6"
 
+[dev-dependencies]
+criterion = "0.5.1"
+
+[lib]
+bench = false
+
+[[bench]]
+name = "benchmarks"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]

--- a/zbus_names/benches/benchmarks.rs
+++ b/zbus_names/benches/benchmarks.rs
@@ -1,0 +1,58 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn name_parse(c: &mut Criterion) {
+    const WELL_KNOWN_NAME: &'static str = "a.very.loooooooooooooooooo-ooooooo_0000o0ng.Name.\
+            That.Is.Valid.For.DBus.and_good.For.benchmarks.I-guess";
+    const UNIQUE_NAME: &'static str = ":a.very.loooooooooooooooooo-ooooooo_0000o0ng.Name.\
+            That.Is.Valid.For.DBus.and_good.For.benchmarks.I-guess";
+    const INTERFACE_NAME: &'static str = "a.very.loooooooooooooooooo_ooooooo_0000o0ng.Name.\
+            That.Is.Valid.For.DBus.and_good.For.benchmarks.I_guess";
+    const MEMBER_NAME: &'static str = "a_very_loooooooooooooooooo_ooooooo_0000o0ng_Name_\
+            That_Is_Valid_For_DBus_and_good_For_benchmarks_I_guess";
+
+    let mut group = c.benchmark_group("parse_name");
+    group.sample_size(1000);
+
+    group.bench_function("well_known", |b| {
+        b.iter(|| {
+            zbus_names::WellKnownName::try_from(black_box(WELL_KNOWN_NAME)).unwrap();
+        })
+    });
+
+    group.bench_function("unique", |b| {
+        b.iter(|| {
+            zbus_names::UniqueName::try_from(black_box(UNIQUE_NAME)).unwrap();
+        })
+    });
+
+    group.bench_function("bus", |b| {
+        b.iter(|| {
+            // Use a well-known name since the parser first tries unique name.
+            zbus_names::BusName::try_from(black_box(WELL_KNOWN_NAME)).unwrap();
+        })
+    });
+
+    group.bench_function("interface", |b| {
+        b.iter(|| {
+            zbus_names::InterfaceName::try_from(black_box(INTERFACE_NAME)).unwrap();
+        })
+    });
+
+    group.bench_function("error", |b| {
+        b.iter(|| {
+            // Error names follow the same rules are interface names.
+            zbus_names::ErrorName::try_from(black_box(INTERFACE_NAME)).unwrap();
+        })
+    });
+
+    group.bench_function("member", |b| {
+        b.iter(|| {
+            zbus_names::MemberName::try_from(black_box(MEMBER_NAME)).unwrap();
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, name_parse);
+criterion_main!(benches);

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -6,8 +6,8 @@ use core::{
 use std::{borrow::Cow, sync::Arc};
 
 use crate::{
-    utils::impl_str_basic, Error, OwnedUniqueName, OwnedWellKnownName, Result, UniqueName,
-    WellKnownName,
+    unique_name, utils::impl_str_basic, Error, OwnedUniqueName, OwnedWellKnownName, Result,
+    UniqueName, WellKnownName,
 };
 use serde::{de, Deserialize, Serialize};
 use static_assertions::assert_impl_all;
@@ -214,8 +214,8 @@ impl<'s> TryFrom<Str<'s>> for BusName<'s> {
     type Error = Error;
 
     fn try_from(value: Str<'s>) -> Result<Self> {
-        if value.starts_with(':') || value == "org.freedesktop.DBus" {
-            UniqueName::try_from(value).map(BusName::Unique)
+        if unique_name::validate_bytes(value.as_bytes()).is_ok() {
+            Ok(BusName::Unique(UniqueName(value)))
         } else {
             WellKnownName::try_from(value).map(BusName::WellKnown)
         }

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -70,7 +70,7 @@ impl<'name> ErrorName<'name> {
 
     /// Same as `try_from`, except it takes a `&'static str`.
     pub fn from_static_str(name: &'static str) -> Result<Self> {
-        ensure_correct_error_name(name)?;
+        validate(name)?;
         Ok(Self(Str::from_static(name)))
     }
 
@@ -150,67 +150,19 @@ impl<'de: 'name, 'name> Deserialize<'de> for ErrorName<'name> {
 impl_try_from! {
     ty: ErrorName<'s>,
     owned_ty: OwnedErrorName,
-    validate_fn: ensure_correct_error_name,
+    validate_fn: validate,
     try_from: [&'s str, String, Arc<str>, Cow<'s, str>, Str<'s>],
 }
 
-fn ensure_correct_error_name(name: &str) -> Result<()> {
-    // Rules
-    //
-    // * Only ASCII alphanumeric or `_`.
-    // * Must not begin with a `.`.
-    // * Must contain at least one `.`.
-    // * Each element must:
-    //   * not begin with a digit.
-    //   * be 1 character (so name must be minimum 3 characters long).
-    // * <= 255 characters.
-    if name.len() < 3 {
-        return Err(Error::InvalidErrorName(format!(
-            "`{}` is {} characters long, which is smaller than minimum allowed (3)",
-            name,
-            name.len(),
-        )));
-    } else if name.len() > 255 {
-        return Err(Error::InvalidErrorName(format!(
-            "`{}` is {} characters long, which is longer than maximum allowed (255)",
-            name,
-            name.len(),
-        )));
-    }
-
-    let mut prev = None;
-    let mut no_dot = true;
-    for c in name.chars() {
-        if c == '.' {
-            if prev.is_none() || prev == Some('.') {
-                return Err(Error::InvalidErrorName(String::from(
-                    "must not contain a double `.`",
-                )));
-            }
-
-            if no_dot {
-                no_dot = false;
-            }
-        } else if c.is_ascii_digit() && (prev.is_none() || prev == Some('.')) {
-            return Err(Error::InvalidErrorName(String::from(
-                "each element must not start with a digit",
-            )));
-        } else if !c.is_ascii_alphanumeric() && c != '_' {
-            return Err(Error::InvalidErrorName(format!(
-                "`{c}` character not allowed"
-            )));
-        }
-
-        prev = Some(c);
-    }
-
-    if no_dot {
-        return Err(Error::InvalidErrorName(String::from(
-            "must contain at least 1 `.`",
-        )));
-    }
-
-    Ok(())
+fn validate(name: &str) -> Result<()> {
+    // Error names follow the same rules as interface names.
+    crate::interface_name::validate_bytes(name.as_bytes()).map_err(|_| {
+        Error::InvalidErrorName(
+            "Invalid error name. See \
+            https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-error"
+                .to_string(),
+        )
+    })
 }
 
 /// This never succeeds but is provided so it's easier to pass `Option::None` values for API

--- a/zbus_names/src/property_name.rs
+++ b/zbus_names/src/property_name.rs
@@ -152,12 +152,6 @@ impl_try_from! {
 }
 
 fn ensure_correct_property_name(name: &str) -> Result<()> {
-    // Rules
-    //
-    // * Only ASCII alphanumeric or `_`.
-    // * Must not begin with a digit.
-    // * Must contain at least 1 character.
-    // * <= 255 characters.
     if name.is_empty() {
         return Err(Error::InvalidPropertyName(format!(
             "`{}` is {} characters long, which is smaller than minimum allowed (1)",

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -38,7 +38,7 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 #[derive(
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
-pub struct UniqueName<'name>(Str<'name>);
+pub struct UniqueName<'name>(pub(crate) Str<'name>);
 
 assert_impl_all!(UniqueName<'_>: Send, Sync, Unpin);
 
@@ -152,7 +152,7 @@ fn validate(name: &str) -> Result<()> {
     })
 }
 
-fn validate_bytes(bytes: &[u8]) -> std::result::Result<(), ()> {
+pub(crate) fn validate_bytes(bytes: &[u8]) -> std::result::Result<(), ()> {
     use winnow::{
         combinator::{alt, separated},
         stream::AsChar,

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -65,7 +65,7 @@ impl<'name> UniqueName<'name> {
 
     /// Same as `try_from`, except it takes a `&'static str`.
     pub fn from_static_str(name: &'static str) -> Result<Self> {
-        ensure_correct_unique_name(name)?;
+        validate(name)?;
         Ok(Self(Str::from_static(name)))
     }
 
@@ -142,67 +142,43 @@ impl<'de: 'name, 'name> Deserialize<'de> for UniqueName<'name> {
     }
 }
 
-fn ensure_correct_unique_name(name: &str) -> Result<()> {
+fn validate(name: &str) -> Result<()> {
+    validate_bytes(name.as_bytes()).map_err(|_| {
+        Error::InvalidUniqueName(
+            "Invalid unique name. \
+            See https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus"
+            .to_string(),
+        )
+    })
+}
+
+fn validate_bytes(bytes: &[u8]) -> std::result::Result<(), ()> {
+    use winnow::{
+        combinator::{alt, separated},
+        stream::AsChar,
+        token::take_while,
+        Parser,
+    };
     // Rules
     //
     // * Only ASCII alphanumeric, `_` or '-'
     // * Must begin with a `:`.
     // * Must contain at least one `.`.
+    // * Each element must be 1 character (so name must be minimum 4 characters long).
     // * <= 255 characters.
-    if name.is_empty() {
-        return Err(Error::InvalidUniqueName(String::from(
-            "must contain at least 4 characters",
-        )));
-    } else if name.len() > 255 {
-        return Err(Error::InvalidUniqueName(format!(
-            "`{}` is {} characters long, which is longer than maximum allowed (255)",
-            name,
-            name.len(),
-        )));
-    } else if name == "org.freedesktop.DBus" {
-        // Bus itself uses its well-known name as its unique name.
-        return Ok(());
-    }
+    let element = take_while::<_, _, ()>(1.., (AsChar::is_alphanum, b'_', b'-'));
+    let peer_name = (b':', (separated(2.., element, b'.'))).map(|_: (_, ())| ());
+    let bus_name = b"org.freedesktop.DBus".map(|_| ());
+    let mut unique_name = alt((bus_name, peer_name));
 
-    // SAFETY: Just checked above that we've at least 1 character.
-    let mut chars = name.chars();
-    let mut prev = match chars.next().expect("no first char") {
-        first @ ':' => first,
-        _ => {
-            return Err(Error::InvalidUniqueName(String::from(
-                "must start with a `:`",
-            )));
-        }
-    };
-
-    let mut no_dot = true;
-    for c in chars {
-        if c == '.' {
-            if prev == '.' {
-                return Err(Error::InvalidUniqueName(String::from(
-                    "must not contain a double `.`",
-                )));
-            }
-
-            if no_dot {
-                no_dot = false;
-            }
-        } else if !c.is_ascii_alphanumeric() && c != '_' && c != '-' {
-            return Err(Error::InvalidUniqueName(format!(
-                "`{c}` character not allowed"
-            )));
+    unique_name.parse(bytes).map_err(|_| ()).and_then(|_: ()| {
+        // Least likely scenario so we check this last.
+        if bytes.len() > 255 {
+            return Err(());
         }
 
-        prev = c;
-    }
-
-    if no_dot {
-        return Err(Error::InvalidUniqueName(String::from(
-            "must contain at least 1 `.`",
-        )));
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 /// This never succeeds but is provided so it's easier to pass `Option::None` values for API
@@ -290,7 +266,7 @@ impl From<UniqueName<'_>> for OwnedUniqueName {
 impl_try_from! {
     ty: UniqueName<'s>,
     owned_ty: OwnedUniqueName,
-    validate_fn: ensure_correct_unique_name,
+    validate_fn: validate,
     try_from: [&'s str, String, Arc<str>, Cow<'s, str>, Str<'s>],
 }
 

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -27,6 +27,7 @@ zvariant_utils = { version = "3.0.0", path = "../zvariant_utils" }
 endi = "1.1.0"
 serde = { version = "1.0.200", features = ["derive"] }
 static_assertions = "1.1.0"
+winnow = "0.6"
 
 # Optional dependencies
 

--- a/zvariant/benches/benchmarks.rs
+++ b/zvariant/benches/benchmarks.rs
@@ -148,6 +148,17 @@ fn signature_parse(c: &mut Criterion) {
     });
 }
 
+fn object_path_parse(c: &mut Criterion) {
+    const PATH: &'static str = "/a/very/very_very/veeeeeeeeeeeeeery/long/long_long/long/long/\
+        _/long_path/to_test_parsing_of/paths/you/see";
+
+    c.bench_function("object_path_parse", |b| {
+        b.iter(|| {
+            zvariant::ObjectPath::try_from(black_box(PATH)).unwrap();
+        })
+    });
+}
+
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug, Clone)]
 struct BigArrayField<'f> {
     int2: u64,
@@ -183,8 +194,15 @@ criterion_group!(
     big_array,
     byte_array,
     fixed_size_array,
-    signature_parse
+    signature_parse,
+    object_path_parse
 );
 #[cfg(not(feature = "serde_bytes"))]
-criterion_group!(benches, big_array, fixed_size_array, signature_parse);
+criterion_group!(
+    benches,
+    big_array,
+    fixed_size_array,
+    signature_parse,
+    object_path_parse
+);
 criterion_main!(benches);

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -66,6 +66,8 @@ pub enum Error {
     SignatureParse(crate::signature::Error),
     /// Attempted to create an empty structure (which is not allowed by the D-Bus specification).
     EmptyStructure,
+    /// Invalid object path.
+    InvalidObjectPath,
 }
 
 assert_impl_all!(Error: Send, Sync, Unpin);
@@ -124,6 +126,7 @@ impl fmt::Display for Error {
             Error::MaxDepthExceeded(max) => write!(f, "{max}"),
             Error::SignatureParse(e) => write!(f, "{e}"),
             Error::EmptyStructure => write!(f, "Attempted to create an empty structure"),
+            Error::InvalidObjectPath => write!(f, "Invalid object path"),
         }
     }
 }
@@ -148,6 +151,7 @@ impl Clone for Error {
             Error::MaxDepthExceeded(max) => Error::MaxDepthExceeded(*max),
             Error::SignatureParse(e) => Error::SignatureParse(*e),
             Error::EmptyStructure => Error::EmptyStructure,
+            Error::InvalidObjectPath => Error::InvalidObjectPath,
         }
     }
 }

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -75,7 +75,7 @@ impl<'a> ObjectPath<'a> {
 
     /// Same as `try_from`, except it takes a `&'static str`.
     pub fn from_static_str(name: &'static str) -> Result<Self> {
-        ensure_correct_object_path_str(name.as_bytes())?;
+        validate(name.as_bytes())?;
 
         Ok(Self::from_static_str_unchecked(name))
     }
@@ -133,7 +133,7 @@ impl<'a> TryFrom<&'a [u8]> for ObjectPath<'a> {
     type Error = Error;
 
     fn try_from(value: &'a [u8]) -> Result<Self> {
-        ensure_correct_object_path_str(value)?;
+        validate(value)?;
 
         // SAFETY: ensure_correct_object_path_str checks UTF-8
         unsafe { Ok(Self::from_bytes_unchecked(value)) }
@@ -153,7 +153,7 @@ impl<'a> TryFrom<String> for ObjectPath<'a> {
     type Error = Error;
 
     fn try_from(value: String) -> Result<Self> {
-        ensure_correct_object_path_str(value.as_bytes())?;
+        validate(value.as_bytes())?;
 
         Ok(Self::from_string_unchecked(value))
     }
@@ -246,9 +246,8 @@ impl<'de> Visitor<'de> for ObjectPathVisitor {
     }
 }
 
-fn ensure_correct_object_path_str(path: &[u8]) -> Result<()> {
-    let mut prev = b'\0';
-
+fn validate(path: &[u8]) -> Result<()> {
+    use winnow::{combinator::separated, stream::AsChar, token::take_while, Parser};
     // Rules
     //
     // * At least 1 character.
@@ -256,38 +255,12 @@ fn ensure_correct_object_path_str(path: &[u8]) -> Result<()> {
     // * No trailing `/`
     // * No `//`
     // * Only ASCII alphanumeric, `_` or '/'
-    if path.is_empty() {
-        return Err(serde::de::Error::invalid_length(0, &"> 0 character"));
-    }
 
-    for i in 0..path.len() {
-        let c = path[i];
+    let allowed_chars = (AsChar::is_alphanum, b'_');
+    let name = take_while::<_, _, ()>(1.., allowed_chars);
+    let mut full_path = (b'/', separated(0.., name, b'/')).map(|_: (u8, ())| ());
 
-        if i == 0 && c != b'/' {
-            return Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Char(c as char),
-                &"/",
-            ));
-        } else if c == b'/' && prev == b'/' {
-            return Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str("//"),
-                &"/",
-            ));
-        } else if path.len() > 1 && i == (path.len() - 1) && c == b'/' {
-            return Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Char('/'),
-                &"an alphanumeric character or `_`",
-            ));
-        } else if !c.is_ascii_alphanumeric() && c != b'/' && c != b'_' {
-            return Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Char(c as char),
-                &"an alphanumeric character, `_` or `/`",
-            ));
-        }
-        prev = c;
-    }
-
-    Ok(())
+    full_path.parse(path).map_err(|_| Error::InvalidObjectPath)
 }
 
 /// Owned [`ObjectPath`](struct.ObjectPath.html)


### PR DESCRIPTION
Since winnow is now our dependency, it'd be best to make full use of that everywhere and use it to verify/parse all string types: zbus_names::*, zvariant::ObjectPath, zbus::Address etc.

Fixes  #1070.

---

TODO:

* Replace `from_options` constructors of all address transport types with winnow parsers, we can use in the `FromStr` impl of `Address`.
* Escape (% decode) all values in address strings as part of the winnow parser upfront. 