### PR TITLE
⚡️ zb: Make header cloning cheaper

### DIFF
--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     io::{Cursor, Write},
     sync::Arc,
 };
@@ -231,7 +232,7 @@ impl<'a> Builder<'a> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 
-        header.fields_mut().signature = signature;
+        header.fields_mut().signature = Cow::Owned(signature);
 
         let body_len_u32 = body_size.size().try_into().map_err(|_| Error::ExcessData)?;
         header.primary_mut().set_body_len(body_len_u32);
@@ -285,7 +286,7 @@ impl<'m> From<Header<'m>> for Builder<'m> {
     fn from(mut header: Header<'m>) -> Self {
         // Signature and Fds are added by body* methods.
         let fields = header.fields_mut();
-        fields.signature = Signature::Unit;
+        fields.signature = Cow::Owned(Signature::Unit);
         fields.unix_fds = None;
 
         Self { header }

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -329,7 +329,7 @@ static SERIAL_NUM: AtomicU32 = AtomicU32::new(0);
 mod tests {
     use crate::message::{Fields, Header, PrimaryHeader, Type};
 
-    use std::error::Error;
+    use std::{borrow::Cow, error::Error};
     use test_log::test;
     use zbus_names::{InterfaceName, MemberName};
     use zvariant::{ObjectPath, Signature};
@@ -361,7 +361,7 @@ mod tests {
         f.error_name = Some("org.zbus.Error".try_into()?);
         f.destination = Some(":1.11".try_into()?);
         f.reply_serial = Some(88.try_into()?);
-        f.signature = "say".try_into().unwrap();
+        f.signature = Cow::Owned("say".try_into().unwrap());
         f.unix_fds = Some(12);
         let h = Header::new(PrimaryHeader::new(Type::MethodReturn, 77), f);
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -1,5 +1,5 @@
 //! D-Bus Message.
-use std::{fmt, sync::Arc};
+use std::{borrow::Cow, fmt, sync::Arc};
 
 use static_assertions::assert_impl_all;
 use zbus_names::{ErrorName, InterfaceName, MemberName};
@@ -176,7 +176,7 @@ impl Message {
             reply_serial: quick_fields.reply_serial(),
             destination: quick_fields.destination(self),
             sender: quick_fields.sender(self),
-            signature: quick_fields.signature().clone(),
+            signature: Cow::Borrowed(quick_fields.signature()),
             unix_fds: quick_fields.unix_fds(),
         };
 


### PR DESCRIPTION
Right now cloning a header involves cloning the `PrimaryHeader` (cheap,
mostly POD), and then cloning the `Fields`, which can be somewhat
complex, as it involves cloning all the strings and the signature, which
if dynamic could be rather costly.

From things coming from a message, strings are always `Borrowed` so the
cloning is cheap, so the only expensive thing is cloning the signature.

Using `Cow` for it looks sensible, it's what `Str` is doing internally
already, effectively.