### PR TITLE
🚸 zn: Streamline Error API

### DIFF
--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -227,7 +227,9 @@ impl<'s> TryFrom<BusName<'s>> for WellKnownName<'s> {
 
     fn try_from(value: BusName<'s>) -> Result<Self> {
         match value {
-            BusName::Unique(name) => Err(Error::InvalidWellKnownName(name.to_string())),
+            BusName::Unique(_) => Err(Error::InvalidName(
+                "Invalid conversion from UniqueName to WellKnownName",
+            )),
             BusName::WellKnown(name) => Ok(name),
         }
     }
@@ -239,7 +241,9 @@ impl<'s> TryFrom<BusName<'s>> for UniqueName<'s> {
     fn try_from(value: BusName<'s>) -> Result<Self> {
         match value {
             BusName::Unique(name) => Ok(name),
-            BusName::WellKnown(name) => Err(Error::InvalidUniqueName(name.to_string())),
+            BusName::WellKnown(_) => Err(Error::InvalidName(
+                "Invalid conversion from WellKnownName to UniqueName",
+            )),
         }
     }
 }

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -227,9 +227,10 @@ impl<'s> TryFrom<BusName<'s>> for WellKnownName<'s> {
 
     fn try_from(value: BusName<'s>) -> Result<Self> {
         match value {
-            BusName::Unique(_) => Err(Error::InvalidName(
-                "Invalid conversion from UniqueName to WellKnownName",
-            )),
+            BusName::Unique(_) => Err(Error::InvalidNameConversion {
+                from: "UniqueName",
+                to: "WellKnownName",
+            }),
             BusName::WellKnown(name) => Ok(name),
         }
     }
@@ -241,9 +242,10 @@ impl<'s> TryFrom<BusName<'s>> for UniqueName<'s> {
     fn try_from(value: BusName<'s>) -> Result<Self> {
         match value {
             BusName::Unique(name) => Ok(name),
-            BusName::WellKnown(_) => Err(Error::InvalidName(
-                "Invalid conversion from WellKnownName to UniqueName",
-            )),
+            BusName::WellKnown(_) => Err(Error::InvalidNameConversion {
+                from: "WellKnownName",
+                to: "UniqueName",
+            }),
         }
     }
 }

--- a/zbus_names/src/error.rs
+++ b/zbus_names/src/error.rs
@@ -61,6 +61,11 @@ pub enum Error {
     InvalidErrorName(String),
     /// An invalid name.
     InvalidName(&'static str),
+    /// Invalid conversion from name type `from` to name type `to`.
+    InvalidNameConversion {
+        from: &'static str,
+        to: &'static str,
+    },
 }
 
 assert_impl_all!(Error: Send, Sync, Unpin);
@@ -77,6 +82,7 @@ impl PartialEq for Error {
             (Self::InvalidPropertyName(_), Self::InvalidPropertyName(_)) => true,
             (Self::InvalidErrorName(_), Self::InvalidErrorName(_)) => true,
             (Self::InvalidName(_), Self::InvalidName(_)) => true,
+            (Self::InvalidNameConversion { .. }, Self::InvalidNameConversion { .. }) => true,
             (Self::Variant(s), Self::Variant(o)) => s == o,
             (_, _) => false,
         }
@@ -95,6 +101,7 @@ impl error::Error for Error {
             Error::InvalidMemberName(_) => None,
             Error::InvalidPropertyName(_) => None,
             Error::InvalidName(_) => None,
+            Error::InvalidNameConversion { .. } => None,
             Error::Variant(e) => Some(e),
         }
     }
@@ -118,6 +125,9 @@ impl fmt::Display for Error {
             Error::InvalidMemberName(s) => write!(f, "Invalid method or signal name: {s}"),
             Error::InvalidPropertyName(s) => write!(f, "Invalid property name: {s}"),
             Error::InvalidName(s) => write!(f, "{s}"),
+            Error::InvalidNameConversion { from, to } => {
+                write!(f, "Invalid conversion from `{from}` to `{to}`")
+            }
         }
     }
 }

--- a/zbus_names/src/error.rs
+++ b/zbus_names/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     InvalidPropertyName(String),
     /// Invalid error name.
     InvalidErrorName(String),
+    /// An invalid name.
+    InvalidName(&'static str),
 }
 
 assert_impl_all!(Error: Send, Sync, Unpin);
@@ -38,6 +40,7 @@ impl PartialEq for Error {
             (Self::InvalidMemberName(_), Self::InvalidMemberName(_)) => true,
             (Self::InvalidPropertyName(_), Self::InvalidPropertyName(_)) => true,
             (Self::InvalidErrorName(_), Self::InvalidErrorName(_)) => true,
+            (Self::InvalidName(_), Self::InvalidName(_)) => true,
             (Self::Variant(s), Self::Variant(o)) => s == o,
             (_, _) => false,
         }
@@ -54,6 +57,7 @@ impl error::Error for Error {
             Error::InvalidErrorName(_) => None,
             Error::InvalidMemberName(_) => None,
             Error::InvalidPropertyName(_) => None,
+            Error::InvalidName(_) => None,
             Error::Variant(e) => Some(e),
         }
     }
