### PR TITLE
Support ProcessFD in fdo::DBus::get_connection_credentials'

### DIFF
--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -69,6 +69,11 @@ impl super::ReadHalf for Reader {
         })
     }
 
+    /// Supports passing file descriptors.
+    fn can_pass_unix_fd(&self) -> bool {
+        true
+    }
+
     async fn peer_credentials(&mut self) -> io::Result<ConnectionCredentials> {
         self_credentials().await
     }
@@ -103,6 +108,11 @@ impl super::WriteHalf for Writer {
         self.0.close();
 
         Ok(())
+    }
+
+    /// Supports passing file descriptors.
+    fn can_pass_unix_fd(&self) -> bool {
+        true
     }
 
     async fn peer_credentials(&mut self) -> io::Result<ConnectionCredentials> {

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -93,7 +93,7 @@ pub trait ReadHalf: std::fmt::Debug + Send + Sync + 'static {
         &mut self,
         seq: u64,
         already_received_bytes: &mut Vec<u8>,
-        #[cfg(unix)] already_received_fds: &mut Vec<std::os::fd::OwnedFd>,
+        #[cfg(unix)] already_received_fds: &mut Vec<OwnedFd>,
     ) -> crate::Result<Message> {
         #[cfg(unix)]
         let mut fds = vec![];
@@ -347,7 +347,7 @@ impl ReadHalf for Box<dyn ReadHalf> {
         &mut self,
         seq: u64,
         already_received_bytes: &mut Vec<u8>,
-        #[cfg(unix)] already_received_fds: &mut Vec<std::os::fd::OwnedFd>,
+        #[cfg(unix)] already_received_fds: &mut Vec<OwnedFd>,
     ) -> crate::Result<Message> {
         (**self)
             .receive_message(

--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -103,7 +103,7 @@ impl super::WriteHalf for Arc<Async<UnixStream>> {
     }
 
     async fn peer_credentials(&mut self) -> io::Result<crate::fdo::ConnectionCredentials> {
-        get_unix_peer_creds(self).await
+        super::ReadHalf::peer_credentials(self).await
     }
 }
 

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -356,12 +356,13 @@ async fn test_freedesktop_credentials() -> Result<()> {
         u32::from(Uid::effective()),
         credentials.unix_user_id().unwrap()
     );
-    credentials
-        .unix_group_ids()
-        .unwrap()
-        .iter()
-        .find(|group| **group == u32::from(Gid::effective()))
-        .unwrap();
+
+    if let Some(group_ids) = credentials.unix_group_ids() {
+        group_ids
+            .iter()
+            .find(|group| **group == u32::from(Gid::effective()))
+            .unwrap();
+    }
 
     Ok(())
 }

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -345,18 +345,8 @@ async fn test_freedesktop_credentials() -> Result<()> {
         if let Some(fd) = credentials.process_fd() {
             let fd = fd.as_raw_fd();
             let fdinfo = read_to_string(&format!("/proc/self/fdinfo/{fd}")).await?;
-            let pidline = fdinfo
-                .split("\n")
-                .into_iter()
-                .find(|s| s.starts_with("Pid:"))
-                .unwrap();
-            let pid: u32 = pidline
-                .split("\t")
-                .into_iter()
-                .last()
-                .unwrap()
-                .parse()
-                .unwrap();
+            let pidline = fdinfo.split('\n').find(|s| s.starts_with("Pid:")).unwrap();
+            let pid: u32 = pidline.split('\t').next_back().unwrap().parse().unwrap();
             assert_eq!(std::process::id(), pid);
         }
     }

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -330,7 +330,6 @@ async fn test_freedesktop_api() -> Result<()> {
 #[instrument]
 async fn test_freedesktop_credentials() -> Result<()> {
     use nix::unistd::{Gid, Uid};
-    use std::os::fd::AsRawFd;
 
     let connection = Connection::session().await?;
     let dbus = zbus::fdo::DBusProxy::new(&connection).await?;
@@ -340,9 +339,12 @@ async fn test_freedesktop_credentials() -> Result<()> {
 
     #[cfg(target_os = "linux")]
     {
+        use std::os::fd::AsRawFd;
+        use tokio::fs::read_to_string;
+
         if let Some(fd) = credentials.process_fd() {
             let fd = fd.as_raw_fd();
-            let fdinfo = tokio::fs::read_to_string(&format!("/proc/self/fdinfo/{fd}")).await?;
+            let fdinfo = read_to_string(&format!("/proc/self/fdinfo/{fd}")).await?;
             let pidline = fdinfo
                 .split("\n")
                 .into_iter()


### PR DESCRIPTION
Add support for the ProcessFD key in `org.freedesktop.DBus.GetConnectionCredentials` to zbus (and thus to busd) by adding the socket pidfd to `ConnectionCredentials` in `socket::unix::get_unix_peer_creds_blocking`.