### PR TITLE
⚡️ zm: interface allows to disable docs in introspection + do that for fdo interfaces

### DIFF
--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -15,6 +15,7 @@ pub(crate) struct Introspectable;
 
 #[interface(
     name = "org.freedesktop.DBus.Introspectable",
+    introspection_docs = false,
     proxy(default_path = "/", visibility = "pub")
 )]
 impl Introspectable {

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -32,7 +32,11 @@ pub type ManagedObjects =
 #[derive(Debug, Clone)]
 pub struct ObjectManager;
 
-#[interface(name = "org.freedesktop.DBus.ObjectManager", proxy(visibility = "pub"))]
+#[interface(
+    name = "org.freedesktop.DBus.ObjectManager",
+    introspection_docs = false,
+    proxy(visibility = "pub")
+)]
 impl ObjectManager {
     /// The return value of this method is a dict whose keys are object paths. All returned object
     /// paths are children of the object path implementing this interface, i.e. their object paths

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -12,7 +12,11 @@ pub(crate) struct Peer;
 /// Service-side implementation for the `org.freedesktop.DBus.Peer` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer](crate::ObjectServer).
-#[crate::interface(name = "org.freedesktop.DBus.Peer", proxy(visibility = "pub"))]
+#[crate::interface(
+    name = "org.freedesktop.DBus.Peer",
+    introspection_docs = false,
+    proxy(visibility = "pub")
+)]
 impl Peer {
     /// On receipt, an application should do nothing other than reply as usual. It does not matter
     /// which object path a ping is sent to.

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -18,7 +18,11 @@ pub struct Properties;
 
 assert_impl_all!(Properties: Send, Sync, Unpin);
 
-#[interface(name = "org.freedesktop.DBus.Properties", proxy(visibility = "pub"))]
+#[interface(
+    name = "org.freedesktop.DBus.Properties",
+    introspection_docs = false,
+    proxy(visibility = "pub")
+)]
 impl Properties {
     /// Get a property value.
     async fn get(

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -231,6 +231,10 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   supports all the [`macro@proxy`]-specific sub-attributes (e.g `gen_async`). The common
 ///   sub-attributes (e.g `name`) are automatically forworded to the [`macro@proxy`] macro.
 ///
+/// * `introspection_docs` - whether to include the documentation in the introspection data
+///   (Default: `true`). If your interface is well-known or well-documented, you may want to set
+///   this to `false` to reduce the the size of your binary and D-Bus traffic.
+///
 /// The methods accepts the `interface` attributes:
 ///
 /// * `name` - override the D-Bus name (pascal case form of the method by default)


### PR DESCRIPTION
Introspection strings are part of the binary and can have an impact on the binary size. This change allows to disable the addition of docs in the introspection for cases where there interface is well-known/well-documented.

For example, this will allow `busd` binary to shed 26 KB.