### PR TITLE
📝 Document generated prop_changed and prop_invalidated methods

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -725,7 +725,14 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     };
 
                     if p.emits_changed_signal == PropertyEmitsChangedSignal::True {
+                        let changed_doc = format!(
+                            "Emit the “PropertiesChanged” signal with the new value for the\n\
+                             `{member_name}` property.\n\n\
+                             This method should be called if a property value changes outside\n\
+                             its setter method."
+                        );
                         let prop_changed_method = quote!(
+                            #[doc = #changed_doc]
                             pub async fn #prop_changed_method_name(
                                 &self,
                                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
@@ -750,7 +757,15 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     }
 
                     if p.emits_changed_signal == PropertyEmitsChangedSignal::Invalidates {
+                        let invalidate_doc = format!(
+                            "Emit the “PropertiesChanged” signal for the `{member_name}` property\n\
+                             without including the new value.\n\n\
+                             It is usually better to call `{prop_changed_method_name}` instead so\n\
+                             that interested peers do not need to fetch the new value separately\n\
+                             (causing excess traffic on the bus)."
+                        );
                         let prop_invalidate_method = quote!(
+                            #[doc = #invalidate_doc]
                             pub async fn #prop_invalidate_method_name(
                                 &self,
                                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,


### PR DESCRIPTION
Avoids "missing documentation for a method" when -W missing-docs enabled in user code.

The documentation added is similar to the wording from the `#[interface]` macro documentation for the PROP_changed methods.

Thanks for a great crate!

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
