### PR TITLE
🐛 zv: Allow f32::NAN to be decoded too

### DIFF
--- a/zvariant/src/dbus/de.rs
+++ b/zvariant/src/dbus/de.rs
@@ -188,7 +188,13 @@ impl<'de, 'd, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> de::Deseriali
             .endian()
             .read_f64(self.0.next_const_size_slice::<f64>()?);
 
-        visitor.visit_f32(f64_to_f32(v))
+        if v.is_finite() && v > (f32::MAX as f64) {
+            return Err(de::Error::invalid_value(
+                de::Unexpected::Float(v),
+                &"Too large for f32",
+            ));
+        }
+        visitor.visit_f32(v as f32)
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -2017,6 +2017,28 @@ mod tests {
         let _: ZVStruct<'_> = encoded.deserialize_for_signature(signature).unwrap().0;
     }
 
+    #[test]
+    fn issue_1145() {
+        // Ensure f32::NAN can be encoded and decoded.
+        let ctxt = Context::new_dbus(LE, 0);
+        {
+            let encoded = to_bytes(ctxt, &f32::NAN).unwrap();
+            let result: f32 = encoded.deserialize().unwrap().0;
+            assert!(result.is_nan());
+        }
+        // Ensure f32::INFINITY can be encoded and decoded.
+        {
+            let encoded = to_bytes(ctxt, &f32::INFINITY).unwrap();
+            let result: f32 = encoded.deserialize().unwrap().0;
+            assert!(result.is_infinite());
+        }
+        {
+            let encoded = to_bytes(ctxt, &f32::NEG_INFINITY).unwrap();
+            let result: f32 = encoded.deserialize().unwrap().0;
+            assert!(result.is_infinite());
+        }
+    }
+
     #[cfg(feature = "ostree-tests")]
     #[test]
     fn ostree_de() {

--- a/zvariant/src/utils.rs
+++ b/zvariant/src/utils.rs
@@ -66,12 +66,6 @@ pub(crate) fn usize_to_u8(value: usize) -> u8 {
     value as u8
 }
 
-pub(crate) fn f64_to_f32(value: f64) -> f32 {
-    assert!(value <= (f32::MAX as f64), "{} too large for `f32`", value,);
-
-    value as f32
-}
-
 /// Slice the given slice of bytes safely and return an error if the slice is too small.
 pub(crate) fn subslice<I, T>(input: &[T], index: I) -> Result<&I::Output>
 where


### PR DESCRIPTION
The range check would fail on NAN, INFINITY and NEG_INFINITY even if they are completely valid things to decode.

This does not promise that an encoded NAN will be bit-wise identical as the decoded NAN, but if signalling NAN is used that precisely the user can have a handful of more interesting problems.

Fixes #1145.