### PR TITLE
zv: Add missing From implementations for Value::Str

### DIFF
--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::BuildHasher};
+use std::{borrow::Cow, collections::HashMap, hash::BuildHasher, sync::Arc};
 
 #[cfg(feature = "gvariant")]
 use crate::Maybe;
@@ -48,6 +48,9 @@ into_value_from_both!(u64, U64);
 into_value_from_both!(i64, I64);
 into_value_from_both!(f32, F64);
 into_value_from_both!(f64, F64);
+
+into_value!(Arc<str>, Str);
+into_value!(Cow<'a, str>, Str);
 
 into_value_from_both!(&'a str, Str);
 into_value_from_both!(Str<'a>, Str);

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -51,6 +51,7 @@ into_value_from_both!(f64, F64);
 
 into_value!(Arc<str>, Str);
 into_value!(Cow<'a, str>, Str);
+into_value_from_both!(String, Str);
 
 into_value_from_both!(&'a str, Str);
 into_value_from_both!(Str<'a>, Str);
@@ -80,12 +81,6 @@ try_into_value_from_ref!(Maybe<'a>, Maybe);
 into_value!(Fd<'a>, Fd);
 #[cfg(unix)]
 try_into_value_from_ref!(Fd<'a>, Fd);
-
-impl From<String> for Value<'_> {
-    fn from(v: String) -> Self {
-        Value::Str(crate::Str::from(v))
-    }
-}
 
 impl<'v, 's: 'v, T> From<T> for Value<'v>
 where
@@ -133,12 +128,6 @@ where
 {
     fn from(value: HashMap<K, V, H>) -> Self {
         Self::Dict(value.into())
-    }
-}
-
-impl<'v> From<&'v String> for Value<'v> {
-    fn from(v: &'v String) -> Value<'v> {
-        Value::Str(v.into())
     }
 }
 


### PR DESCRIPTION
This PR mainly fixes Value not implementing From for Arced or Cowed strs.
Additionally I replaced the manual implementations of `From<String>` and `From<&'v String>` with the macro one.
I think this makes the PR not atomic anymore, sorry about that. 😅

fixes #1234 
