### PR TITLE
➖ all: Drop `static_assertions` dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,19 +87,9 @@ scripts contained within this repository. You can enable them with:
 cp .githooks/* .git/hooks/
 ```
 
-## Adding public API
-
-### Assert auto traits on items
-
-Please make sure to add `assert_impl_all!()` macros to ensure that accidental changes to auto trait
-implementations like `Send`, `Sync`, and `Unpin` can be detected easily. You should use the existing
-code to see how it is done with all of the current items already. For further information see the
-Rust API Guidelines on [C-SEND-SYNC].
-
 ## Conduct
 
 In all zbus-related forums, we follow the
 [Rust Code of Conduct](https://www.rust-lang.org/conduct.html). For escalation or moderation issues
 please contact Zeeshan (zeeshanak@gnome.org) instead of the Rust moderation team.
 
-[C-SEND-SYNC]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-send-sync

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,12 +1532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,7 +2156,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_repr",
- "static_assertions",
  "tempfile",
  "test-log",
  "tokio",
@@ -2203,7 +2196,6 @@ version = "4.2.0"
 dependencies = [
  "criterion",
  "serde",
- "static_assertions",
  "winnow 0.7.2",
  "zvariant",
 ]
@@ -2215,7 +2207,6 @@ dependencies = [
  "doc-comment",
  "quick-xml",
  "serde",
- "static_assertions",
  "zbus_names",
  "zvariant",
 ]
@@ -2310,7 +2301,6 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "static_assertions",
  "time",
  "url",
  "uuid",
@@ -2341,7 +2331,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
  "syn 2.0.98",
  "winnow 0.7.2",
  "zvariant",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -63,7 +63,6 @@ hex = "0.4.3"
 ordered-stream = "0.2"
 rand = { version = "0.9.0", optional = true }
 event-listener = "5.3.0"
-static_assertions = "1.1.0"
 async-trait = "0.1.80"
 xdg-home = "1.1.0"
 tracing = "0.1.40"

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -1,4 +1,3 @@
-use static_assertions::assert_impl_all;
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
 #[cfg(all(unix, not(feature = "tokio")))]
@@ -23,8 +22,6 @@ use crate::{
 #[derive(Debug)]
 #[must_use]
 pub struct Builder<'a>(crate::connection::Builder<'a>);
-
-assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -2,7 +2,6 @@
 
 use enumflags2::BitFlags;
 use event_listener::EventListener;
-use static_assertions::assert_impl_all;
 use std::{io, ops::Deref};
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName};
 use zvariant::ObjectPath;
@@ -26,8 +25,6 @@ pub use builder::Builder;
 pub struct Connection {
     inner: crate::Connection,
 }
-
-assert_impl_all!(Connection: Send, Sync, Unpin);
 
 impl Connection {
     /// Create a `Connection` to the session/user message bus.

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -1,5 +1,4 @@
 use futures_lite::StreamExt;
-use static_assertions::assert_impl_all;
 
 use crate::{
     blocking::Connection, message::Message, utils::block_on, MatchRule, OwnedMatchRule, Result,
@@ -18,8 +17,6 @@ pub struct MessageIterator {
     // dropped.
     pub(crate) azync: Option<crate::MessageStream>,
 }
-
-assert_impl_all!(MessageIterator: Send, Sync, Unpin);
 
 impl MessageIterator {
     /// Get a reference to the underlying async message stream.

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -1,6 +1,5 @@
 //! The object server API.
 
-use static_assertions::assert_impl_all;
 use zvariant::ObjectPath;
 
 use crate::{
@@ -131,8 +130,6 @@ where
 pub struct ObjectServer {
     azync: crate::ObjectServer,
 }
-
-assert_impl_all!(ObjectServer: Send, Sync, Unpin);
 
 impl ObjectServer {
     /// Create a new D-Bus `ObjectServer`.

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -1,4 +1,3 @@
-use static_assertions::assert_impl_all;
 use zbus_names::{BusName, InterfaceName};
 use zvariant::ObjectPath;
 
@@ -9,8 +8,6 @@ pub use crate::proxy::Defaults;
 /// Builder for proxies.
 #[derive(Debug, Clone)]
 pub struct Builder<'a, T = ()>(crate::proxy::Builder<'a, T>);
-
-assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
 
 impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -2,7 +2,6 @@
 
 use enumflags2::BitFlags;
 use futures_lite::StreamExt;
-use static_assertions::assert_impl_all;
 use std::{fmt, ops::Deref};
 use zbus_names::{BusName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, OwnedValue, Value};
@@ -76,8 +75,6 @@ impl fmt::Debug for Proxy<'_> {
             .finish_non_exhaustive()
     }
 }
-
-assert_impl_all!(Proxy<'_>: Send, Sync, Unpin);
 
 impl<'a> Proxy<'a> {
     /// Create a new `Proxy` for the given destination/path/interface.
@@ -406,8 +403,6 @@ impl<'a> SignalIterator<'a> {
         self.0.as_ref().expect("`SignalStream` is `None`").name()
     }
 }
-
-assert_impl_all!(SignalIterator<'_>: Send, Sync, Unpin);
 
 impl std::iter::Iterator for SignalIterator<'_> {
     type Item = Message;

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -1,7 +1,6 @@
 #[cfg(not(feature = "tokio"))]
 use async_io::Async;
 use event_listener::Event;
-use static_assertions::assert_impl_all;
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
 #[cfg(all(unix, not(feature = "tokio")))]
@@ -71,8 +70,6 @@ pub struct Builder<'a> {
     #[cfg(feature = "bus-impl")]
     unique_name: Option<crate::names::UniqueName<'a>>,
 }
-
-assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -3,7 +3,6 @@ use async_broadcast::{broadcast, InactiveReceiver, Receiver, Sender as Broadcast
 use enumflags2::BitFlags;
 use event_listener::{Event, EventListener};
 use ordered_stream::{OrderedFuture, OrderedStream, PollResult};
-use static_assertions::assert_impl_all;
 use std::{
     collections::HashMap,
     io::{self, ErrorKind},
@@ -209,8 +208,6 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 pub struct Connection {
     pub(crate) inner: Arc<ConnectionInner>,
 }
-
-assert_impl_all!(Connection: Send, Sync, Unpin);
 
 /// A method call whose completion can be awaited or joined with other streams.
 ///

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -1,4 +1,3 @@
-use static_assertions::assert_impl_all;
 use std::{convert::Infallible, error, fmt, io, sync::Arc};
 use zbus_names::{Error as NamesError, InterfaceName, OwnedErrorName};
 use zvariant::{Error as VariantError, ObjectPath};
@@ -62,8 +61,6 @@ pub enum Error {
     /// The given interface already exists at the given path.
     InterfaceExists(InterfaceName<'static>, ObjectPath<'static>),
 }
-
-assert_impl_all!(Error: Send, Sync, Unpin);
 
 impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -6,7 +6,6 @@
 use enumflags2::{bitflags, BitFlags};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use static_assertions::assert_impl_all;
 use std::collections::HashMap;
 use zbus_names::{
     BusName, OwnedBusName, OwnedInterfaceName, OwnedUniqueName, UniqueName, WellKnownName,
@@ -51,8 +50,6 @@ pub enum RequestNameFlags {
     DoNotQueue = 0x04,
 }
 
-assert_impl_all!(RequestNameFlags: Send, Sync, Unpin);
-
 /// The return code of the [`request_name`] method.
 ///
 /// [`request_name`]: struct.DBusProxy.html#method.request_name
@@ -86,8 +83,6 @@ pub enum RequestNameReply {
     AlreadyOwner = 0x04,
 }
 
-assert_impl_all!(RequestNameReply: Send, Sync, Unpin);
-
 /// The return code of the [`release_name`] method.
 ///
 /// [`release_name`]: struct.DBusProxy.html#method.release_name
@@ -105,8 +100,6 @@ pub enum ReleaseNameReply {
     /// own this name.
     NotOwner = 0x03,
 }
-
-assert_impl_all!(ReleaseNameReply: Send, Sync, Unpin);
 
 /// Credentials of a process connected to a bus server.
 ///
@@ -360,7 +353,3 @@ pub trait DBus {
     #[zbus(property)]
     fn interfaces(&self) -> Result<Vec<OwnedInterfaceName>>;
 }
-
-assert_impl_all!(DBusProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(DBusProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/error.rs
+++ b/zbus/src/fdo/error.rs
@@ -1,5 +1,3 @@
-use static_assertions::assert_impl_all;
-
 use crate::DBusError;
 
 /// Errors from <https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/dbus/dbus-protocol.h>
@@ -175,5 +173,3 @@ pub enum Error {
 ///
 /// [`zbus::fdo::Error`]: enum.Error.html
 pub type Result<T> = std::result::Result<T, Error>;
-
-assert_impl_all!(Error: Send, Sync, Unpin);

--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -3,8 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
-
 use super::{Error, Result};
 use crate::{interface, message::Header, ObjectServer};
 
@@ -35,7 +33,3 @@ impl Introspectable {
         Ok(node.introspect().await)
     }
 }
-
-assert_impl_all!(IntrospectableProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(IntrospectableProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/monitoring.rs
+++ b/zbus/src/fdo/monitoring.rs
@@ -3,8 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
-
 /// Proxy for the `org.freedesktop.DBus.Monitoring` interface.
 #[crate::proxy(
     interface = "org.freedesktop.DBus.Monitoring",
@@ -34,7 +32,3 @@ pub trait Monitoring {
     /// [`MessageStream`]: https://docs.rs/zbus/latest/zbus/struct.MessageStream.html
     fn become_monitor(self, match_rules: &[crate::MatchRule<'_>], flags: u32) -> super::Result<()>;
 }
-
-assert_impl_all!(MonitoringProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(MonitoringProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -3,7 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
 use std::{borrow::Cow, collections::HashMap};
 use zbus_names::{InterfaceName, OwnedInterfaceName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
@@ -80,7 +79,3 @@ impl ObjectManager {
         interfaces: Cow<'_, [InterfaceName<'_>]>,
     ) -> zbus::Result<()>;
 }
-
-assert_impl_all!(ObjectManagerProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(ObjectManagerProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -3,8 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
-
 use super::{Error, Result};
 
 pub(crate) struct Peer;
@@ -46,7 +44,3 @@ impl Peer {
         Ok(id)
     }
 }
-
-assert_impl_all!(PeerProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(PeerProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -3,7 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
 use std::{borrow::Cow, collections::HashMap};
 use zbus_names::InterfaceName;
 use zvariant::{OwnedValue, Value};
@@ -15,8 +14,6 @@ use crate::{interface, message::Header, object_server::SignalEmitter, Connection
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer].
 pub struct Properties;
-
-assert_impl_all!(Properties: Send, Sync, Unpin);
 
 #[interface(
     name = "org.freedesktop.DBus.Properties",
@@ -152,7 +149,3 @@ impl Properties {
         invalidated_properties: Cow<'_, [&str]>,
     ) -> zbus::Result<()>;
 }
-
-assert_impl_all!(PropertiesProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(PropertiesProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -3,7 +3,6 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use static_assertions::assert_impl_all;
 use std::collections::HashMap;
 use zbus_names::BusName;
 use zvariant::OwnedValue;
@@ -29,7 +28,3 @@ pub trait Stats {
         &self,
     ) -> Result<Vec<HashMap<crate::names::OwnedUniqueName, Vec<crate::OwnedMatchRule>>>>;
 }
-
-assert_impl_all!(StatsProxy<'_>: Send, Sync, Unpin);
-#[cfg(feature = "blocking-api")]
-assert_impl_all!(StatsProxyBlocking<'_>: Send, Sync, Unpin);

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use zvariant::{Str, Type};
 
 /// A D-Bus server GUID.
@@ -19,8 +18,6 @@ use zvariant::{Str, Type};
 /// [TryFrom]: #impl-TryFrom%3C%26%27_%20str%3E
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Type, Serialize)]
 pub struct Guid<'g>(Str<'g>);
-
-assert_impl_all!(Guid<'_>: Send, Sync, Unpin);
 
 impl Guid<'_> {
     /// Generate a D-Bus GUID that can be used with e.g.
@@ -171,8 +168,6 @@ impl Borrow<str> for Guid<'_> {
 /// Owned version of [`Guid`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Type, Serialize)]
 pub struct OwnedGuid(#[serde(borrow)] Guid<'static>);
-
-assert_impl_all!(OwnedGuid: Send, Sync, Unpin);
 
 impl OwnedGuid {
     /// Get a reference to the inner [`Guid`].

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -101,7 +101,6 @@ pub mod export {
     pub use futures_core;
     pub use ordered_stream;
     pub use serde;
-    pub use static_assertions;
 }
 
 pub use zbus_names as names;

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -1,5 +1,3 @@
-use static_assertions::assert_impl_all;
-
 use crate::{
     match_rule::PathSpec,
     message::Type,
@@ -15,8 +13,6 @@ const MAX_ARGS: u8 = 64;
 /// This is created by [`MatchRule::builder`].
 #[derive(Debug)]
 pub struct Builder<'m>(MatchRule<'m>);
-
-assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
 
 impl<'m> Builder<'m> {
     /// Build the `MatchRule`.

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use zvariant::Structure;
 
 use crate::{
@@ -101,8 +100,6 @@ pub struct MatchRule<'m> {
     pub(crate) arg_paths: Vec<(u8, ObjectPath<'m>)>,
     pub(crate) arg0ns: Option<Str<'m>>,
 }
-
-assert_impl_all!(MatchRule<'_>: Send, Sync, Unpin);
 
 impl<'m> MatchRule<'m> {
     /// Create a builder for `MatchRule`.
@@ -499,8 +496,6 @@ pub enum PathSpec<'m> {
     PathNamespace(ObjectPath<'m>),
 }
 
-assert_impl_all!(PathSpec<'_>: Send, Sync, Unpin);
-
 impl PathSpec<'_> {
     /// Create an owned clone of `self`.
     fn to_owned(&self) -> PathSpec<'static> {
@@ -522,8 +517,6 @@ impl PathSpec<'_> {
 /// Owned sibling of [`MatchRule`].
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, VariantType)]
 pub struct OwnedMatchRule(#[serde(borrow)] MatchRule<'static>);
-
-assert_impl_all!(OwnedMatchRule: Send, Sync, Unpin);
 
 impl OwnedMatchRule {
     /// Convert to the inner `MatchRule`, consuming `self`.

--- a/zbus/src/message/field_code.rs
+++ b/zbus/src/message/field_code.rs
@@ -1,6 +1,5 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use static_assertions::assert_impl_all;
 use zvariant::Type;
 
 /// The message field code.
@@ -34,5 +33,3 @@ pub(crate) enum FieldCode {
     /// Code for [`Field::UnixFDs`](enum.Field.html#variant.UnixFDs).
     UnixFDs = 9,
 }
-
-assert_impl_all!(FieldCode: Send, Sync, Unpin);

--- a/zbus/src/message/fields.rs
+++ b/zbus/src/message/fields.rs
@@ -3,7 +3,6 @@ use serde::{
     ser::{SerializeSeq, SerializeStruct},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use static_assertions::assert_impl_all;
 use std::{borrow::Cow, num::NonZeroU32};
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, Signature, Type, Value};
@@ -26,8 +25,6 @@ pub(crate) struct Fields<'f> {
     pub signature: Cow<'f, Signature>,
     pub unix_fds: Option<u32>,
 }
-
-assert_impl_all!(Fields<'_>: Send, Sync, Unpin);
 
 impl Fields<'_> {
     /// Create an empty collection of fields.

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -7,7 +7,6 @@ use enumflags2::{bitflags, BitFlags};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use static_assertions::assert_impl_all;
 use zbus_names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName};
 use zvariant::{
     serialized::{self, Context},
@@ -30,8 +29,6 @@ pub enum EndianSig {
     /// The D-Bus message is in little-endian byte order.
     Little = b'l',
 }
-
-assert_impl_all!(EndianSig: Send, Sync, Unpin);
 
 // Such a shame I've to do this manually
 impl TryFrom<u8> for EndianSig {
@@ -87,8 +84,6 @@ pub enum Type {
     Signal = 4,
 }
 
-assert_impl_all!(Type: Send, Sync, Unpin);
-
 /// Pre-defined flags that can be passed in message headers.
 #[bitflags]
 #[repr(u8)]
@@ -111,8 +106,6 @@ pub enum Flags {
     AllowInteractiveAuth = 0x4,
 }
 
-assert_impl_all!(Flags: Send, Sync, Unpin);
-
 /// The primary message header, which is present in all D-Bus messages.
 ///
 /// This header contains all the essential information about a message, regardless of its type.
@@ -125,8 +118,6 @@ pub struct PrimaryHeader {
     body_len: u32,
     serial_num: NonZeroU32,
 }
-
-assert_impl_all!(PrimaryHeader: Send, Sync, Unpin);
 
 impl PrimaryHeader {
     /// Create a new `PrimaryHeader` instance.
@@ -243,8 +234,6 @@ pub struct Header<'m> {
     #[serde(borrow)]
     fields: Fields<'m>,
 }
-
-assert_impl_all!(Header<'_>: Send, Sync, Unpin);
 
 impl<'m> Header<'m> {
     /// Create a new `Header` instance.

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -1,7 +1,6 @@
 //! D-Bus Message.
 use std::{borrow::Cow, fmt, sync::Arc};
 
-use static_assertions::assert_impl_all;
 use zbus_names::{ErrorName, InterfaceName, MemberName};
 use zvariant::{serialized, Endian};
 
@@ -65,8 +64,6 @@ pub(super) struct Inner {
     pub(crate) body_offset: usize,
     pub(crate) recv_seq: Sequence,
 }
-
-assert_impl_all!(Message: Send, Sync, Unpin);
 
 impl Message {
     /// Create a builder for a message of type [`Type::MethodCall`].

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -7,7 +7,6 @@ use std::{
 use async_broadcast::Receiver as ActiveReceiver;
 use futures_core::stream::{self, FusedStream};
 use ordered_stream::{OrderedStream, PollResult};
-use static_assertions::assert_impl_all;
 use tracing::warn;
 
 use crate::{
@@ -31,8 +30,6 @@ use crate::{
 pub struct MessageStream {
     inner: Inner,
 }
-
-assert_impl_all!(MessageStream: Send, Sync, Unpin);
 
 impl MessageStream {
     /// Create a message stream for the given match rule.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -3,7 +3,6 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 use tracing::{debug, instrument, trace, trace_span, Instrument};
 
-use static_assertions::assert_impl_all;
 use zbus_names::InterfaceName;
 use zvariant::{ObjectPath, Value};
 
@@ -93,8 +92,6 @@ pub struct ObjectServer {
     conn: WeakConnection,
     root: Arc<RwLock<Node>>,
 }
-
-assert_impl_all!(ObjectServer: Send, Sync, Unpin);
 
 impl ObjectServer {
     /// Create a new D-Bus `ObjectServer`.

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 
-use static_assertions::assert_impl_all;
 use zbus_names::{BusName, InterfaceName};
 use zvariant::{ObjectPath, Str};
 
@@ -45,8 +44,6 @@ impl<T> Clone for Builder<'_, T> {
         }
     }
 }
-
-assert_impl_all!(Builder<'_>: Send, Sync, Unpin);
 
 impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -5,7 +5,6 @@ use event_listener::{Event, EventListener};
 use futures_core::{ready, stream};
 use futures_lite::stream::Map;
 use ordered_stream::{join as join_streams, FromFuture, Join, OrderedStream, PollResult};
-use static_assertions::assert_impl_all;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -73,8 +72,6 @@ pub use defaults::Defaults;
 pub struct Proxy<'a> {
     pub(crate) inner: Arc<ProxyInner<'a>>,
 }
-
-assert_impl_all!(Proxy<'_>: Send, Sync, Unpin);
 
 /// This is required to avoid having the Drop impl extend the lifetime 'a, which breaks zbus_xmlgen
 /// (and possibly other crates).
@@ -1062,8 +1059,6 @@ pub enum MethodFlags {
     AllowInteractiveAuth = 0x4,
 }
 
-assert_impl_all!(MethodFlags: Send, Sync, Unpin);
-
 impl From<MethodFlags> for Flags {
     fn from(method_flag: MethodFlags) -> Self {
         match method_flag {
@@ -1086,8 +1081,6 @@ pub struct OwnerChangedStream<'a> {
     stream: OwnerChangedStreamMap,
     name: BusName<'a>,
 }
-
-assert_impl_all!(OwnerChangedStream<'_>: Send, Sync, Unpin);
 
 impl<'a> OwnerChangedStream<'a> {
     /// The bus name being tracked.
@@ -1272,8 +1265,6 @@ impl<'a> SignalStream<'a> {
         Ok(false)
     }
 }
-
-assert_impl_all!(SignalStream<'_>: Send, Sync, Unpin);
 
 impl stream::Stream for SignalStream<'_> {
     type Item = Message;

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -1105,10 +1105,6 @@ fn gen_proxy_signal(
         #[derive(Debug)]
         #visibility struct #stream_name(#zbus::#signal_type<'static>);
 
-        #zbus::export::static_assertions::assert_impl_all!(
-            #stream_name: ::std::marker::Send, ::std::marker::Unpin
-        );
-
         impl #stream_name {
             /// Consumes `self`, returning the underlying `zbus::#signal_type`.
             pub fn into_inner(self) -> #zbus::#signal_type<'static> {

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0.200", features = ["derive"] }
 zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, features = [
     "enumflags2",
 ] }
-static_assertions = "1.1.0"
 winnow = "0.7"
 
 [dev-dependencies]

--- a/zbus_names/src/bus_name.rs
+++ b/zbus_names/src/bus_name.rs
@@ -10,7 +10,6 @@ use crate::{
     OwnedWellKnownName, Result, UniqueName, WellKnownName,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 
 /// String that identifies a [bus name].
@@ -54,8 +53,6 @@ pub enum BusName<'name> {
     #[serde(borrow)]
     WellKnown(WellKnownName<'name>),
 }
-
-assert_impl_all!(BusName<'_>: Send, Sync, Unpin);
 
 impl_str_basic!(BusName<'_>);
 

--- a/zbus_names/src/error.rs
+++ b/zbus_names/src/error.rs
@@ -1,4 +1,3 @@
-use static_assertions::assert_impl_all;
 use std::{convert::Infallible, error, fmt};
 use zvariant::Error as VariantError;
 
@@ -67,8 +66,6 @@ pub enum Error {
         to: &'static str,
     },
 }
-
-assert_impl_all!(Error: Send, Sync, Unpin);
 
 impl PartialEq for Error {
     #[allow(deprecated)]

--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -44,8 +43,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct ErrorName<'name>(Str<'name>);
-
-assert_impl_all!(ErrorName<'_>: Send, Sync, Unpin);
 
 impl_str_basic!(ErrorName<'_>);
 
@@ -197,8 +194,6 @@ impl<'name> NoneValue for ErrorName<'name> {
 /// Owned sibling of [`ErrorName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedErrorName(#[serde(borrow)] ErrorName<'static>);
-
-assert_impl_all!(OwnedErrorName: Send, Sync, Unpin);
 
 impl_str_basic!(OwnedErrorName);
 

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -44,8 +43,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 pub struct InterfaceName<'name>(Str<'name>);
 
 impl_str_basic!(InterfaceName<'_>);
-
-assert_impl_all!(InterfaceName<'_>: Send, Sync, Unpin);
 
 impl<'name> InterfaceName<'name> {
     /// This is faster than `Clone::clone` when `self` contains owned data.
@@ -230,8 +227,6 @@ impl<'name> NoneValue for InterfaceName<'name> {
 /// Owned sibling of [`InterfaceName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedInterfaceName(#[serde(borrow)] InterfaceName<'static>);
-
-assert_impl_all!(OwnedInterfaceName: Send, Sync, Unpin);
 
 impl_str_basic!(OwnedInterfaceName);
 

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -40,8 +39,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct MemberName<'name>(Str<'name>);
-
-assert_impl_all!(MemberName<'_>: Send, Sync, Unpin);
 
 impl_str_basic!(MemberName<'_>);
 
@@ -218,8 +215,6 @@ impl<'name> NoneValue for MemberName<'name> {
 /// Owned sibling of [`MemberName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedMemberName(#[serde(borrow)] MemberName<'static>);
-
-assert_impl_all!(OwnedMemberName: Send, Sync, Unpin);
 
 impl_str_basic!(OwnedMemberName);
 

--- a/zbus_names/src/property_name.rs
+++ b/zbus_names/src/property_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -35,8 +34,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct PropertyName<'name>(Str<'name>);
-
-assert_impl_all!(PropertyName<'_>: Send, Sync, Unpin);
 
 impl_str_basic!(PropertyName<'_>);
 
@@ -192,8 +189,6 @@ impl<'name> NoneValue for PropertyName<'name> {
 /// Owned sibling of [`PropertyName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedPropertyName(#[serde(borrow)] PropertyName<'static>);
-
-assert_impl_all!(OwnedPropertyName: Send, Sync, Unpin);
 
 impl_str_basic!(OwnedPropertyName);
 

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -39,8 +38,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
     Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
 )]
 pub struct UniqueName<'name>(pub(crate) Str<'name>);
-
-assert_impl_all!(UniqueName<'_>: Send, Sync, Unpin);
 
 impl_str_basic!(UniqueName<'_>);
 
@@ -213,8 +210,6 @@ impl<'name> NoneValue for UniqueName<'name> {
 /// Owned sibling of [`UniqueName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedUniqueName(#[serde(borrow)] UniqueName<'static>);
-
-assert_impl_all!(OwnedUniqueName: Send, Sync, Unpin);
 
 impl_str_basic!(OwnedUniqueName);
 

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -3,7 +3,6 @@ use crate::{
     Error, Result,
 };
 use serde::{de, Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{self, Debug, Display, Formatter},
@@ -42,8 +41,6 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 pub struct WellKnownName<'name>(pub(crate) Str<'name>);
 
 impl_str_basic!(WellKnownName<'_>);
-
-assert_impl_all!(WellKnownName<'_>: Send, Sync, Unpin);
 
 impl<'name> WellKnownName<'name> {
     /// This is faster than `Clone::clone` when `self` contains owned data.
@@ -219,8 +216,6 @@ impl<'name> NoneValue for WellKnownName<'name> {
 /// Owned sibling of [`WellKnownName`].
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
 pub struct OwnedWellKnownName(#[serde(borrow)] WellKnownName<'static>);
-
-assert_impl_all!(OwnedWellKnownName: Send, Sync, Unpin);
 
 impl OwnedWellKnownName {
     /// Convert to the inner `WellKnownName`, consuming `self`.

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0.200", features = ["derive"] }
 zvariant = { path = "../zvariant", version = "5.0.0", default-features = false }
 zbus_names = { path = "../zbus_names", version = "4.0" }
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
-static_assertions = "1.1.0"
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -1,5 +1,4 @@
 use quick_xml::de::DeError;
-use static_assertions::assert_impl_all;
 use std::{convert::Infallible, error, fmt};
 use zvariant::Error as VariantError;
 
@@ -13,8 +12,6 @@ pub enum Error {
     /// An XML error from quick_xml
     QuickXml(DeError),
 }
-
-assert_impl_all!(Error: Send, Sync, Unpin);
 
 impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -16,7 +16,6 @@ pub use error::{Error, Result};
 
 use quick_xml::{de::Deserializer, se::to_writer};
 use serde::{Deserialize, Serialize};
-use static_assertions::assert_impl_all;
 use std::{
     io::{BufReader, Read, Write},
     ops::Deref,
@@ -32,8 +31,6 @@ pub struct Annotation {
     #[serde(rename = "@value")]
     value: String,
 }
-
-assert_impl_all!(Annotation: Send, Sync, Unpin);
 
 impl Annotation {
     /// Return the annotation name/key.
@@ -69,8 +66,6 @@ pub struct Arg {
     annotations: Vec<Annotation>,
 }
 
-assert_impl_all!(Arg: Send, Sync, Unpin);
-
 impl Arg {
     /// Return the argument name, if any.
     pub fn name(&self) -> Option<&str> {
@@ -104,8 +99,6 @@ pub struct Method<'a> {
     annotations: Vec<Annotation>,
 }
 
-assert_impl_all!(Method<'_>: Send, Sync, Unpin);
-
 impl Method<'_> {
     /// Return the method name.
     pub fn name(&self) -> MemberName<'_> {
@@ -134,8 +127,6 @@ pub struct Signal<'a> {
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
 }
-
-assert_impl_all!(Signal<'_>: Send, Sync, Unpin);
 
 impl Signal<'_> {
     /// Return the signal name.
@@ -190,8 +181,6 @@ pub struct Property<'a> {
     annotations: Vec<Annotation>,
 }
 
-assert_impl_all!(Property<'_>: Send, Sync, Unpin);
-
 impl Property<'_> {
     /// Returns the property name.
     pub fn name(&self) -> PropertyName<'_> {
@@ -229,8 +218,6 @@ pub struct Interface<'a> {
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
 }
-
-assert_impl_all!(Interface<'_>: Send, Sync, Unpin);
 
 impl<'a> Interface<'a> {
     /// Returns the interface name.
@@ -270,8 +257,6 @@ pub struct Node<'a> {
     #[serde(rename = "node", default, borrow)]
     nodes: Vec<Node<'a>>,
 }
-
-assert_impl_all!(Node<'_>: Send, Sync, Unpin);
 
 impl<'a> Node<'a> {
     /// Parse the introspection XML document from reader.

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -26,7 +26,6 @@ zvariant_derive = { version = "=5.4.0", path = "../zvariant_derive" }
 zvariant_utils = { version = "3.1.0", path = "../zvariant_utils" }
 endi = "1.1.0"
 serde = { version = "1.0.200", features = ["derive"] }
-static_assertions = "1.1.0"
 winnow = "0.7"
 
 # Optional dependencies

--- a/zvariant/fuzz/Cargo.lock
+++ b/zvariant/fuzz/Cargo.lock
@@ -132,12 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "syn"
 version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +156,7 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -181,13 +175,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "zvariant"
-version = "5.2.0"
+version = "5.4.0"
 dependencies = [
  "endi",
  "serde",
- "static_assertions",
- "winnow",
+ "winnow 0.7.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -203,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.2.0"
+version = "5.4.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -214,12 +216,11 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
  "syn",
- "winnow",
+ "winnow 0.7.2",
 ]

--- a/zvariant/src/array.rs
+++ b/zvariant/src/array.rs
@@ -3,7 +3,6 @@ use serde::{
     de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
     ser::{Serialize, SerializeSeq, Serializer},
 };
-use static_assertions::assert_impl_all;
 use std::fmt::{Display, Write};
 
 use crate::{
@@ -22,8 +21,6 @@ pub struct Array<'a> {
     elements: Vec<Value<'a>>,
     signature: Signature,
 }
-
-assert_impl_all!(Array<'_>: Send, Sync, Unpin);
 
 impl<'a> Array<'a> {
     /// Create a new empty `Array`, given the signature of the elements.
@@ -202,8 +199,6 @@ impl ArraySeed {
         }
     }
 }
-
-assert_impl_all!(ArraySeed: Unpin);
 
 impl DynamicType for Array<'_> {
     fn signature(&self) -> Signature {

--- a/zvariant/src/deserialize_value.rs
+++ b/zvariant/src/deserialize_value.rs
@@ -2,7 +2,6 @@ use core::str;
 use std::marker::PhantomData;
 
 use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
-use static_assertions::assert_impl_all;
 
 use crate::{Signature, Type};
 
@@ -27,8 +26,6 @@ pub struct DeserializeValue<'de, T: Type + Deserialize<'de>>(
     pub T,
     std::marker::PhantomData<&'de T>,
 );
-
-assert_impl_all!(DeserializeValue<'_, i32>: Send, Sync, Unpin);
 
 impl<'de, T: Type + Deserialize<'de>> Deserialize<'de> for DeserializeValue<'de, T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use serde::ser::{Serialize, SerializeMap, Serializer};
-use static_assertions::assert_impl_all;
 
 use crate::{value_display_fmt, Basic, DynamicType, Error, Signature, Type, Value};
 
@@ -20,8 +19,6 @@ pub struct Dict<'k, 'v> {
     map: BTreeMap<Value<'k>, Value<'v>>,
     signature: Signature,
 }
-
-assert_impl_all!(Dict<'_, '_>: Send, Sync, Unpin);
 
 impl<'k, 'v> Dict<'k, 'v> {
     /// Create a new empty `Dict`, given the signature of the keys and values.

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -1,5 +1,4 @@
 use serde::{de, ser};
-use static_assertions::assert_impl_all;
 use std::{convert::Infallible, error, fmt, io, result, sync::Arc};
 
 use crate::Signature;
@@ -69,8 +68,6 @@ pub enum Error {
     /// Invalid object path.
     InvalidObjectPath,
 }
-
-assert_impl_all!(Error: Send, Sync, Unpin);
 
 impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -1,5 +1,4 @@
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-use static_assertions::assert_impl_all;
 use std::os::fd::{self, AsFd, AsRawFd, BorrowedFd, RawFd};
 
 use crate::{Basic, Type};
@@ -97,8 +96,6 @@ impl std::fmt::Display for Fd<'_> {
 
 macro_rules! fd_impl {
     ($i:ty) => {
-        assert_impl_all!($i: Send, Sync, Unpin);
-
         impl Basic for $i {
             const SIGNATURE_CHAR: char = 'h';
             const SIGNATURE_STR: &'static str = "h";

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -1,5 +1,4 @@
 use serde::ser::{Serialize, Serializer};
-use static_assertions::assert_impl_all;
 use std::fmt::Display;
 
 use crate::{value_display_fmt, Error, Signature, Type, Value};
@@ -14,8 +13,6 @@ pub struct Maybe<'a> {
     value: Box<Option<Value<'a>>>,
     signature: Signature,
 }
-
-assert_impl_all!(Maybe<'_>: Send, Sync, Unpin);
 
 impl<'a> Maybe<'a> {
     /// Get a reference to underlying value.

--- a/zvariant/src/object_path.rs
+++ b/zvariant/src/object_path.rs
@@ -3,7 +3,6 @@ use serde::{
     de::{self, Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
-use static_assertions::assert_impl_all;
 use std::borrow::Cow;
 
 use crate::{Basic, Error, Result, Str, Type};
@@ -34,8 +33,6 @@ use crate::{Basic, Error, Result, Str, Type};
 /// ```
 #[derive(PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub struct ObjectPath<'a>(Str<'a>);
-
-assert_impl_all!(ObjectPath<'_>: Send, Sync, Unpin);
 
 impl<'a> ObjectPath<'a> {
     /// This is faster than `Clone::clone` when `self` contains owned data.
@@ -266,8 +263,6 @@ fn validate(path: &[u8]) -> Result<()> {
 /// Owned [`ObjectPath`](struct.ObjectPath.html)
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, Type)]
 pub struct OwnedObjectPath(ObjectPath<'static>);
-
-assert_impl_all!(OwnedObjectPath: Send, Sync, Unpin);
 
 impl OwnedObjectPath {
     pub fn into_inner(self) -> ObjectPath<'static> {

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use static_assertions::assert_impl_all;
 use std::{collections::HashMap, hash::BuildHasher};
 
 use crate::{
@@ -19,8 +18,6 @@ use crate::Maybe;
 /// Owned [`Value`](enum.Value.html)
 #[derive(Debug, PartialEq, Serialize, Type)]
 pub struct OwnedValue(pub(crate) Value<'static>);
-
-assert_impl_all!(OwnedValue: Send, Sync, Unpin);
 
 impl OwnedValue {
     /// Attempt to clone the value.

--- a/zvariant/src/serialize_value.rs
+++ b/zvariant/src/serialize_value.rs
@@ -1,5 +1,4 @@
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use static_assertions::assert_impl_all;
 
 use crate::Type;
 
@@ -17,8 +16,6 @@ use crate::Type;
 ///
 /// [`Value`]: enum.Value.html
 pub struct SerializeValue<'a, T: Type + Serialize>(pub &'a T);
-
-assert_impl_all!(SerializeValue<'_, i32>: Send, Sync, Unpin);
 
 impl<T: Type + Serialize> Serialize for SerializeValue<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/zvariant/src/serialized/context.rs
+++ b/zvariant/src/serialized/context.rs
@@ -1,5 +1,3 @@
-use static_assertions::assert_impl_all;
-
 use crate::{serialized::Format, Endian};
 
 /// The encoding context to use with the [serialization and deserialization] API.
@@ -34,8 +32,6 @@ pub struct Context {
     position: usize,
     endian: Endian,
 }
-
-assert_impl_all!(Context: Send, Sync, Unpin);
 
 impl Context {
     /// Create a new encoding context.

--- a/zvariant/src/str.rs
+++ b/zvariant/src/str.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use static_assertions::assert_impl_all;
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -91,8 +90,6 @@ impl<'de: 'a, 'a> Deserialize<'de> for Inner<'a> {
         <&'a str>::deserialize(deserializer).map(Inner::Borrowed)
     }
 }
-
-assert_impl_all!(Str<'_>: Send, Sync, Unpin);
 
 impl Str<'_> {
     /// An owned string without allocations

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -3,7 +3,6 @@ use serde::{
     de::{DeserializeSeed, Deserializer, Error, SeqAccess, Visitor},
     ser::{Serialize, SerializeTupleStruct, Serializer},
 };
-use static_assertions::assert_impl_all;
 use std::fmt::{Display, Write};
 
 use crate::{
@@ -16,8 +15,6 @@ use crate::{
 /// [`Structure`]: struct.Structure.html
 #[derive(Debug, Default, PartialEq)]
 pub struct StructureBuilder<'a>(Vec<Value<'a>>);
-
-assert_impl_all!(StructureBuilder<'_>: Send, Sync, Unpin);
 
 impl<'a> StructureBuilder<'a> {
     /// Create a new `StructureBuilder`.
@@ -103,8 +100,6 @@ pub struct StructureSeed<'a> {
     phantom: std::marker::PhantomData<&'a ()>,
 }
 
-assert_impl_all!(StructureSeed<'_>: Unpin);
-
 impl StructureSeed<'static> {
     /// Create a new `StructureSeed`
     ///
@@ -178,8 +173,6 @@ pub struct Structure<'a> {
     fields: Vec<Value<'a>>,
     signature: Signature,
 }
-
-assert_impl_all!(Structure<'_>: Send, Sync, Unpin);
 
 impl<'a> Structure<'a> {
     /// Get a reference to all the fields of `self`.

--- a/zvariant/src/type/libstd.rs
+++ b/zvariant/src/type/libstd.rs
@@ -262,8 +262,6 @@ impl_type_for_wrapper!(Wrapping<T>, Saturating<T>, Reverse<T>);
 macro_rules! atomic_impl {
     ($($ty:ident $size:expr => $primitive:ident)*) => {
         $(
-            static_assertions::assert_impl_all!($ty: From<$primitive>);
-
             #[cfg(target_has_atomic = $size)]
             impl Type for $ty {
                 const SIGNATURE: &'static Signature = <$primitive as Type>::SIGNATURE;

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -16,7 +16,6 @@ use serde::{
         Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeTupleStruct, Serializer,
     },
 };
-use static_assertions::assert_impl_all;
 
 use crate::{
     array_display_fmt, dict_display_fmt, structure_display_fmt, utils::*, Array, Basic, Dict,
@@ -150,8 +149,6 @@ impl Ord for Value<'_> {
             })
     }
 }
-
-assert_impl_all!(Value<'_>: Send, Sync, Unpin);
 
 macro_rules! serialize_value {
     ($self:ident $serializer:ident.$method:ident $($first_arg:expr)*) => {

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -23,7 +23,6 @@ gvariant = []
 proc-macro2 = "1.0.81"
 syn = { version = "2.0.64", features = ["extra-traits", "full"] }
 quote = "1.0.36"
-static_assertions = "1.1.0"
 serde = "1.0.200"
 winnow = "0.7"
 

--- a/zvariant_utils/src/serialized.rs
+++ b/zvariant_utils/src/serialized.rs
@@ -1,5 +1,3 @@
-use static_assertions::assert_impl_all;
-
 /// The encoding format.
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
 pub enum Format {
@@ -11,8 +9,6 @@ pub enum Format {
     #[cfg(feature = "gvariant")]
     GVariant,
 }
-
-assert_impl_all!(Format: Send, Sync, Unpin);
 
 impl std::fmt::Display for Format {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/zvariant_utils/src/signature/child.rs
+++ b/zvariant_utils/src/signature/child.rs
@@ -10,7 +10,6 @@ pub enum Child {
     /// A dynamic child signature.
     Dynamic { child: Box<Signature> },
 }
-static_assertions::assert_impl_all!(Child: Send, Sync, Unpin);
 
 impl Child {
     /// The underlying child `Signature`.

--- a/zvariant_utils/src/signature/fields.rs
+++ b/zvariant_utils/src/signature/fields.rs
@@ -10,7 +10,6 @@ pub enum Fields {
         fields: Box<[Signature]>,
     },
 }
-static_assertions::assert_impl_all!(Fields: Send, Sync, Unpin);
 
 impl Fields {
     /// A iterator over the fields' signatures.


### PR DESCRIPTION
We were only using its `assert_impl_all` method, which seems to be not needed anymore because of sever checks in the CI:

https://github.com/dbus2/zbus/actions/runs/13395177653/job/37412291150?pr=1262
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
