### PR TITLE
🐛 zm: Fix generated get_all() function

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -693,7 +693,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     get_dispatch.extend(q);
 
                     let q = if is_fallible_property {
-                        quote!(
+                        quote!({
                             #args_from_msg
                             if let Ok(prop) = self.#ident(#args_names)#method_await {
                             props.insert(
@@ -705,9 +705,9 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 )
                                 .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
                             );
-                        })
+                        }})
                     } else {
-                        quote!(
+                        quote!({
                             #args_from_msg
                             props.insert(
                         ::std::string::ToString::to_string(#member_name),
@@ -717,7 +717,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             ),
                         )
                         .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
-                    );)
+                    );})
                     };
 
                     get_all.extend(q);


### PR DESCRIPTION
Naming the optional header parameter 'header' several times for different property getters collides with the 'header` local argument of the generated get_all() function. Obvious workaround is don't name your special parameter 'header'.

This is easily fixed by simply wrapping each getter code block generated for get_all() in its own scope.