### PR TITLE
✨ zb,zm: Support special args in interface property setters

### DIFF
--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -46,7 +46,7 @@ impl Properties {
             .instance
             .read()
             .await
-            .get(property_name, server, conn, &Some(header))
+            .get(property_name, server, conn, Some(&header))
             .await;
         res.unwrap_or_else(|| {
             Err(Error::UnknownProperty(format!(
@@ -74,12 +74,12 @@ impl Properties {
                 Error::UnknownInterface(format!("Unknown interface '{interface_name}'"))
             })?;
 
-        match iface.instance.read().await.set(
-            property_name,
-            &value,
-            &emitter,
-            &Some(header.clone()),
-        ) {
+        match iface
+            .instance
+            .read()
+            .await
+            .set(property_name, &value, &emitter, Some(&header))
+        {
             zbus::object_server::DispatchResult::RequiresMut => {}
             zbus::object_server::DispatchResult::NotFound => {
                 return Err(Error::UnknownProperty(format!(
@@ -94,7 +94,7 @@ impl Properties {
             .instance
             .write()
             .await
-            .set_mut(property_name, &value, &emitter, &Some(header))
+            .set_mut(property_name, &value, &emitter, Some(&header))
             .await;
         res.unwrap_or_else(|| {
             Err(Error::UnknownProperty(format!(
@@ -124,7 +124,7 @@ impl Properties {
             .instance
             .read()
             .await
-            .get_all(server, connection, &Some(header))
+            .get_all(server, connection, Some(&header))
             .await?;
         Ok(res)
     }

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -58,7 +58,7 @@ pub trait Interface: Any + Send + Sync {
         property_name: &str,
         server: &ObjectServer,
         connection: &Connection,
-        header: &Option<message::Header<'_>>,
+        header: Option<&message::Header<'_>>,
     ) -> Option<fdo::Result<OwnedValue>>;
 
     /// Return all the properties.
@@ -66,7 +66,7 @@ pub trait Interface: Any + Send + Sync {
         &self,
         object_server: &ObjectServer,
         connection: &Connection,
-        header: &Option<message::Header<'_>>,
+        header: Option<&message::Header<'_>>,
     ) -> fdo::Result<HashMap<String, OwnedValue>>;
 
     /// Set a property value.
@@ -79,7 +79,7 @@ pub trait Interface: Any + Send + Sync {
         property_name: &'call str,
         value: &'call Value<'_>,
         emitter: &'call SignalEmitter<'_>,
-        header: &'call Option<message::Header<'_>>,
+        header: Option<&'call message::Header<'_>>,
     ) -> DispatchResult<'call> {
         let _ = (property_name, value, emitter, header);
         DispatchResult::RequiresMut
@@ -95,7 +95,7 @@ pub trait Interface: Any + Send + Sync {
         property_name: &str,
         value: &Value<'_>,
         emitter: &SignalEmitter<'_>,
-        header: &Option<Header<'_>>,
+        header: Option<&Header<'_>>,
     ) -> Option<fdo::Result<()>>;
 
     /// Call a method.

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -78,10 +78,19 @@ pub trait Interface: Any + Send + Sync {
         &'call self,
         property_name: &'call str,
         value: &'call Value<'_>,
+        object_server: &'call ObjectServer,
+        connection: &'call Connection,
         emitter: &'call SignalEmitter<'_>,
         header: Option<&'call message::Header<'_>>,
     ) -> DispatchResult<'call> {
-        let _ = (property_name, value, emitter, header);
+        let _ = (
+            property_name,
+            value,
+            object_server,
+            connection,
+            emitter,
+            header,
+        );
         DispatchResult::RequiresMut
     }
 
@@ -94,6 +103,8 @@ pub trait Interface: Any + Send + Sync {
         &mut self,
         property_name: &str,
         value: &Value<'_>,
+        object_server: &ObjectServer,
+        connection: &Connection,
         emitter: &SignalEmitter<'_>,
         header: Option<&Header<'_>>,
     ) -> Option<fdo::Result<()>>;

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -252,7 +252,7 @@ impl Node {
             .instance
             .read()
             .await
-            .get_all(object_server, connection, &None)
+            .get_all(object_server, connection, None)
             .await
     }
 }

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -279,6 +279,22 @@ impl MyIface {
 
     #[instrument]
     #[zbus(property)]
+    fn set_test_header_prop(
+        &self,
+        value: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+        #[zbus(connection)] connection: &Connection,
+        #[zbus(object_server)] object_server: &ObjectServer,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) {
+        debug!("`TestHeaderProp` setter called, value: {}, header: {:?}, connection: {:?}, object_server: {:?}, emitter: {:?}",
+            value, header, connection, object_server, emitter
+        );
+        assert!(header.is_some());
+    }
+
+    #[instrument]
+    #[zbus(property)]
     async fn hash_map(&self) -> HashMap<String, String> {
         debug!("`HashMap` getter called.");
         self.test_hashmap_return().await.unwrap()
@@ -585,6 +601,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     drop(props_changed_stream);
 
     proxy.ping().await?;
+    proxy.set_test_header_prop(true).await?;
     assert_eq!(proxy.test_header_prop().await?, true);
     assert_eq!(proxy.count().await?, 1);
     assert_eq!(proxy.cached_count()?, None);

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -719,7 +719,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 &self,
                                 signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
                             ) -> #zbus::Result<()> {
-                                let header = None as Option<#zbus::message::Header<'_>>;
+                                let header = ::std::option::Option::None::<&#zbus::message::Header<'_>>;
                                 let connection = signal_emitter.connection();
                                 let object_server = connection.object_server();
                                 #args_from_msg
@@ -864,7 +864,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 property_name: &str,
                 object_server: &#zbus::ObjectServer,
                 connection: &#zbus::Connection,
-                header: &Option<#zbus::message::Header<'_>>,
+                header: Option<&#zbus::message::Header<'_>>,
             ) -> ::std::option::Option<#zbus::fdo::Result<#zbus::zvariant::OwnedValue>> {
                 match property_name {
                     #get_dispatch
@@ -876,7 +876,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 &self,
                 object_server: &#zbus::ObjectServer,
                 connection: &#zbus::Connection,
-                header: &Option<#zbus::message::Header<'_>>,
+                header: Option<&#zbus::message::Header<'_>>,
             ) -> #zbus::fdo::Result<::std::collections::HashMap<
                 ::std::string::String,
                 #zbus::zvariant::OwnedValue,
@@ -894,7 +894,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 property_name: &'call str,
                 value: &'call #zbus::zvariant::Value<'_>,
                 signal_emitter: &'call #zbus::object_server::SignalEmitter<'_>,
-                header: &'call Option<#zbus::message::Header<'_>>,
+                header: Option<&'call #zbus::message::Header<'_>>,
             ) -> #zbus::object_server::DispatchResult<'call> {
                 match property_name {
                     #set_dispatch
@@ -907,7 +907,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 property_name: &str,
                 value: &#zbus::zvariant::Value<'_>,
                 signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
-                header: &Option<#zbus::message::Header<'_>>,
+                header: Option<&#zbus::message::Header<'_>>,
             ) -> ::std::option::Option<#zbus::fdo::Result<()>> {
                 match property_name {
                     #set_mut_dispatch
@@ -1017,7 +1017,9 @@ fn get_args_from_inputs(
                 let header_arg = &input.pat;
 
                 header_arg_decl = match method_type {
-                    MethodType::Property(_) => Some(quote! { let #header_arg = header.clone(); }),
+                    MethodType::Property(_) => Some(quote! {
+                        let #header_arg = ::std::option::Option::<&#zbus::message::Header<'_>>::cloned(header);
+                    }),
                     _ => Some(quote! { let #header_arg = message.header(); }),
                 };
             } else if signal_context || signal_emitter {

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -289,17 +289,16 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// using this since it will force all interested peers to fetch the new value and hence result in
 /// excess traffic on the bus.
 ///
-/// The method and property getter arguments support the following `zbus` attributes:
+/// The method arguments support the following `zbus` attributes:
 ///
 /// * `object_server` - This marks the method argument to receive a reference to the
 ///   [`ObjectServer`] this method was called by.
 /// * `connection` - This marks the method argument to receive a reference to the [`Connection`] on
 ///   which the method call was received.
 /// * `header` - This marks the method argument to receive the message header associated with the
-///   D-Bus method call being handled. For property getter methods, this will be an
-///   `Option<Header<'_>>`, which will be `None` when the function is being called as part of the
-///   initial object setup (before it gets registered on the bus), or when we send out property
-///   changed notifications.
+///   D-Bus method call being handled. For property methods, this will be an `Option<Header<'_>>`,
+///   which will be set to `None` if the method is called for reasons other than to respond to an
+///   external property access.
 /// * `signal_emitter` - This marks the method argument to receive a [`SignalEmitter`] instance,
 ///   which is needed for emitting signals the easy way. This argument is not available for property
 ///   getters.


### PR DESCRIPTION
Along with all the other special parameter types that methods currently support (connection, object_server and signal_emitter).