### PR TITLE
🩹 zm: do not reply if no-reply-expected flag is set

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -783,7 +783,11 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             #args_from_msg
                             let reply = self.#ident(#args_names)#method_await;
                             let hdr = message.header();
-                            #reply
+                            if hdr.primary().flags().contains(zbus::message::Flags::NoReplyExpected) {
+                                Ok(())
+                            } else {
+                                #reply
+                            }
                         };
                         #zbus::object_server::DispatchResult::Async(::std::boxed::Box::pin(async move {
                             future.await


### PR DESCRIPTION
I am using zbus to define an inteface method, like this:

```rust
#[zbus::interface(name = "public.settings")]
impl SettingsInterface {
    async fn set_var(
        &self,
        originator: &str,
        object: &str,
        interface: &str,
        arguments: &str,
    ) {
        //...
    }
}
```

This method is called with with the `NoReplyExpected` flag. However zbus generates a reply, which ended up in an error shown in `dbus-monitor`: 

```
Rejected send message, 0 matched rules; type="method_return", sender=":1.16" ...
```


I used `cargo expand` to see what code is generated by the interface macros and found something like this:

```rust
let reply = self.set_var(originator, object, interface, arguments).await;
let hdr = message.header();
connection.reply(&hdr, &reply).await
```

The `connection.reply()` method is called in every case. So i guess, that the flag is not evaluated yet, to handle the case where no response is expected!?


With my adjustment, the generated code looks like this:

```rust
let reply = self.set_var(originator, object, interface, arguments).await;
let hdr = message.header();
if hdr.primary().flags().contains(zbus::message::Flags::NoReplyExpected)
{
    Ok(())
} else {
    connection.reply(&hdr, &reply).await
}
```

And the error shown with `dbus-monitor` was gone.