### PR TITLE
zb: allow direct access to message properties without allocating

### DIFF
--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -231,7 +231,7 @@ impl<'a> Builder<'a> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 
-        header.fields_mut().signature = signature;
+        header.fields_mut().signature = std::borrow::Cow::Owned(signature);
 
         let body_len_u32 = body_size.size().try_into().map_err(|_| Error::ExcessData)?;
         header.primary_mut().set_body_len(body_len_u32);
@@ -285,7 +285,7 @@ impl<'m> From<Header<'m>> for Builder<'m> {
     fn from(mut header: Header<'m>) -> Self {
         // Signature and Fds are added by body* methods.
         let fields = header.fields_mut();
-        fields.signature = Signature::Unit;
+        fields.signature = std::borrow::Cow::Owned(Signature::Unit);
         fields.unix_fds = None;
 
         Self { header }

--- a/zbus/src/message/fields.rs
+++ b/zbus/src/message/fields.rs
@@ -5,6 +5,7 @@ use serde::{
 };
 use static_assertions::assert_impl_all;
 use std::num::NonZeroU32;
+use std::borrow::Cow;
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, Signature, Type, Value};
 
@@ -23,7 +24,7 @@ pub(crate) struct Fields<'f> {
     pub reply_serial: Option<NonZeroU32>,
     pub destination: Option<BusName<'f>>,
     pub sender: Option<UniqueName<'f>>,
-    pub signature: Signature,
+    pub signature: Cow<'f, Signature>,
     pub unix_fds: Option<u32>,
 }
 
