### PR TITLE
👷 CI: Only build/test in release mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,17 +78,10 @@ jobs:
   linux_test:
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
-    strategy:
-      matrix:
-        # Test in both debug and release mode
-        env:
-          - PROFILE: dev
-          - PROFILE: release
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
       RUST_LOG: trace
-      PROFILE: ${{ matrix.env.PROFILE }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -103,17 +96,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build and Test
         run: |
-          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --profile "$PROFILE" --verbose -- basic_connection
+          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --release --verbose -- basic_connection
           # All features except tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --profile "$PROFILE" --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
+            cargo --locked test --release --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
               -- --skip fdpass_systemd
           # Test tokio support.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --profile "$PROFILE" --verbose --tests -p zbus --no-default-features \
+            cargo --locked test --release --verbose --tests -p zbus --no-default-features \
               --features tokio-vsock -- --skip fdpass_systemd
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --profile "$PROFILE" --verbose --doc --no-default-features connection::Connection::executor
+            cargo --locked test --release --verbose --doc --no-default-features connection::Connection::executor
           # zvariant only with ostree tests (which implicitly enables `gvariant` feature too).
           cargo --locked t -p zvariant --features ostree-tests
 


### PR DESCRIPTION
Buiding and testing in both debug and release modes take a lot of time and we don't really need to build in debug mode anyway.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
