### PR TITLE
Revert "🔥 CI: Drop now unneeded MSRV check"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  MSRV:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      MSRV: 1.77.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.MSRV }}
+          targets: x86_64-pc-windows-gnu, x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Check build with MSRV
+        run: |
+          cargo --locked check
+          cargo --locked check --target x86_64-pc-windows-gnu
+          cargo --locked check --target x86_64-apple-darwin
+          cargo --locked check --target x86_64-unknown-freebsd
+          cargo --locked check --target x86_64-unknown-netbsd
+        # This would be nice but some optional deps (e.g `time`) move very fast wrt to MSRV.
+        # cargo --locked check --all-features
+
   fmt:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This reverts commit dd6de5b8a80fc97a6020d0f73e4c5f71362fbcfc.

Also change the job to use 1.77.0, our current MSRV.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
