### PR TITLE
🚧 zv: Turn SerializeDict & DeserializeDict into wrappers around serde::{Serialize,Deserialize}

### DIFF
--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -1,5 +1,5 @@
 use serde::{
-    ser::{self, SerializeSeq, SerializeTuple},
+    ser::{self, SerializeMap, SerializeSeq, SerializeTuple},
     Serialize,
 };
 use std::{
@@ -338,6 +338,7 @@ where
             Signature::Structure(_) => {
                 StructSerializer::structure(self).map(StructSeqSerializer::Struct)
             }
+            Signature::Dict { .. } => self.serialize_map(Some(len)).map(StructSeqSerializer::Map),
             _ => Err(Error::SignatureMismatch(
                 self.0.signature.clone(),
                 "a struct, array or variant".to_string(),
@@ -554,6 +555,7 @@ where
 pub enum StructSeqSerializer<'ser, 'b, W> {
     Struct(StructSerializer<'ser, 'b, W>),
     Seq(SeqSerializer<'ser, 'b, W>),
+    Map(MapSerializer<'ser, 'b, W>),
 }
 
 macro_rules! serialize_struct_anon_fields {
@@ -591,6 +593,7 @@ macro_rules! serialize_struct_anon_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.$method(value),
                     StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Map(_) => unreachable!(),
                 }
             }
 
@@ -598,6 +601,7 @@ macro_rules! serialize_struct_anon_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.end_struct(),
                     StructSeqSerializer::Seq(ser) => ser.end_seq(),
+                    StructSeqSerializer::Map(_) => unreachable!(),
                 }
             }
         }
@@ -607,13 +611,13 @@ serialize_struct_anon_fields!(SerializeTuple serialize_element);
 serialize_struct_anon_fields!(SerializeTupleStruct serialize_field);
 serialize_struct_anon_fields!(SerializeTupleVariant serialize_field);
 
-pub(crate) struct MapSerializer<'ser, 'b, W> {
+pub struct MapSerializer<'ser, 'b, W> {
     seq: SeqSerializer<'ser, 'b, W>,
     key_signature: &'ser Signature,
     value_signature: &'ser Signature,
 }
 
-impl<W> ser::SerializeMap for MapSerializer<'_, '_, W>
+impl<W> SerializeMap for MapSerializer<'_, '_, W>
 where
     W: Write + Seek,
 {
@@ -680,6 +684,10 @@ macro_rules! serialize_struct_named_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.serialize_field(key, value),
                     StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Map(ser) => {
+                        ser.serialize_key(key)?;
+                        ser.serialize_value(value)
+                    }
                 }
             }
 
@@ -687,6 +695,7 @@ macro_rules! serialize_struct_named_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.end_struct(),
                     StructSeqSerializer::Seq(ser) => ser.end_seq(),
+                    StructSeqSerializer::Map(ser) => ser.end(),
                 }
             }
         }


### PR DESCRIPTION
We have discussed this on and off before but I think last time we really looked into it some years back, our ser/de machinery was needlessly over-complicated and therefore very fragile so it wasn't easy to make this work. However, now it seems like it'd be very much possible, especially after the first commit here (e2b2fcd0d2521a7b9a1e5cbf2208fe288948e763).

This will automatically fix various rough edges with our macros, like #1344.

~~Having said that, I'm quite busy these days with other stuff so maybe someone else can help me finish this PR? If not, I'll get to it in few weeks hopefully.~~
