### PR TITLE
✨ zm: Copy attributes to `receive_*_changed` and `cached_*` methods

### DIFF
--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -723,6 +723,7 @@ fn gen_proxy_property(
                 This is a convenient wrapper around [`{proxy_name}::receive_property_changed`]."
                 );
                 quote! {
+                    #(#other_attrs)*
                     #[doc = #gen_doc]
                     pub #usage fn #receive #ty_generics(
                         &self
@@ -747,6 +748,7 @@ fn gen_proxy_property(
                     " Get the cached value of the `{property_name}` property, or `None` if the property is not cached.",
                 );
                 quote! {
+                    #(#other_attrs)*
                     #[doc = #cached_doc]
                     pub fn #cached_getter(&self) -> ::std::result::Result<
                         ::std::option::Option<<#ret_type as #zbus::ResultAdapter>::Ok>,


### PR DESCRIPTION
Fix #1312 

In the `proxy` macro, support applying attributes to the related methods of the same property. This ensures that common attributes, such as `#[doc = "..."]` and `#[cfg(...)]`, can be applied to both the getter methods `receive_<property>_changed` and `cached_<property>`.

# Macro expanding preview

```rust
/// Test property for testing.
#[cfg(test)]
#[zbus(property)]
fn property(&self) -> fdo::Result<Vec<String>>;
```
will generates
```diff
 #[doc = " Test property for testing."]
 #[cfg(test)]
 #[allow(clippy::needless_question_mark)]
 pub fn property(&self) -> fdo::Result<Vec<String>> { ... }

+#[doc = " Test property for testing."]
+#[cfg(test)]
 #[doc = "Get the cached value of the `Property` property, or `None` if the property is not cached."]
 pub fn cached_property(
     &self,
 ) -> ::std::result::Result<
     ::std::option::Option<<fdo::Result<Vec<String>> as ::zbus::ResultAdapter>::Ok>,
     <fdo::Result<Vec<String>> as ::zbus::ResultAdapter>::Err,
 > { ... }

+#[doc = " Test property for testing."]
+#[cfg(test)]
 #[doc = "Create a stream for the `Property` property changes. This is a convenient wrapper around [`zbus::blocking::Proxy::receive_property_changed`]."]
 pub fn receive_property_changed(
     &self,
 ) -> ::zbus::blocking::proxy::PropertyIterator<
     'p,
     <fdo::Result<Vec<String>> as ::zbus::ResultAdapter>::Ok,
 > { ... }
```

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
