### PR TITLE
⚡️zb: don't clone signature when creating body

### DIFF
--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -33,6 +33,9 @@ fn msg_de(c: &mut Criterion) {
         b.iter(|| {
             let header = msg.header();
             black_box(header);
+            let body = msg.body();
+            let signature = body.signature();
+            black_box(signature);
         })
     });
 
@@ -43,6 +46,8 @@ fn msg_de(c: &mut Criterion) {
     g.bench_function("body", |b| {
         b.iter(|| {
             let body = msg.body();
+            let signature = body.signature();
+            black_box(signature);
             let body: BigBoy<'_> = body.deserialize().unwrap();
             black_box(body);
         })

--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -12,18 +12,11 @@ use crate::{Error, Message, Result};
 pub struct Body {
     data: Data<'static, 'static>,
     msg: Message,
-    signature: Signature,
 }
 
 impl Body {
     pub(super) fn new(data: Data<'static, 'static>, msg: Message) -> Self {
-        let body_sig = msg.header().signature().clone();
-
-        Self {
-            data,
-            msg,
-            signature: body_sig,
-        }
+        Self { data, msg }
     }
 
     /// Deserialize the body using the contained signature.
@@ -31,8 +24,7 @@ impl Body {
     where
         B: zvariant::DynamicDeserialize<'s>,
     {
-        let header = self.msg.header();
-        let body_sig = header.signature();
+        let body_sig = self.signature();
 
         self.data
             .deserialize_for_dynamic_signature(body_sig)
@@ -50,7 +42,7 @@ impl Body {
 
     /// The signature of the body.
     pub fn signature(&self) -> &Signature {
-        &self.signature
+        self.msg.quick_fields().signature()
     }
 
     /// The length of the body in bytes.


### PR DESCRIPTION
We saw performance uplifts in the range of 10-15% in parsing events just by not cloning, reparsing the signature every time a body was created.

Hopefully it's a small enough change that it's easy to review.

This directly reduces the cost of calling `Body::new(...)` by 90-95%.