### PR TITLE
Deprecate *Dict derive macros

### DIFF
--- a/zbus/README.md
+++ b/zbus/README.md
@@ -86,7 +86,7 @@ trait MyGreeter {
 async fn main() -> Result<()> {
     let connection = Connection::session().await?;
 
-    // `proxy` macro creates `MyGreaterProxy` based on `Notifications` trait.
+    // `proxy` macro creates `MyGreaterProxy` based on `MyGreeter` trait.
     let proxy = MyGreeterProxy::new(&connection).await?;
     let reply = proxy.say_hello("Maria").await?;
     println!("{reply}");

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -12,7 +12,7 @@ use zbus_names::{
 };
 #[cfg(unix)]
 use zvariant::OwnedFd;
-use zvariant::{DeserializeDict, Optional, SerializeDict, Type};
+use zvariant::{dict_utils::opt_value, Optional, Type};
 
 use super::Result;
 use crate::{proxy, OwnedGuid};
@@ -112,26 +112,51 @@ pub enum ReleaseNameReply {
 ///
 /// **Note**: unknown keys, in particular those with "." that are not from the specification, will
 /// be ignored. Use your own implementation or contribute your keys here, or in the specification.
-#[derive(Debug, Default, DeserializeDict, PartialEq, Eq, SerializeDict, Type)]
+#[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize, Type)]
 #[zvariant(signature = "a{sv}")]
+#[serde(default)]
 pub struct ConnectionCredentials {
-    #[zvariant(rename = "UnixUserID")]
+    #[serde(
+        rename = "UnixUserID",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) unix_user_id: Option<u32>,
 
-    #[zvariant(rename = "UnixGroupIDs")]
+    #[serde(
+        rename = "UnixGroupIDs",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) unix_group_ids: Option<Vec<u32>>,
 
     #[cfg(unix)]
-    #[zvariant(rename = "ProcessFD")]
+    #[serde(
+        rename = "ProcessFD",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) process_fd: Option<OwnedFd>,
 
-    #[zvariant(rename = "ProcessID")]
+    #[serde(
+        rename = "ProcessID",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) process_id: Option<u32>,
 
-    #[zvariant(rename = "WindowsSID")]
+    #[serde(
+        rename = "WindowsSID",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) windows_sid: Option<String>,
 
-    #[zvariant(rename = "LinuxSecurityLabel")]
+    #[serde(
+        rename = "LinuxSecurityLabel",
+        with = "opt_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) linux_security_label: Option<Vec<u8>>,
 }
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -19,7 +19,7 @@ use zbus::{
     object_server::ResponseDispatchNotifier,
     DBusError, Error, Message, MessageStream,
 };
