### PR TITLE
⚡️ zx: Remove a needless iteration

### DIFF
--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             OutputTarget::MultipleFiles => {
                 let filename = interface_name
                     .split('.')
-                    .last()
+                    .next_back()
                     .expect("Failed to split name");
                 let filename = to_snakecase(filename);
                 std::fs::write(format!("{}.rs", &filename), output)?;


### PR DESCRIPTION
Clippy:

```rust
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> zbus_xmlgen/src/main.rs:101:22
    |
101 |                     .last()
    |                      ^^^^^^ help: try: `next_back()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
    = note: `#[warn(clippy::double_ended_iterator_last)]` on by default
```
