### PR TITLE
🤖 renovate: Only major and minor version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,24 @@
 {
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "commitMessagePrefix": "⬆️  "
     },
     {
-      "matchManagers": ["cargo"],
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
       "commitMessagePrefix": "⬆️  ",
       "commitMessageTopic": "{{depName}}",
-      "lockFileMaintenance": { "enabled": true }
-    },
-    {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true,
-      "rebaseWhen": "conflicted"
+      "lockFileMaintenance": {
+        "enabled": true
+      }
     }
   ]
 }


### PR DESCRIPTION
We're a library so micro and nano versions don't really affect our users and renovating creating PRs for every single release of all deps create a lot of noise.

This also means that we can now disable automerge, since they were only enalbed for micro and nano versions.