### PR TITLE
🚑️ zb: Fix fdo::StatsProxy method return values

### DIFF
--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -10,19 +10,26 @@ use zvariant::OwnedValue;
 use super::Result;
 use crate::proxy;
 
-/// Proxy for the `org.freedesktop.DBus.Debug.Stats` interface.
+/// Proxy for the [`org.freedesktop.DBus.Debug.Stats`][link] interface.
+///
+/// [link]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-debug-stats-interface
 #[proxy(
     interface = "org.freedesktop.DBus.Debug.Stats",
     default_service = "org.freedesktop.DBus",
     default_path = "/org/freedesktop/DBus"
 )]
 pub trait Stats {
-    /// GetStats (undocumented)
+    /// Get statistics about the message bus itself.
     fn get_stats(&self) -> Result<HashMap<String, OwnedValue>>;
 
-    /// GetConnectionStats (undocumented)
+    /// Get statistics about a connection, identified by its unique connection name or by any
+    /// well-known bus name for which it is the primary owner. This method is not meaningful for
+    /// the message bus `org.freedesktop.DBus` itself.
     fn get_connection_stats(&self, name: BusName<'_>) -> Result<HashMap<String, OwnedValue>>;
 
-    /// GetAllMatchRules (undocumented)
+    /// List all of the match rules that are active on this message bus. The keys in the result
+    /// dictionary are unique connection names. The values are lists of match rules registered by
+    /// that connection, in an unspecified order. If a connection has registered the same match rule
+    /// more than once, it is unspecified whether duplicate entries appear in the list.
     fn get_all_match_rules(&self) -> Result<HashMap<OwnedUniqueName, Vec<crate::OwnedMatchRule>>>;
 }

--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -4,7 +4,7 @@
 //! be useful across various D-Bus applications. This module provides their proxy.
 
 use std::collections::HashMap;
-use zbus_names::BusName;
+use zbus_names::{BusName, OwnedUniqueName};
 use zvariant::OwnedValue;
 
 use super::Result;
@@ -18,13 +18,11 @@ use crate::proxy;
 )]
 pub trait Stats {
     /// GetStats (undocumented)
-    fn get_stats(&self) -> Result<Vec<HashMap<String, OwnedValue>>>;
+    fn get_stats(&self) -> Result<HashMap<String, OwnedValue>>;
 
     /// GetConnectionStats (undocumented)
-    fn get_connection_stats(&self, name: BusName<'_>) -> Result<Vec<HashMap<String, OwnedValue>>>;
+    fn get_connection_stats(&self, name: BusName<'_>) -> Result<HashMap<String, OwnedValue>>;
 
     /// GetAllMatchRules (undocumented)
-    fn get_all_match_rules(
-        &self,
-    ) -> Result<Vec<HashMap<crate::names::OwnedUniqueName, Vec<crate::OwnedMatchRule>>>>;
+    fn get_all_match_rules(&self) -> Result<HashMap<OwnedUniqueName, Vec<crate::OwnedMatchRule>>>;
 }


### PR DESCRIPTION
The return value of the methods were wrong so we fix it now but since that involves (theoretically) breaking the API, we go one step further and provide a more specific (and hence nicer) API.
    
Fixes #1341.