### PR TITLE
🐛 zd: Prefix a local variable w/ `__` so it doesn't conflict w/ fields

### DIFF
--- a/zvariant_derive/src/dict.rs
+++ b/zvariant_derive/src/dict.rs
@@ -196,8 +196,8 @@ pub fn expand_deserialize_derive(input: DeriveInput) -> Result<TokenStream, Erro
                         #( let mut #fields = ::std::default::Default::default(); )*
 
                         // does not check duplicated fields, since those shouldn't exist in stream
-                        while let ::std::option::Option::Some(key) = access.next_key::<&str>()? {
-                            match key {
+                        while let ::std::option::Option::Some(__key) = access.next_key::<&str>()? {
+                            match __key {
                                 #(#entries)*
                             }
                         }

--- a/zvariant_derive/tests/tests.rs
+++ b/zvariant_derive/tests/tests.rs
@@ -99,3 +99,16 @@ fn issues_311() {
         pub sinr: Option<i32>,
     }
 }
+
+#[test]
+#[ignore]
+fn issues_1252() {
+    // Issue 1252: Naming a field `key` in a dict struct causes a conflict with variables created by
+    // `DeserializeDict` macro, ending up with a strange error.
+    #[derive(DeserializeDict, Type)]
+    #[zvariant(signature = "a{sv}")]
+    pub struct OwnedProperties {
+        key: String,
+        val: OwnedValue,
+    }
+}


### PR DESCRIPTION
..in the struct deriving `DeserializeDict`.

Fixes #1252.