-use zvariant::{DeserializeDict, Optional, OwnedValue, SerializeDict, Str, Type, Value};
+use zvariant::{Optional, OwnedValue, Str, Type, Value};
 
 use zbus::{
     connection, interface,
@@ -37,10 +37,12 @@ pub struct ArgStructTest {
 
 // Mimic a NetworkManager interface property that's a dict. This tests ability to use a custom
 // dict type using the `Type` And `*Dict` macros (issue #241).
-#[derive(DeserializeDict, SerializeDict, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
 #[zvariant(signature = "dict")]
 pub struct IP4Adress {
+    #[serde(with = "zvariant::dict_utils::value")]
     prefix: u32,
+    #[serde(with = "zvariant::dict_utils::value")]
     address: String,
 }
 

--- a/zvariant/src/dbus/de.rs
+++ b/zvariant/src/dbus/de.rs
@@ -660,7 +660,12 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> SeqAccess<'de>
             ValueParseStage::Signature => {
                 self.stage = ValueParseStage::Value;
 
-                seed.deserialize(&mut *self.de).map(Some)
+                let signature = self.de.0.signature;
+                self.de.0.signature = &Signature::Signature;
+                let ret = seed.deserialize(&mut *self.de).map(Some);
+                self.de.0.signature = signature;
+
+                ret
             }
             ValueParseStage::Value => {
                 self.stage = ValueParseStage::Done;

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -1,5 +1,5 @@
 use serde::{
-    ser::{self, SerializeSeq, SerializeTuple},
+    ser::{self, SerializeMap, SerializeSeq, SerializeTuple},
     Serialize,
 };
 use std::{
@@ -338,6 +338,7 @@ where
             Signature::Structure(_) => {
                 StructSerializer::structure(self).map(StructSeqSerializer::Struct)
             }
+            Signature::Dict { .. } => self.serialize_map(Some(len)).map(StructSeqSerializer::Map),
             _ => Err(Error::SignatureMismatch(
                 self.0.signature.clone(),
                 "a struct, array or variant".to_string(),
@@ -554,6 +555,7 @@ where
 pub enum StructSeqSerializer<'ser, 'b, W> {
     Struct(StructSerializer<'ser, 'b, W>),
     Seq(SeqSerializer<'ser, 'b, W>),
+    Map(MapSerializer<'ser, 'b, W>),
 }
 
 macro_rules! serialize_struct_anon_fields {
@@ -591,6 +593,7 @@ macro_rules! serialize_struct_anon_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.$method(value),
                     StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Map(_) => unreachable!(),
                 }
             }
 
@@ -598,6 +601,7 @@ macro_rules! serialize_struct_anon_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.end_struct(),
                     StructSeqSerializer::Seq(ser) => ser.end_seq(),
+                    StructSeqSerializer::Map(_) => unreachable!(),
                 }
             }
         }
@@ -607,13 +611,13 @@ serialize_struct_anon_fields!(SerializeTuple serialize_element);
 serialize_struct_anon_fields!(SerializeTupleStruct serialize_field);
 serialize_struct_anon_fields!(SerializeTupleVariant serialize_field);
 
-pub(crate) struct MapSerializer<'ser, 'b, W> {
+pub struct MapSerializer<'ser, 'b, W> {
     seq: SeqSerializer<'ser, 'b, W>,
     key_signature: &'ser Signature,
     value_signature: &'ser Signature,
 }
 
-impl<W> ser::SerializeMap for MapSerializer<'_, '_, W>
+impl<W> SerializeMap for MapSerializer<'_, '_, W>
 where
     W: Write + Seek,
 {
@@ -680,6 +684,10 @@ macro_rules! serialize_struct_named_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.serialize_field(key, value),
                     StructSeqSerializer::Seq(ser) => ser.serialize_element(value),
+                    StructSeqSerializer::Map(ser) => {
+                        ser.serialize_key(key)?;
+                        ser.serialize_value(value)
+                    }
                 }
             }
 
@@ -687,6 +695,7 @@ macro_rules! serialize_struct_named_fields {
                 match self {
                     StructSeqSerializer::Struct(ser) => ser.end_struct(),
                     StructSeqSerializer::Seq(ser) => ser.end_seq(),
+                    StructSeqSerializer::Map(ser) => ser.end(),
                 }
             }
         }

--- a/zvariant/src/dict_utils.rs
+++ b/zvariant/src/dict_utils.rs
@@ -1,0 +1,56 @@
+//! Utilities to (de)serialize a value as a [`enum@zvariant::Value`].
+//!
+//! Utilities to use with `serde::{Deserialize, Serialize}` to serialize and deserialize a given
+//! value as a `zvariant::Value` (variant type). See the relevant [FAQ entry] in our book for more
+//! details and examples.
+//!
+//! [FAQ entry]: https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary
+
+use crate::{DeserializeValue, SerializeValue, Type};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Utilities to (de)serialize an optional value as a [`enum@zvariant::Value`].
+pub mod opt_value {
+    use super::*;
+
+    /// Serialize an optional value as a [`enum@zvariant::Value`].
+    pub fn serialize<T, S>(value: &Option<T>, ser: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Type + Serialize,
+    {
+        super::value::serialize(value.as_ref().unwrap(), ser)
+    }
+
+    /// Deserialize an optional value as a [`enum@zvariant::Value`].
+    pub fn deserialize<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de> + Type + 'de,
+    {
+        super::value::deserialize(deserializer).map(Some)
+    }
+}
+
+/// Utilities to (de)serialize a value as a [`enum@zvariant::Value`].
+pub mod value {
+    use super::*;
+
+    /// Serialize a value as a [`enum@zvariant::Value`].
+    pub fn serialize<T, S>(value: &T, ser: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Type + Serialize,
+    {
+        SerializeValue(value).serialize(ser)
+    }
+
+    /// Deserialize a value as a [`enum@zvariant::Value`].
+    pub fn deserialize<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de> + Type + 'de,
+    {
+        DeserializeValue::deserialize(deserializer).map(|v| v.0)
+    }
+}

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -124,14 +124,17 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{to_bytes, to_bytes_for_signature, MaxDepthExceeded};
+    use crate::{
+        dict_utils::{opt_value, value},
+        to_bytes, to_bytes_for_signature, MaxDepthExceeded,
+    };
 
     #[cfg(unix)]
     use crate::Fd;
     use crate::{
         serialized::{Context, Format},
-        Array, Basic, DeserializeDict, DeserializeValue, Dict, Error, ObjectPath, OwnedValue,
-        Result, SerializeDict, SerializeValue, Str, Structure, Type, Value, BE, LE, NATIVE_ENDIAN,
+        Array, Basic, DeserializeValue, Dict, Error, ObjectPath, OwnedValue, Result,
+        SerializeValue, Str, Structure, Type, Value, BE, LE, NATIVE_ENDIAN,
     };
 
     // Test through both generic and specific API (wrt byte order)
@@ -1095,13 +1098,18 @@ mod tests {
             panic!();
         }
 
-        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug)]
+        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
         #[zvariant(signature = "a{sv}")]
+        #[serde(default)]
         struct Test {
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
+            #[serde(with = "value")]
             user: String,
         }
+
         let test = Test {
             process_id: Some(42),
             group_id: None,
@@ -1119,12 +1127,16 @@ mod tests {
         let decoded: Test = encoded.deserialize().unwrap().0;
         assert_eq!(decoded, test);
 
-        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug)]
+        #[derive(Serialize, Deserialize, Type, PartialEq, Debug)]
         #[zvariant(signature = "a{sv}")]
         struct TestMissing {
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none", default)]
             process_id: Option<u32>,
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none", default)]
             group_id: Option<u32>,
+            #[serde(with = "value")]
             user: String,
+            #[serde(with = "value")]
             quota: u8,
         }
         let decoded: Result<(TestMissing, _)> = encoded.deserialize();
@@ -1133,21 +1145,27 @@ mod tests {
             Error::Message("missing field `quota`".to_string())
         );
 
-        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug)]
+        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
         #[zvariant(signature = "a{sv}")]
