### PR TITLE
zb: Replace futures-util runtime dependency with futures-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2153,6 +2153,7 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
+ "futures-lite",
  "futures-util",
  "hex",
  "nix",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -36,7 +36,6 @@ async-io = [
   # features for only specific target OS: https://github.com/rust-lang/cargo/issues/1197.
   "async-process",
   "blocking",
-  "futures-util/io",
 ]
 tokio = ["dep:tokio"]
 vsock = ["dep:vsock", "dep:async-io"]
@@ -56,7 +55,7 @@ serde = { version = "1.0.200", features = ["derive"] }
 serde_repr = "0.1.19"
 enumflags2 = { version = "0.7.9", features = ["serde"] }
 futures-core = "0.3.30"
-futures-util = { version = "0.3.30", default-features = false, features = [
+futures-lite = { version = "2.6.0", default-features = false, features = [
   "std",
 ] }
 async-broadcast = "0.7.0"
@@ -121,7 +120,7 @@ async-recursion = "1.1.1"
 [dev-dependencies]
 zbus_xml = { path = "../zbus_xml", version = "5.0.0" }
 doc-comment = "0.3.3"
-futures-util = "0.3.30" # activate default features
+futures-util = { version = "0.3.30", features = ["io"] }
 ntest = "0.9.2"
 test-log = { version = "0.2.16", features = [
   "trace",

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -1,4 +1,4 @@
-use futures_util::StreamExt;
+use futures_lite::StreamExt;
 use static_assertions::assert_impl_all;
 
 use crate::{

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -1,7 +1,7 @@
 //! The client-side proxy API.
 
 use enumflags2::BitFlags;
-use futures_util::StreamExt;
+use futures_lite::StreamExt;
 use static_assertions::assert_impl_all;
 use std::{fmt, ops::Deref};
 use zbus_names::{BusName, InterfaceName, MemberName, UniqueName};

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -17,7 +17,7 @@ use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName,
 use zvariant::ObjectPath;
 
 use futures_core::Future;
-use futures_util::StreamExt;
+use futures_lite::StreamExt;
 
 use crate::{
     async_lock::{Mutex, Semaphore, SemaphorePermit},
@@ -1541,14 +1541,14 @@ mod tests {
 #[cfg(feature = "p2p")]
 #[cfg(test)]
 mod p2p_tests {
-    use futures_util::stream::TryStreamExt;
+    use event_listener::Event;
+    use futures_util::TryStreamExt;
     use ntest::timeout;
     use test_log::test;
     use zvariant::{Endian, NATIVE_ENDIAN};
 
-    use crate::{conn::AuthMechanism, Guid};
-
-    use super::*;
+    use super::{socket, Builder, Connection};
+    use crate::{conn::AuthMechanism, Guid, Message, MessageStream, Result};
 
     // Same numbered client and server are already paired up.
     async fn test_p2p(
@@ -1740,6 +1740,9 @@ mod p2p_tests {
         feature = "tokio-vsock"
     ))]
     async fn test_vsock_connect() -> Result<(Connection, Connection)> {
+        #[cfg(feature = "tokio-vsock")]
+        use futures_util::StreamExt;
+
         let guid = Guid::generate();
 
         #[cfg(all(feature = "vsock", not(feature = "tokio")))]
@@ -1814,6 +1817,7 @@ mod p2p_tests {
 
     #[cfg(feature = "tokio-vsock")]
     async fn vsock_p2p_pipe() -> Result<(Connection, Connection)> {
+        use futures_util::StreamExt;
         use tokio_vsock::VsockAddr;
 
         let guid = Guid::generate();

--- a/zbus/src/connection/socket/command.rs
+++ b/zbus/src/connection/socket/command.rs
@@ -60,7 +60,7 @@ impl TryFrom<&mut Child> for Command {
 #[async_trait::async_trait]
 impl ReadHalf for ChildStdout {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
-        match futures_util::AsyncReadExt::read(&mut self, buf).await {
+        match futures_lite::AsyncReadExt::read(&mut self, buf).await {
             Err(e) => Err(e),
             Ok(len) => {
                 #[cfg(unix)]
@@ -104,11 +104,11 @@ impl WriteHalf for ChildStdin {
             ));
         }
 
-        futures_util::AsyncWriteExt::write(&mut self, buf).await
+        futures_lite::AsyncWriteExt::write(&mut self, buf).await
     }
 
     async fn close(&mut self) -> io::Result<()> {
-        futures_util::AsyncWriteExt::close(&mut self).await
+        futures_lite::AsyncWriteExt::close(&mut self).await
     }
 }
 

--- a/zbus/src/connection/socket/tcp.rs
+++ b/zbus/src/connection/socket/tcp.rs
@@ -14,7 +14,7 @@ use super::{Socket, Split};
 #[async_trait::async_trait]
 impl ReadHalf for Arc<Async<TcpStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
-        match futures_util::AsyncReadExt::read(&mut self.as_ref(), buf).await {
+        match futures_lite::AsyncReadExt::read(&mut self.as_ref(), buf).await {
             Err(e) => Err(e),
             Ok(len) => {
                 #[cfg(unix)]
@@ -69,7 +69,7 @@ impl WriteHalf for Arc<Async<TcpStream>> {
             ));
         }
 
-        futures_util::AsyncWriteExt::write(&mut self.as_ref(), buf).await
+        futures_lite::AsyncWriteExt::write(&mut self.as_ref(), buf).await
     }
 
     async fn close(&mut self) -> io::Result<()> {

--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -208,7 +208,7 @@ impl super::WriteHalf for tokio::net::unix::OwnedWriteHalf {
 #[async_trait::async_trait]
 impl super::ReadHalf for Arc<Async<UnixStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> super::RecvmsgResult {
-        match futures_util::AsyncReadExt::read(&mut self.as_ref(), buf).await {
+        match futures_lite::AsyncReadExt::read(&mut self.as_ref(), buf).await {
             Err(e) => Err(e),
             Ok(len) => {
                 #[cfg(unix)]
@@ -247,7 +247,7 @@ impl super::WriteHalf for Arc<Async<UnixStream>> {
         buf: &[u8],
         #[cfg(unix)] _fds: &[BorrowedFd<'_>],
     ) -> std::io::Result<usize> {
-        futures_util::AsyncWriteExt::write(&mut self.as_ref(), buf).await
+        futures_lite::AsyncWriteExt::write(&mut self.as_ref(), buf).await
     }
 
     async fn close(&mut self) -> std::io::Result<()> {

--- a/zbus/src/connection/socket/vsock.rs
+++ b/zbus/src/connection/socket/vsock.rs
@@ -5,7 +5,7 @@ use super::{Socket, Split};
 #[async_trait::async_trait]
 impl super::ReadHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> super::RecvmsgResult {
-        match futures_util::AsyncReadExt::read(&mut self.as_ref(), buf).await {
+        match futures_lite::AsyncReadExt::read(&mut self.as_ref(), buf).await {
             Err(e) => Err(e),
             Ok(len) => {
                 #[cfg(unix)]
@@ -40,7 +40,7 @@ impl super::WriteHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
             ));
         }
 
-        futures_util::AsyncWriteExt::write(&mut self.as_ref(), buf).await
+        futures_lite::AsyncWriteExt::write(&mut self.as_ref(), buf).await
     }
 
     async fn close(&mut self) -> std::io::Result<()> {

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -99,7 +99,6 @@ extern crate self as zbus;
 pub mod export {
     pub use async_trait;
     pub use futures_core;
-    pub use futures_util;
     pub use ordered_stream;
     pub use serde;
     pub use static_assertions;

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -5,8 +5,7 @@ use std::{
 };
 
 use async_broadcast::Receiver as ActiveReceiver;
-use futures_core::stream;
-use futures_util::stream::FusedStream;
+use futures_core::stream::{self, FusedStream};
 use ordered_stream::{OrderedStream, PollResult};
 use static_assertions::assert_impl_all;
 use tracing::warn;

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -524,11 +524,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                         quote!(self.#ident(#args_names)#method_await)
                     } else if is_async {
                         quote!(
-                                #zbus::export::futures_util::future::FutureExt::map(
-                                    self.#ident(#args_names),
-                                    ::std::result::Result::Ok,
-                                )
-                                .await
+                            ::std::result::Result::Ok(self.#ident(#args_names).await)
                         )
                     } else {
                         quote!(


### PR DESCRIPTION
I took a quick look at replacing the dev-dependency as well, but it looks like that's harder, and also not as useful. (the first roadblock I found was `futures_lite::StreamExt::try_for_each` using a different signature from `futures_util::TryStreamExt::try_for_each` that's less helpful if the closure itself returns a future)

Fixes https://github.com/dbus2/zbus/issues/1242.