@@ -75,6 +79,7 @@ impl fmt::Display for Error {
             Error::InvalidErrorName(s) => write!(f, "Invalid interface or error name: {s}"),
             Error::InvalidMemberName(s) => write!(f, "Invalid method or signal name: {s}"),
             Error::InvalidPropertyName(s) => write!(f, "Invalid property name: {s}"),
+            Error::InvalidName(s) => write!(f, "{s}"),
         }
     }
 }

--- a/zbus_names/src/error.rs
+++ b/zbus_names/src/error.rs
@@ -11,18 +11,53 @@ pub enum Error {
     Variant(VariantError),
     /// Invalid bus name. The strings describe why the bus name is neither a valid unique nor
     /// well-known name, respectively.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidBusName(String, String),
     /// Invalid well-known bus name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidWellKnownName(String),
     /// Invalid unique bus name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidUniqueName(String),
     /// Invalid interface name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidInterfaceName(String),
     /// Invalid member (method or signal) name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidMemberName(String),
     /// Invalid property name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidPropertyName(String),
     /// Invalid error name.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This variant is no longer returned from any of our API.\
+                Use `Error::InvalidName` instead."
+    )]
     InvalidErrorName(String),
     /// An invalid name.
     InvalidName(&'static str),
@@ -31,6 +66,7 @@ pub enum Error {
 assert_impl_all!(Error: Send, Sync, Unpin);
 
 impl PartialEq for Error {
+    #[allow(deprecated)]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::InvalidBusName(_, _), Self::InvalidBusName(_, _)) => true,
@@ -48,6 +84,7 @@ impl PartialEq for Error {
 }
 
 impl error::Error for Error {
+    #[allow(deprecated)]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Error::InvalidBusName(_, _) => None,
@@ -64,6 +101,7 @@ impl error::Error for Error {
 }
 
 impl fmt::Display for Error {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Variant(e) => write!(f, "{e}"),

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -157,10 +157,9 @@ impl_try_from! {
 fn validate(name: &str) -> Result<()> {
     // Error names follow the same rules as interface names.
     crate::interface_name::validate_bytes(name.as_bytes()).map_err(|_| {
-        Error::InvalidErrorName(
+        Error::InvalidName(
             "Invalid error name. See \
-            https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-error"
-                .to_string(),
+            https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-error",
         )
     })
 }

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -160,10 +160,9 @@ impl<'name> From<InterfaceName<'name>> for Str<'name> {
 
 fn validate(name: &str) -> Result<()> {
     validate_bytes(name.as_bytes()).map_err(|_| {
-        Error::InvalidInterfaceName(
+        Error::InvalidName(
             "Invalid interface name. See \
             https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-interface"
-            .to_string(),
         )
     })
 }

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -158,10 +158,9 @@ impl_try_from! {
 
 fn validate(name: &str) -> Result<()> {
     validate_bytes(name.as_bytes()).map_err(|_| {
-        Error::InvalidMemberName(
+        Error::InvalidName(
             "Invalid member name. See \
-            https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member"
-                .to_string(),
+            https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member",
         )
     })
 }

--- a/zbus_names/src/property_name.rs
+++ b/zbus_names/src/property_name.rs
@@ -153,17 +153,13 @@ impl_try_from! {
 
 fn ensure_correct_property_name(name: &str) -> Result<()> {
     if name.is_empty() {
-        return Err(Error::InvalidPropertyName(format!(
-            "`{}` is {} characters long, which is smaller than minimum allowed (1)",
-            name,
-            name.len(),
-        )));
+        return Err(Error::InvalidName(
+            "Invalid property name. It has to be at least 1 character long.",
+        ));
     } else if name.len() > 255 {
-        return Err(Error::InvalidPropertyName(format!(
-            "`{}` is {} characters long, which is longer than maximum allowed (255)",
-            name,
-            name.len(),
-        )));
+        return Err(Error::InvalidName(
+            "Invalid property name. It can not be longer than 255 characters.",
+        ));
     }
 
     Ok(())

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -144,10 +144,9 @@ impl<'de: 'name, 'name> Deserialize<'de> for UniqueName<'name> {
 
 fn validate(name: &str) -> Result<()> {
     validate_bytes(name.as_bytes()).map_err(|_| {
-        Error::InvalidUniqueName(
+        Error::InvalidName(
             "Invalid unique name. \
             See https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus"
-            .to_string(),
         )
     })
 }

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -145,10 +145,9 @@ impl<'de: 'name, 'name> Deserialize<'de> for WellKnownName<'name> {
 
 fn validate(name: &str) -> Result<()> {
     validate_bytes(name.as_bytes()).map_err(|_| {
-        Error::InvalidWellKnownName(
+        Error::InvalidName(
             "Invalid well-known name. \
             See https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus"
-            .to_string(),
         )
     })
 }


### PR DESCRIPTION
Let's deprecate specific name parsing errors in favor of one generic one that doesn't allocate. Also add a separate variant for name conversion errors as they're different from parsing errors.