### PR TITLE
🐛 zv: fix wrong lifetime when creating a Value from &Vec and &[]

### DIFF
--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -91,11 +91,11 @@ where
     }
 }
 
-impl<'v, V> From<&'v [V]> for Value<'v>
+impl<'b, 'v, V> From<&'b [V]> for Value<'v>
 where
-    &'v [V]: Into<Array<'v>>,
+    &'b [V]: Into<Array<'v>>,
 {
-    fn from(v: &'v [V]) -> Value<'v> {
+    fn from(v: &'b [V]) -> Value<'v> {
         Value::Array(v.into())
     }
 }
@@ -109,11 +109,11 @@ where
     }
 }
 
-impl<'v, V> From<&'v Vec<V>> for Value<'v>
+impl<'b, 'v, V> From<&'b Vec<V>> for Value<'v>
 where
-    &'v Vec<V>: Into<Array<'v>>,
+    &'b Vec<V>: Into<Array<'v>>,
 {
-    fn from(v: &'v Vec<V>) -> Value<'v> {
+    fn from(v: &'b Vec<V>) -> Value<'v> {
         Value::Array(v.into())
     }
 }


### PR DESCRIPTION
When creating a Value from a borrowed vec or slice using Value's From implementation, the compiler would wrongfully assume, that the created value has the same lifetime, even though the input gets cloned when creating the Array struct.
This PR makes the impl assign a new lifetime to the cloned value.

If I've messed up the gitmoji again, please let me know :)

# Minimal example that compiles with the patch
```rust
use std::collections::HashMap;
use zvariant::Value;

fn main() {
    println!("{:?}", func());
}

// 'a could also be replaced with 'static since Value is supposed to own all its data here
fn func<'a>() -> HashMap<&'static str, Value<'a>> {
    let mut map = HashMap::new();
    let vec = vec!["Hello", "World", "!"];

    // this works because the From<Vec<V>> impl only uses the lifetime of Value
    map.insert("some_key", vec.clone().into());

    // this does not because the From impl requires that &Vec lives as long as the retuned Value.
    // However, since the implementation of From<&Vec<T>> uses .clone() internally we *should* be able to do this.
    map.insert("another_key", (&vec).into());

    // same goes for slices
    map.insert("different_key", vec.as_slice().into());

    map
}
```
