### PR TITLE
🚩 zm: Add `gvariant` feature flag

### DIFF
--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 default = []
 # Enable blocking API.
 blocking-api = ["zbus/blocking-api"]
+gvariant = ["zvariant/gvariant", "zvariant_utils/gvariant"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
It's just a proxy feature for zvariant and only needed to fix the build in the root workspace when building with `--features gvariant`.

Fixes #1125.
