### PR TITLE
⬇️ all: Reduce `rust-version` to `1.80`

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus"
 version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "API for D-Bus communication"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "proc-macros for zbus"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_names"
 version = "4.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "A collection of D-Bus bus names types"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_xml"
 version = "5.0.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "API to handle D-Bus introspection XML"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "D-Bus XML interface code generator"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -3,7 +3,7 @@ name = "zvariant"
 version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -4,7 +4,7 @@ name = "zvariant_derive"
 version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "turbocooler <turbocooler@cocaine.ninja>",
 ]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.80"
 
 description = "Various utilities used internally by the zvariant crate."
 repository = "https://github.com/dbus2/zbus/"


### PR DESCRIPTION
Require a slightly older and slightly more universally available Rust release. Rust 1.81 doesn't seem to have many features that zbus would likely need.

Fixes https://github.com/dbus2/zbus/issues/1107.