### PR TITLE
🚸 Make PR template a comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,9 @@
-Thank you for your contribution! 🙏 We hope you have read our contribution guideline and followed it to the best of your abilities: https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests
+<!--
+
+Thank you for your contribution! 🙏
+
+We hope you have read our contribution guideline and followed it to the best of your abilities:
+
+https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests
+
+-->


### PR DESCRIPTION
This will ease contributions because for obvious PRs, the contributor can just leave the template in the description.