+        #[serde(default)]
         struct TestSkipUnknown {
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
         }
         let _: TestSkipUnknown = encoded.deserialize().unwrap().0;
 
-        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug)]
-        #[zvariant(deny_unknown_fields, signature = "a{sv}")]
-        struct TestUnknown {
+        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
+        #[serde(deny_unknown_fields, default)]
+        #[zvariant(signature = "a{sv}")]
+        struct TestDenyUnknown {
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
+            #[serde(with = "opt_value", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
         }
-        let decoded: Result<(TestUnknown, _)> = encoded.deserialize();
+        let decoded: Result<(TestDenyUnknown, _)> = encoded.deserialize();
         assert_eq!(
             decoded.unwrap_err(),
             Error::Message("unknown field `user`, expected `process_id` or `group_id`".to_string())

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -95,6 +95,8 @@ mod framing_offsets;
 
 mod container_depths;
 
+pub mod dict_utils;
+
 pub use zvariant_derive::{DeserializeDict, OwnedValue, SerializeDict, Type, Value};
 
 // Required for the macros to function within this crate.

--- a/zvariant/src/str.rs
+++ b/zvariant/src/str.rs
@@ -15,8 +15,9 @@ use crate::{Basic, Type};
 ///
 /// * is specialized for strings.
 /// * treats `&'static str` as a separate type. This allows you to avoid allocations and copying
-///   when turning an `Str` instance created  from a `&'static str` into an owned version in generic
+///   when turning an `Str` instance created from a `&'static str` into an owned version in generic
 ///   code that doesn't/can't assume the inner lifetime of the source `Str` instance.
+/// * `Clone` doesn't copy+allocate when the inner type is `&str`.
 ///
 /// This type is used for keeping strings in a [`Value`], among other things.
 ///

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -601,10 +601,6 @@ impl<'de: 'a, 'a> Deserialize<'de> for Value<'a> {
     }
 }
 
