### PR TITLE
🐛 zx: use unformatted code for rustfmt failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Same rules apply here as for bug reports and feature requests. Plus:
   [this excellent blog post](https://www.aleksandrhovhannisyan.com/blog/atomic-git-commits/) for
   more information, including the rationale. For larger changes addressing several packages
   consider splitting your pull request, using a single commit for each package changed.
-* Please try your best to follow [these guidelines](https://wiki.gnome.org/Git/CommitMessages) for
+* Please try your best to follow [these guidelines](https://handbook.gnome.org/development/commit-messages.html) for
   commit messages.
 * We also prefer adding [emoji prefixes to commit messages](https://gitmoji.carloscuesta.me/). Since
   the `gitmoji` CLI tool can be very [slow](https://github.com/zeenix/gimoji#rationale), we

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -479,7 +479,12 @@ fn format_generated_code(generated_code: &str) -> std::io::Result<String> {
     writeln!(rustfmt_stdin)?;
     rustfmt_stdin.write_all(generated_code.as_bytes())?;
 
-    process.wait()?;
+    let exit_status = process.wait()?;
+    if !exit_status.success() {
+        eprintln!("`rustfmt` did not exit successfully. Continuing with unformatted code.");
+        return Ok(generated_code.to_string());
+    }
+
     let mut formatted = String::new();
     rustfmt_stdout.read_to_string(&mut formatted)?;
 


### PR DESCRIPTION
When `rustfmt` is not installed or exits with a failure, print a warning message and continue with the unformatted generated code, instead of returning an empty string.

Closes: https://github.com/dbus2/zbus/issues/1122