### PR TITLE
🧑‍💻 all: Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,17 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,16 +2078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,7 +2113,6 @@ version = "5.5.0"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -2166,7 +2144,6 @@ dependencies = [
  "vsock",
  "windows-sys 0.59.0",
  "winnow 0.7.3",
- "xdg-home",
  "zbus_macros",
  "zbus_names",
  "zbus_xml",
@@ -2328,8 +2305,6 @@ dependencies = [
 name = "zvariant_utils"
 version = "3.2.0"
 dependencies = [
- "proc-macro2",
- "quote",
  "serde",
  "syn 2.0.99",
  "winnow 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,92 @@ repository = "https://github.com/dbus2/zbus/"
 [profile.bench]
 debug = true
 strip = "none"
+
+[workspace.dependencies]
+# Local dependencies
+zvariant_derive = { path = "./zvariant_derive" }
+zvariant_utils = { path = "./zvariant_utils" }
+zvariant = { path = "./zvariant", default-features = false }
+zbus_names = { path = "./zbus_names" }
+zbus_macros = { path = "./zbus_macros" }
+zbus_xml = { path = "./zbus_xml" }
+zbus = { path = "./zbus" }
+
+# 3rd party
+snakecase = "0.1.0"
+pretty_assertions = "1.4"
+clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+endi = "1.1.0"
+arrayvec = { version = "0.7.4", features = ["serde"] }
+uuid = { version = "1.8.0", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
+time = { version = "0.3.36", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"], default-features = false }
+heapless = { version = "0.8.0", features = ["serde"] }
+camino = "1.1.9"
+rand = "0.9.0"
+enumflags2 = { version = "0.7.9", features = ["serde"] }
+async-io = "2.3.2"
+async-broadcast = "0.7.0"
+async-lock = "3.3.0"
+async-executor = "1.11.0"
+async-trait = "0.1.80"
+hex = "0.4.3"
+ordered-stream = "0.2"
+futures-util = { version = "0.3.30", default-features = false }
+futures-core = "0.3.30"
+futures-lite = { version = "2.6.0", default-features = false, features = [
+    "std",
+] }
+
+quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
+event-listener = "5.3.0"
+xdg-home = "1.1.0"
+tracing = "0.1.40"
+blocking = "1.6.0"
+async-task = "4.7.1"
+async-fs = "2.1.2"
+async-process = "2.2.2"
+tokio = "1.37.0"
+vsock = "0.5.0"
+tokio-vsock = "0.7"
+ntest = "0.9.2"
+test-log = { version = "0.2.16", features = [
+    "trace",
+], default-features = false }
+tracing-subscriber = { version = "0.3.18", features = [
+    "env-filter",
+    "fmt",
+    "ansi",
+], default-features = false }
+tempfile = "3.10.1"
+serde = { version = "1.0.200", features = ["derive"] }
+serde_repr = "0.1.19"
+serde_bytes = "0.11.14"
+serde_json = "1.0.116"
+criterion = "0.5.1"
+doc-comment = "0.3.3"
+proc-macro2 = "1.0.81"
+proc-macro-crate = "3.2.0"
+syn = { version = "2.0.64", features = ["extra-traits", "full"] }
+quote = "1.0.36"
+static_assertions = "1.1.0"
+async-recursion = "1.1.1"
+winnow = "0.7"
+uds_windows = "1.1.0"
+nix = { version = "0.29", default-features = false, features = [
+    "socket",
+    "uio",
+    "user",
+] }
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security_Authorization",
+    "Win32_System_Memory",
+    "Win32_Networking",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+] }

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -29,6 +29,7 @@ p2p = ["dep:rand"]
 async-io = [
     "dep:async-io",
     "async-executor",
+  "async-fs",
     "async-task",
     "async-lock",
     # FIXME: We only currently only need this for unix but Cargo doesn't provide a way to enable
@@ -43,6 +44,8 @@ tokio-vsock = ["dep:tokio-vsock", "tokio"]
 blocking-api = ["zbus_macros/blocking-api"]
 # Enable `serde_bytes` feature of `zvariant`.
 serde_bytes = ["zvariant/serde_bytes"]
+# Dummy features to satisfy `cargo semver`. Should be removed at the next major version bump.
+async-fs = []
 
 [dependencies]
 zbus_macros.workspace = true

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -27,15 +27,14 @@ bus-impl = ["p2p"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["dep:rand"]
 async-io = [
-  "dep:async-io",
-  "async-executor",
-  "async-task",
-  "async-lock",
-  "async-fs",
-  # FIXME: We only currently only need this for unix but Cargo doesn't provide a way to enable
-  # features for only specific target OS: https://github.com/rust-lang/cargo/issues/1197.
-  "async-process",
-  "blocking",
+    "dep:async-io",
+    "async-executor",
+    "async-task",
+    "async-lock",
+    # FIXME: We only currently only need this for unix but Cargo doesn't provide a way to enable
+    # features for only specific target OS: https://github.com/rust-lang/cargo/issues/1197.
+    "async-process",
+    "blocking",
 ]
 tokio = ["dep:tokio"]
 vsock = ["dep:vsock", "dep:async-io"]
@@ -46,101 +45,80 @@ blocking-api = ["zbus_macros/blocking-api"]
 serde_bytes = ["zvariant/serde_bytes"]
 
 [dependencies]
-zbus_macros = { path = "../zbus_macros", version = "=5.5.0" }
-zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, features = [
-  "enumflags2",
-] }
-zbus_names = { path = "../zbus_names", version = "4.0" }
-serde = { version = "1.0.200", features = ["derive"] }
-serde_repr = "0.1.19"
-enumflags2 = { version = "0.7.9", features = ["serde"] }
-futures-core = "0.3.30"
-futures-lite = { version = "2.6.0", default-features = false, features = [
-  "std",
-] }
-async-broadcast = "0.7.0"
-hex = "0.4.3"
-ordered-stream = "0.2"
-rand = { version = "0.9.0", optional = true }
-event-listener = "5.3.0"
-async-trait = "0.1.80"
-xdg-home = "1.1.0"
-tracing = "0.1.40"
-winnow = "0.7"
+zbus_macros.workspace = true
+zvariant = { workspace = true, features = ["enumflags2"] }
+zbus_names.workspace = true
+
+serde.workspace = true
+serde_repr.workspace = true
+enumflags2.workspace = true
+futures-core.workspace = true
+futures-lite.workspace = true
+async-broadcast.workspace = true
+hex.workspace = true
+ordered-stream.workspace = true
+rand = { workspace = true, optional = true }
+event-listener.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+winnow.workspace = true
 
 # Optional and target-specific dependencies.
-
-async-io = { version = "2.3.2", optional = true }
-async-lock = { version = "3.3.0", optional = true }
-async-executor = { version = "1.11.0", optional = true }
-blocking = { version = "1.6.0", optional = true }
-async-task = { version = "4.7.1", optional = true }
-async-fs = { version = "2.1.2", optional = true }
-async-process = { version = "2.2.2", optional = true }
-tokio = { version = "1.37.0", optional = true, features = [
-  "rt",
-  "net",
-  "time",
-  "fs",
-  "io-util",
-  # FIXME: We should only enable this feature for unix. See comment above regarding `async-process`
-  # on why we can't.
-  "process",
-  "sync",
-  "tracing",
+async-io = { workspace = true, optional = true }
+async-lock = { workspace = true, optional = true }
+async-executor = { workspace = true, optional = true }
+blocking = { workspace = true, optional = true }
+async-task = { workspace = true, optional = true }
+async-process = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = [
+    "rt",
+    "net",
+    "time",
+    "fs",
+    "io-util",
+    # FIXME: We should only enable this feature for unix. See comment above regarding `async-process`
+    # on why we can't.
+    "process",
+    "sync",
+    "tracing",
 ] }
-vsock = { version = "0.5.0", optional = true }
-tokio-vsock = { version = "0.7", optional = true }
+vsock = { workspace = true, optional = true }
+tokio-vsock = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = [
-  "Win32_Foundation",
-  "Win32_Security_Authorization",
-  "Win32_System_Memory",
-  "Win32_Networking",
-  "Win32_Networking_WinSock",
-  "Win32_NetworkManagement",
-  "Win32_NetworkManagement_IpHelper",
-  "Win32_System_IO",
-  "Win32_System_Threading",
-] }
-uds_windows = "1.1.0"
+windows-sys.workspace = true
+uds_windows.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", default-features = false, features = [
-  "socket",
-  "uio",
-  "user",
-] }
+nix.workspace = true
 
 [target.'cfg(any(target_os = "macos", windows))'.dependencies]
-async-recursion = "1.1.1"
+async-recursion.workspace = true
 
 [dev-dependencies]
-zbus_xml = { path = "../zbus_xml", version = "5.0.0" }
-doc-comment = "0.3.3"
-futures-util = { version = "0.3.30", features = ["io"] }
-ntest = "0.9.2"
-test-log = { version = "0.2.16", features = [
-  "trace",
-], default-features = false }
-tokio = { version = "1.37.0", features = [
-  "macros",
-  "rt-multi-thread",
-  "fs",
-  "io-util",
-  "net",
-  "sync",
-  "time",
-  "test-util",
+zbus_xml.workspace = true
+
+doc-comment.workspace = true
+futures-util = { workspace = true, features = [
+    "io",
+    "async-await-macro",
+    "async-await",
 ] }
-tracing-subscriber = { version = "0.3.18", features = [
-  "env-filter",
-  "fmt",
-  "ansi",
-], default-features = false }
-tempfile = "3.10.1"
-criterion = "0.5.1"
+ntest.workspace = true
+test-log.workspace = true
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "fs",
+    "io-util",
+    "net",
+    "sync",
+    "time",
+    "test-util",
+] }
+tracing-subscriber.workspace = true
+tempfile.workspace = true
+criterion.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -71,7 +71,6 @@ async-io = { workspace = true, optional = true }
 async-lock = { workspace = true, optional = true }
 async-executor = { workspace = true, optional = true }
 blocking = { workspace = true, optional = true }
-async-task = { workspace = true, optional = true }
 async-process = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
     "rt",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -29,7 +29,7 @@ p2p = ["dep:rand"]
 async-io = [
     "dep:async-io",
     "async-executor",
-  "async-fs",
+    "async-fs",
     "async-task",
     "async-lock",
     # FIXME: We only currently only need this for unix but Cargo doesn't provide a way to enable
@@ -71,6 +71,7 @@ async-io = { workspace = true, optional = true }
 async-lock = { workspace = true, optional = true }
 async-executor = { workspace = true, optional = true }
 blocking = { workspace = true, optional = true }
+async-task = { workspace = true, optional = true }
 async-process = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
     "rt",

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -26,19 +26,20 @@ gvariant = ["zvariant/gvariant", "zvariant_utils/gvariant"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.81"
-syn = { version = "2.0.64", features = ["extra-traits", "fold", "full"] }
-quote = "1.0.36"
-proc-macro-crate = "3.2.0"
-zvariant = { path = "../zvariant", version = "5.0.0", default-features = false }
-zbus_names = { path = "../zbus_names", version = "4.0" }
-zvariant_utils = { path = "../zvariant_utils", version = "3.1.0" }
+proc-macro2.workspace = true
+syn = { workspace = true, features = ["extra-traits", "fold", "full"] }
+quote.workspace = true
+proc-macro-crate.workspace = true
+
+zvariant.workspace = true
+zbus_names.workspace = true
+zvariant_utils.workspace = true
 
 [dev-dependencies]
-zbus = { path = "../zbus" }
-serde = { version = "1.0.200", features = ["derive"] }
-async-io = "2.3.2"
-futures-util = { version = "0.3.30", default-features = false }
+zbus.workspace = true
+serde.workspace = true
+async-io.workspace = true
+futures-util.workspace = true
 
 [lints]
 workspace = true

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -13,14 +13,13 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.200", features = ["derive"] }
-zvariant = { path = "../zvariant", version = "5.0.0", default-features = false, features = [
-    "enumflags2",
-] }
-winnow = "0.7"
+zvariant = { workspace = true, features = [ "enumflags2"] }
+
+serde.workspace = true 
+winnow.workspace = true
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion.workspace = true
 
 [lib]
 bench = false

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -13,13 +13,13 @@ categories = ["parsing"]
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.200", features = ["derive"] }
-zvariant = { path = "../zvariant", version = "5.0.0", default-features = false }
-zbus_names = { path = "../zbus_names", version = "4.0" }
-quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
+serde.workspace = true
+zvariant.workspace = true
+zbus_names.workspace = true
+quick-xml.workspace = true
 
 [dev-dependencies]
-doc-comment = "0.3.3"
+doc-comment.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -25,13 +25,15 @@ name = "zbus-xmlgen"
 path = "src/main.rs"
 
 [dependencies]
-zbus = { path = "../zbus", version = "5.0.0", features = ["blocking-api"] }
-zbus_xml = { path = "../zbus_xml", version = "5.0.0" }
-snakecase = "0.1.0"
-clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+zbus = { workspace = true, features = ["blocking-api"] }
+zbus_xml.workspace = true
+
+snakecase.workspace = true
+clap.workspace = true
+
 
 [dev-dependencies]
-pretty_assertions = "1.4"
+pretty_assertions.workspace = true
 
 [lints]
 workspace = true

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -22,35 +22,30 @@ option-as-array = []
 camino = ["dep:camino"]
 
 [dependencies]
-zvariant_derive = { version = "=5.4.0", path = "../zvariant_derive" }
-zvariant_utils = { version = "3.1.0", path = "../zvariant_utils" }
-endi = "1.1.0"
-serde = { version = "1.0.200", features = ["derive"] }
-winnow = "0.7"
+zvariant_derive.workspace = true
+zvariant_utils.workspace = true
+endi.workspace = true
+serde.workspace = true
+winnow.workspace = true
 
 # Optional dependencies
+arrayvec = { workspace = true, optional = true }
+enumflags2 = { workspace = true, optional = true }
+serde_bytes = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+time = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+heapless = { workspace = true, optional = true }
+camino = { workspace = true, optional = true }
 
-arrayvec = { version = "0.7.4", features = ["serde"], optional = true }
-enumflags2 = { version = "0.7.9", features = ["serde"], optional = true }
-serde_bytes = { version = "0.11.14", optional = true }
-uuid = { version = "1.8.0", features = ["serde"], optional = true }
-url = { version = "2.5.0", features = ["serde"], optional = true }
-time = { version = "0.3.36", features = ["serde"], optional = true }
-chrono = { version = "0.4.38", features = [
-    "serde",
-], default-features = false, optional = true }
-heapless = { version = "0.8.0", features = ["serde"], optional = true }
-camino = { version = "1.1.9", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.116"
-serde_repr = "0.1.19"
-rand = "0.9.0"
-criterion = "0.5.1"
-chrono = { version = "0.4.38", features = [
-    "serde",
-    "alloc",
-], default-features = false }
+serde_json.workspace = true 
+serde_repr.workspace = true
+rand.workspace = true
+criterion.workspace = true
+chrono = { workspace = true, features = [ "serde", "alloc"], default-features = false }
 
 [lib]
 bench = false

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -21,17 +21,17 @@ default = []
 gvariant = ["zvariant_utils/gvariant", "zvariant/gvariant"]
 
 [dependencies]
-proc-macro2 = "1.0.81"
-syn = { version = "2.0.64", features = ["extra-traits", "full"] }
-quote = "1.0.36"
-proc-macro-crate = "3.2.0"
-zvariant_utils = { path = "../zvariant_utils", version = "3.1.0" }
+proc-macro2.workspace = true
+syn.workspace = true
+quote.workspace = true
+proc-macro-crate.workspace = true
+zvariant_utils.workspace = true
 
 [dev-dependencies]
-zvariant = { path = "../zvariant", features = ["enumflags2"] }
-enumflags2 = { version = "0.7.9", features = ["serde"] }
-serde = { version = "1.0.200", features = ["derive"] }
-serde_repr = "0.1.19"
+zvariant = { workspace = true, features = ["enumflags2"] }
+enumflags2.workspace = true
+serde.workspace = true
+serde_repr.workspace = true
 
 [lints]
 workspace = true

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -20,14 +20,12 @@ default = []
 gvariant = []
 
 [dependencies]
-proc-macro2 = "1.0.81"
-syn = { version = "2.0.64", features = ["extra-traits", "full"] }
-quote = "1.0.36"
-serde = "1.0.200"
-winnow = "0.7"
+syn.workspace = true
+serde.workspace = true
+winnow.workspace = true
 
 [dev-dependencies]
-zvariant = { path = "../zvariant" }
+zvariant.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Move dependencies to workspace. 

It will facilitate a future upgrade of dependency.
