### PR TITLE
🏷️ zv: Implement Clone for *Value

### DIFF
--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -283,6 +283,19 @@ impl<'de> Deserialize<'de> for OwnedValue {
     }
 }
 
+impl Clone for OwnedValue {
+    /// Clone the value.
+    ///
+    /// # Panics
+    ///
+    /// This method can only fail on Unix platforms for [`Value::Fd`] variant containing an
+    /// [`Fd::Owned`] variant. This happens when the current process exceeds the limit on maximum
+    /// number of open file descriptors.
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, error::Error};

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -974,6 +974,20 @@ impl<'a> TryFrom<&Value<'a>> for Value<'a> {
     }
 }
 
+impl Clone for Value<'_> {
+    /// Clone the value.
+    ///
+    /// # Panics
+    ///
+    /// This method can only fail on Unix platforms for [`Value::Fd`] variant containing an
+    /// [`Fd::Owned`] variant. This happens when the current process exceeds the limit on maximum
+    /// number of open file descriptors.
+    fn clone(&self) -> Self {
+        self.try_clone()
+            .expect("Process exceeded limit on maximum number of open file descriptors")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
While `try_clone` should generally be used, there are times when `Clone` is really needed. Given that the chances of `try_clone` failing are pretty low these days, let's implement `Clone` based on `try_clone` than panics on `try_clone` failure.

Fixes #1078.