### PR TITLE
🐛 zbus: Fix typing of zbus::fdo::stats::get_stats

### DIFF
--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -17,13 +17,13 @@ use crate::proxy;
     default_path = "/org/freedesktop/DBus"
 )]
 pub trait Stats {
-    /// GetStats (undocumented)
-    fn get_stats(&self) -> Result<Vec<HashMap<String, OwnedValue>>>;
+    /// GetStats (undocumented - tested with dbus-broker-36-4)
+    fn get_stats(&self) -> Result<HashMap<String, OwnedValue>>;
 
-    /// GetConnectionStats (undocumented)
+    /// GetConnectionStats (undocumented - unimplemented with dbus-broker-36-4)
     fn get_connection_stats(&self, name: BusName<'_>) -> Result<Vec<HashMap<String, OwnedValue>>>;
 
-    /// GetAllMatchRules (undocumented)
+    /// GetAllMatchRules (undocumented - unimplemented with dbus-broker-36-4)
     fn get_all_match_rules(
         &self,
     ) -> Result<Vec<HashMap<crate::names::OwnedUniqueName, Vec<crate::OwnedMatchRule>>>>;


### PR DESCRIPTION
- Fix the typing we return data
- Commented each method had been at least attempted to be tested on `dbus-broker-36-4`
- Only get_stats() is implemented, others are not

Testing:
- Added a temporary "integration test" into zbus/fdo/mod.rs to see a valid object being returned
  - https://pastebin.com/2ShrnYmV
- Removed and ran tests
  - `cargo test --all-features`
  - `test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.27s`

Happy to adjust or remove comments etc.