-// Note that the Visitor implementations don't check for validity of the
-// signature. That's left to the Deserialize implementation of Signature
-// itself.
-
 struct ValueVisitor;
 
 impl<'de> Visitor<'de> for ValueVisitor {

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -110,14 +110,20 @@ mod value;
 /// an alias for `a{sv}`. Here is an example:
 ///
 /// ```
-/// use zvariant::{SerializeDict, DeserializeDict, serialized::Context, to_bytes, Type, LE};
+/// use zvariant::{
+///     serialized::Context, dict_utils::value, to_bytes, Type, LE,
+/// };
+/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug)]
+/// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 /// // `#[zvariant(signature = "a{sv}")]` would be the same.
 /// #[zvariant(signature = "dict")]
 /// struct Struct {
+///     #[serde(with = "value")]
 ///     field1: u16,
+///     #[serde(with = "value")]
 ///     field2: i64,
+///     #[serde(with = "value")]
 ///     field3: String,
 /// }
 ///
@@ -174,60 +180,17 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// [D-Bus](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties)
 /// and GVariant.
 ///
-/// # Examples
-///
-/// For structs it works just like serde's [`Serialize`] macros:
-///
-/// ```
-/// use zvariant::{SerializeDict, Type};
-///
-/// #[derive(SerializeDict, Type)]
-/// #[zvariant(signature = "a{sv}")]
-/// struct Struct {
-///     field1: u16,
-///     #[zvariant(rename = "another-name")]
-///     field2: i64,
-///     optional_field: Option<String>,
-/// }
-/// ```
-///
-/// The serialized D-Bus version of `Struct {42, 77, None}`
-/// will be `{"field1": Value::U16(42), "another-name": Value::I64(77)}`.
-///
-/// # Auto renaming fields
-///
-/// The macro supports specifying a Serde-like `#[zvariant(rename_all = "case")]` attribute on
-/// structures. The attribute allows to rename all the fields from snake case to another case
-/// automatically:
-///
-/// ```
-/// use zvariant::{SerializeDict, Type};
-///
-/// #[derive(SerializeDict, Type)]
-/// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
-/// struct Struct {
-///     field1: u16,
-///     #[zvariant(rename = "another-name")]
-///     field2: i64,
-///     optional_field: Option<String>,
-/// }
-/// ```
-///
-/// It's still possible to specify custom names for individual fields using the
-/// `#[zvariant(rename = "another-name")]` attribute even when the `rename_all` attribute is
-/// present.
-///
-/// Currently the macro supports the following values for `case`:
-///
-/// * `"lowercase"`
-/// * `"UPPERCASE"`
-/// * `"PascalCase"`
-/// * `"camelCase"`
-/// * `"snake_case"`
-/// * `"kebab-case"`
+/// Starting from version `5.5.0`, this macro is deprecated in favor of using the `Serialize` derive
+/// with `zvariant::dict_utils`. See the relevant [FAQ entry] in our book for more details and
+/// examples.
 ///
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
+/// [FAQ entry]: https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary
 #[proc_macro_derive(SerializeDict, attributes(zbus, zvariant))]
