### PR TITLE
⚡️ zb: Don't use proxies in connection code

### DIFF
--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -324,6 +324,21 @@ impl<'m> MatchRule<'m> {
 
         Ok(true)
     }
+
+    pub(crate) fn fdo_signal_builder<S>(signal_name: S) -> Builder<'m>
+    where
+        S: TryInto<MemberName<'m>>,
+        S::Error: Into<Error>,
+    {
+        Builder::new()
+            .msg_type(Type::Signal)
+            .sender("org.freedesktop.DBus")
+            .unwrap()
+            .interface("org.freedesktop.DBus")
+            .unwrap()
+            .member(signal_name)
+            .unwrap()
+    }
 }
 
 impl Display for MatchRule<'_> {


### PR DESCRIPTION
This allows LTO to remove the proxy-side code from the binary if the users isn't directly using proxy APIs. On busd, this reduces the binary size by 200KB.