### PR TITLE
Revert "🤖 renovate: Only major and minor version updates"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,24 +1,19 @@
 {
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "commitMessagePrefix": "⬆️  "
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
+      "matchManagers": ["cargo"],
       "commitMessagePrefix": "⬆️  ",
       "commitMessageTopic": "{{depName}}",
-      "lockFileMaintenance": {
-        "enabled": true
-      }
+      "lockFileMaintenance": { "enabled": true }
+    },
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true,
+      "rebaseWhen": "conflicted"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 9db949a194ade49a209c6776539b47b900a8e7c0.

Turns out this wasn't the way to skip micro and nano updates. It only skipped our custom title for such updates instead. 🤦 I gotta find a way to do this right.