### PR TITLE
Lower MSRV via workspace configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.package]
-rust-version = "1.80"
+rust-version = "1.77"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ resolver = "2"
 # This optional cfg flag is used by tokio code to set task name
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
+[workspace.package]
+rust-version = "1.80"
+
 [profile.bench]
 debug = true
 strip = "none"

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus"
 version = "5.2.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "API for D-Bus communication"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "proc-macros for zbus"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_names"
 version = "4.1.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "A collection of D-Bus bus names types"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -3,7 +3,7 @@ name = "zbus_xml"
 version = "5.0.1"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "API to handle D-Bus introspection XML"
 repository = "https://github.com/dbus2/zbus/"

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "D-Bus XML interface code generator"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -3,7 +3,7 @@ name = "zvariant"
 version = "5.1.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -4,7 +4,7 @@ name = "zvariant_derive"
 version = "5.1.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "D-Bus & GVariant encoding & decoding"
 repository = "https://github.com/dbus2/zbus/"

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "turbocooler <turbocooler@cocaine.ninja>",
 ]
 edition = "2021"
-rust-version = "1.80"
+rust-version = { workspace = true }
 
 description = "Various utilities used internally by the zvariant crate."
 repository = "https://github.com/dbus2/zbus/"


### PR DESCRIPTION
Lowers the MSRV of all packages to 1.77 as per https://github.com/dbus2/zbus/issues/1107#issuecomment-2573181948. I decided to introduce it as a workspace variable to reduce the duplication across the packages.