@@ -63,7 +64,7 @@ impl<'f> Serialize for Fields<'f> {
         if let Some(sender) = &self.sender {
             seq.serialize_element(&(FieldCode::Sender, Value::from(sender.as_str())))?;
         }
-        if !matches!(&self.signature, Signature::Unit) {
+        if self.signature != Cow::Borrowed(&Signature::Unit) {
             seq.serialize_element(&(FieldCode::Signature, SignatureSerializer(&self.signature)))?;
         }
         if let Some(unix_fds) = self.unix_fds {
@@ -149,7 +150,7 @@ impl<'de> Visitor<'de> for FieldsVisitor {
                     fields.sender = Some(UniqueName::try_from(value).map_err(V::Error::custom)?)
                 }
                 FieldCode::Signature => {
-                    fields.signature = Signature::try_from(value).map_err(V::Error::custom)?
+                    fields.signature = Cow::Owned(Signature::try_from(value).map_err(V::Error::custom)?)
                 }
                 FieldCode::UnixFDs => {
                     fields.unix_fds = Some(u32::try_from(value).map_err(V::Error::custom)?)

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -69,6 +69,27 @@ pub(super) struct Inner {
 assert_impl_all!(Message: Send, Sync, Unpin);
 
 impl Message {
+    pub fn into_body(self) -> Body {
+        Body::new(self.inner.bytes.slice(self.inner.body_offset..), self)
+    }
+    pub fn signature(&self) -> &zvariant::Signature {
+        self.quick_fields().signature()
+    }
+    pub fn interface(&self) -> Option<InterfaceName<'_>> {
+        self.quick_fields().interface(self)
+    }
+    pub fn member(&self) -> Option<MemberName<'_>> {
+        self.quick_fields().member(self)
+    }
+    pub fn path(&self) -> Option<zvariant::ObjectPath<'_>> {
+        self.quick_fields().path(self)
+    }
+    pub fn sender(&self) -> Option<zbus_names::UniqueName<'_>> {
+        self.quick_fields().sender(self)
+    }
+}
+
+impl Message {
     /// Create a builder for a message of type [`Type::MethodCall`].
     pub fn method_call<'b, 'p: 'b, 'm: 'b, P, M>(path: P, method_name: M) -> Result<Builder<'b>>
     where

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -197,7 +197,7 @@ impl Message {
             reply_serial: quick_fields.reply_serial(),
             destination: quick_fields.destination(self),
             sender: quick_fields.sender(self),
-            signature: quick_fields.signature().clone(),
+            signature: std::borrow::Cow::Borrowed(quick_fields.signature()),
             unix_fds: quick_fields.unix_fds(),
         };
 


### PR DESCRIPTION
- Creates a handful of new methods (there could potentially be a few more, too) that allow the user of `zbus` to directly access a reference to header properties without cloning the signature or the `PrimaryHeader`.
- Secondly, it allows you to consume the message in exchange for an owned `zbus::message::Body` type.

This increases performance relative to taking the cloned primary header and signature.
[`atspi`, branch = "deserialize-properly"](https://github.com/odilia-app/atspi/tree/deserialize-properly) can be cloned and `cargo bench` run to confirm these results.

Performance improvement for atspi is in the 30-50% range; I'll attach my benchmarks here for reference.

## `zbus-5.x` branch of atspi

```
     Running benches/event_parsing.rs (target/release/deps/event_parsing-08ab76e3e81624d0)
Gnuplot not found, using plotters backend
Benchmarking 1000 Messages into Events
Benchmarking 1000 Messages into Events: Warming up for 3.0000 s
Benchmarking 1000 Messages into Events: Collecting 100 samples in estimated 9.3177 s (10k iterations)
Benchmarking 1000 Messages into Events: Analyzing
1000 Messages into Events
                        time:   [923.37 µs 925.20 µs 927.12 µs]
                        change: [+109.91% +110.21% +110.52%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 21 outliers among 100 measurements (21.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  15 (15.00%) high severe

     Running benches/event_parsing_100k.rs (target/release/deps/event_parsing_100k-da6ad9ef4c4bfa68)
Gnuplot not found, using plotters backend
Benchmarking 100_000 Messages into Events
Benchmarking 100_000 Messages into Events: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, or reduce sample count to 50.
Benchmarking 100_000 Messages into Events: Collecting 100 samples in estimated 9.3435 s (100 iterations)
Benchmarking 100_000 Messages into Events: Analyzing
100_000 Messages into Events
                        time:   [93.347 ms 93.455 ms 93.579 ms]
                        change: [+136.69% +137.03% +137.44%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```

## `deserialize-properly` branch of atspi

```
     Running benches/event_parsing.rs (target/release/deps/event_parsing-a86e9ef1e3bf8bc7)
Gnuplot not found, using plotters backend
Benchmarking 1000 Messages into Events
Benchmarking 1000 Messages into Events: Warming up for 3.0000 s
Benchmarking 1000 Messages into Events: Collecting 100 samples in estimated 6.6050 s (15k iterations)
Benchmarking 1000 Messages into Events: Analyzing
1000 Messages into Events
                        time:   [434.71 µs 435.44 µs 436.31 µs]
                        change: [-52.873% -52.782% -52.699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high severe

     Running benches/event_parsing_100k.rs (target/release/deps/event_parsing_100k-74d92936c60bb4e4)
Gnuplot not found, using plotters backend
Benchmarking 100_000 Messages into Events
Benchmarking 100_000 Messages into Events: Warming up for 3.0000 s
Benchmarking 100_000 Messages into Events: Collecting 100 samples in estimated 7.5467 s (200 iterations)
Benchmarking 100_000 Messages into Events: Analyzing
100_000 Messages into Events
                        time:   [38.021 ms 38.071 ms 38.123 ms]
                        change: [-59.336% -59.263% -59.188%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking 100_000 Messages into Events (with header call)
Benchmarking 100_000 Messages into Events (with header call): Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
Benchmarking 100_000 Messages into Events (with header call): Collecting 100 samples in estimated 5.8684 s (100 iterations)
Benchmarking 100_000 Messages into Events (with header call): Analyzing
100_000 Messages into Events (with header call)
                        time:   [59.386 ms 59.432 ms 59.479 ms]

Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running unittests src/lib.rs (target/release/deps/atspi_common-d6719e5605143917)
```

Please let me know if there is a better way to implement this.
For example, an appropriate trait to use, or whether this is even something you want to support.

(Also, I know the commits/formatting might be wrong; that's why it's a draft)

Thanks for everything,
—Tait