+#[deprecated(
+    since = "5.5.0",
+    note = "See https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary"
+)]
 pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_serialize_derive(input)
@@ -242,61 +205,17 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// [D-Bus](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties)
 /// and GVariant.
 ///
-/// # Examples
-///
-/// For structs it works just like serde's [`Deserialize`] macros:
-///
-/// ```
-/// use zvariant::{DeserializeDict, Type};
-///
-/// #[derive(DeserializeDict, Type)]
-/// #[zvariant(signature = "a{sv}")]
-/// ##[allow(unused)]
-/// struct Struct {
-///     field1: u16,
-///     #[zvariant(rename = "another-name")]
-///     field2: i64,
-///     optional_field: Option<String>,
-/// }
-/// ```
-///
-/// The deserialized D-Bus dictionary `{"field1": Value::U16(42), "another-name": Value::I64(77)}`
-/// will be `Struct {42, 77, None}`.
-///
-/// # Auto renaming fields
-///
-/// The macro supports specifying a Serde-like `#[zvariant(rename_all = "case")]` attribute on
-/// structures. The attribute allows to rename all the fields from snake case to another case
-/// automatically:
-///
-/// ```
-/// use zvariant::{SerializeDict, Type};
-///
-/// #[derive(SerializeDict, Type)]
-/// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
-/// struct Struct {
-///     field1: u16,
-///     #[zvariant(rename = "another-name")]
-///     field2: i64,
-///     optional_field: Option<String>,
-/// }
-/// ```
-///
-/// It's still possible to specify custom names for individual fields using the
-/// `#[zvariant(rename = "another-name")]` attribute even when the `rename_all` attribute is
-/// present.
-///
-/// Currently the macro supports the following values for `case`:
-///
-/// * `"lowercase"`
-/// * `"UPPERCASE"`
-/// * `"PascalCase"`
-/// * `"camelCase"`
-/// * `"snake_case"`
-/// * `"kebab-case"`
+/// Starting from version `5.5.0`, this macro is deprecated in favor of using the `Deserialize`
+/// derive with `zvariant::dict_utils`. See the relevant [FAQ entry] in our book for more details
+/// and examples.
 ///
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
+/// [FAQ entry]: https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary
 #[proc_macro_derive(DeserializeDict, attributes(zbus, zvariant))]
+#[deprecated(
+    since = "5.5.0",
+    note = "See https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary"
+)]
 pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_deserialize_derive(input)

--- a/zvariant_derive/tests/no_prelude.rs
+++ b/zvariant_derive/tests/no_prelude.rs
@@ -1,7 +1,10 @@
 #![no_implicit_prelude]
 #![allow(dead_code)]
 
-use ::zvariant_derive::{DeserializeDict, SerializeDict, Type};
+use ::serde::{Deserialize, Serialize};
+use ::zvariant_derive::Type;
+
+use ::zvariant::dict_utils::*;
 
 #[derive(Type)]
 struct FooF(f64);
@@ -21,11 +24,19 @@ enum RequestNameFlags {
     DoNotQueue = 0x04,
 }
 
-#[derive(SerializeDict, DeserializeDict, Type)]
-#[zvariant(deny_unknown_fields, signature = "a{sv}")]
+#[derive(Serialize, Deserialize, Type)]
+#[zvariant(signature = "a{sv}")]
+#[serde(deny_unknown_fields)]
 struct Test {
+    #[serde(
+        with = "opt_value",
+        skip_serializing_if = "::std::option::Option::is_none",
+        default
+    )]
     field_a: ::std::option::Option<u32>,
-    #[zvariant(rename = "field-b")]
+    #[serde(rename = "field-b")]
+    #[serde(with = "value")]
     field_b: ::std::string::String,
+    #[serde(with = "value")]
     field_c: ::std::vec::Vec<u8>,
 }


### PR DESCRIPTION
Instead make it possible to use `serde::{Serialize, Deserialize}` directly when (de)serializing a custom struct as an `a{sv}` type.

Fixes #1344, #73, #85, #856.