### PR TITLE
⚡️ zu: A few Signature micro optimizations

### DIFF
--- a/zvariant_utils/src/signature/child.rs
+++ b/zvariant_utils/src/signature/child.rs
@@ -14,7 +14,7 @@ static_assertions::assert_impl_all!(Child: Send, Sync, Unpin);
 
 impl Child {
     /// The underlying child `Signature`.
-    pub fn signature(&self) -> &Signature {
+    pub const fn signature(&self) -> &Signature {
         match self {
             Child::Static { child } => child,
             Child::Dynamic { child } => child,

--- a/zvariant_utils/src/signature/child.rs
+++ b/zvariant_utils/src/signature/child.rs
@@ -20,6 +20,11 @@ impl Child {
             Child::Dynamic { child } => child,
         }
     }
+
+    /// The length of the child signature in string form.
+    pub const fn string_len(&self) -> usize {
+        self.signature().string_len()
+    }
 }
 
 impl Deref for Child {

--- a/zvariant_utils/src/signature/fields.rs
+++ b/zvariant_utils/src/signature/fields.rs
@@ -40,7 +40,7 @@ impl Fields {
     }
 
     /// The number of fields.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         match self {
             Self::Static { fields } => fields.len(),
             Self::Dynamic { fields } => fields.len(),

--- a/zvariant_utils/src/signature/mod.rs
+++ b/zvariant_utils/src/signature/mod.rs
@@ -149,12 +149,24 @@ impl Signature {
 
     /// Convert `self` to a string, without any enclosing parenthesis.
     ///
-    /// This produces the same output as the `ToString::to_string`, unless `self` is a
+    /// This produces the same output as the [`Signature::to_string`], unless `self` is a
     /// [`Signature::Structure`], in which case the written string will **not** be wrapped in
     /// parenthesis (`()`).
     pub fn to_string_no_parens(&self) -> String {
         let mut s = String::with_capacity(self.string_len());
         self.write_as_string(&mut s, false).unwrap();
+
+        s
+    }
+
+    /// Convert `self` to a string.
+    ///
+    /// This produces the same output as the `ToString::to_string`, except it preallocates the
+    /// required memory and hence avoids reallocations and moving of data.
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.string_len());
+        self.write_as_string(&mut s, true).unwrap();
 
         s
     }

--- a/zvariant_utils/src/signature/mod.rs
+++ b/zvariant_utils/src/signature/mod.rs
@@ -101,7 +101,7 @@ pub enum Signature {
 
 impl Signature {
     /// The size of the string form of `self`.
-    pub fn string_len(&self) -> usize {
+    pub const fn string_len(&self) -> usize {
         match self {
             Signature::Unit => 0,
             Signature::U8
@@ -123,8 +123,13 @@ impl Signature {
             Signature::Dict { key, value } => 3 + key.string_len() + value.string_len(),
             Signature::Structure(fields) => {
                 let mut len = 2;
-                for field in fields.iter() {
-                    len += field.string_len();
+                let mut i = 0;
+                while i < fields.len() {
+                    len += match fields {
+                        Fields::Static { fields } => fields[i].string_len(),
+                        Fields::Dynamic { fields } => fields[i].string_len(),
+                    };
+                    i += 1;
                 }
                 len
             }

--- a/zvariant_utils/src/signature/tests.rs
+++ b/zvariant_utils/src/signature/tests.rs
@@ -11,6 +11,17 @@ macro_rules! validate {
                 let parsed = Signature::from_str($signature).unwrap();
                 assert_eq!(parsed, $expected);
                 assert_eq!(parsed, $signature);
+                match parsed {
+                    Signature::Structure(_) => {
+                        assert!(
+                            $signature.len() == parsed.string_len() - 2 ||
+                            $signature.len() == parsed.string_len()
+                        );
+                    }
+                    _ => {
+                        assert_eq!(parsed.string_len(), $signature.len());
+                    }
+                }
             )+
         };
     }


### PR DESCRIPTION
* Turn Signature's size methods `const`.
* Add `Signature::to_string` that shadows `ToString::to_string` implementation coming from `Display` impl, that avoids reallocations during the string serialization process.