### PR TITLE
✨ zd: Simplify & un-deprecate SerializeDict & DeserializeDict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ async-executor = "1.11.0"
 async-trait = "0.1.80"
 hex = "0.4.3"
 ordered-stream = "0.2"
-futures-util = { version = "0.3.30", default-features = false }
+futures-util = { version = "0.3.31", default-features = false }
 futures-core = "0.3.30"
 futures-lite = { version = "2.6.0", default-features = false, features = [
     "std",

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -66,7 +66,6 @@ use zbus::zvariant::{Type, OwnedValue, as_value::{self, optional}};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Type)]
-// `Type` treats `dict` is an alias for `a{sv}`.
 #[zvariant(signature = "dict")]
 pub struct Dictionary {
     #[serde(with = "as_value")]
@@ -96,7 +95,6 @@ make use of the `default` container attribute if your struct can implemented the
 # use serde::{Deserialize, Serialize};
 #
 #[derive(Default, Deserialize, Serialize, Type)]
-// `Type` treats `dict` is an alias for `a{sv}`.
 #[zvariant(signature = "dict")]
 #[serde(default)]
 pub struct Dictionary {

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -51,7 +51,7 @@ async-fs = []
 zbus_macros = { path = "../zbus_macros", version = "5.6.0" }
 zvariant = { path = "../zvariant", features = [
     "enumflags2",
-], version = "5.5.0" }
+], version = "5.5.1" }
 zbus_names = { path = "../zbus_names", version = "4.2.0" }
 
 serde.workspace = true

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -12,7 +12,7 @@ use zbus_names::{
 };
 #[cfg(unix)]
 use zvariant::OwnedFd;
-use zvariant::{as_value::optional, Optional, Type};
+use zvariant::{DeserializeDict, Optional, SerializeDict, Type};
 
 use super::Result;
 use crate::{proxy, OwnedGuid};
@@ -112,51 +112,26 @@ pub enum ReleaseNameReply {
 ///
 /// **Note**: unknown keys, in particular those with "." that are not from the specification, will
 /// be ignored. Use your own implementation or contribute your keys here, or in the specification.
-#[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize, Type)]
+#[derive(Debug, Default, DeserializeDict, PartialEq, Eq, SerializeDict, Type)]
 #[zvariant(signature = "a{sv}")]
-#[serde(default)]
 pub struct ConnectionCredentials {
-    #[serde(
-        rename = "UnixUserID",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "UnixUserID")]
     pub(crate) unix_user_id: Option<u32>,
 
-    #[serde(
-        rename = "UnixGroupIDs",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "UnixGroupIDs")]
     pub(crate) unix_group_ids: Option<Vec<u32>>,
 
     #[cfg(unix)]
-    #[serde(
-        rename = "ProcessFD",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "ProcessFD")]
     pub(crate) process_fd: Option<OwnedFd>,
 
-    #[serde(
-        rename = "ProcessID",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "ProcessID")]
     pub(crate) process_id: Option<u32>,
 
-    #[serde(
-        rename = "WindowsSID",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "WindowsSID")]
     pub(crate) windows_sid: Option<String>,
 
-    #[serde(
-        rename = "LinuxSecurityLabel",
-        with = "optional",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[zvariant(rename = "LinuxSecurityLabel")]
     pub(crate) linux_security_label: Option<Vec<u8>>,
 }
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -19,7 +19,7 @@ use zbus::{
     object_server::ResponseDispatchNotifier,
     DBusError, Error, Message, MessageStream,
 };
-use zvariant::{Optional, OwnedValue, Str, Type, Value};
+use zvariant::{DeserializeDict, Optional, OwnedValue, SerializeDict, Str, Type, Value};
 
 use zbus::{
     connection, interface,
@@ -37,12 +37,10 @@ pub struct ArgStructTest {
 
 // Mimic a NetworkManager interface property that's a dict. This tests ability to use a custom
 // dict type using the `Type` And `*Dict` macros (issue #241).
-#[derive(Deserialize, Serialize, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
+#[derive(DeserializeDict, SerializeDict, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
 #[zvariant(signature = "dict")]
 pub struct IP4Adress {
-    #[serde(with = "zvariant::as_value")]
     prefix: u32,
-    #[serde(with = "zvariant::as_value")]
     address: String,
 }
 

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -31,7 +31,7 @@ syn = { workspace = true, features = ["extra-traits", "fold", "full"] }
 quote.workspace = true
 proc-macro-crate.workspace = true
 
-zvariant = { path = "../zvariant", version = "5.5.0" }
+zvariant = { path = "../zvariant", version = "5.5.1" }
 zbus_names = { path = "../zbus_names", version = "4.2.0" }
 zvariant_utils = { path = "../zvariant_utils", version = "3.2.0" }
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -972,6 +972,8 @@ mod tests {
 
     #[test]
     fn dict_value() {
+        use zvariant::{DeserializeDict, SerializeDict};
+
         let mut map: HashMap<i64, &str> = HashMap::new();
         map.insert(1, "123");
         map.insert(2, "456");
@@ -1105,15 +1107,11 @@ mod tests {
             panic!();
         }
 
-        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
+        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug, Default)]
         #[zvariant(signature = "a{sv}")]
-        #[serde(default)]
         struct Test {
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
-            #[serde(with = "as_value")]
             user: String,
         }
 
@@ -1134,16 +1132,12 @@ mod tests {
         let decoded: Test = encoded.deserialize().unwrap().0;
         assert_eq!(decoded, test);
 
-        #[derive(Serialize, Deserialize, Type, PartialEq, Debug)]
+        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug)]
         #[zvariant(signature = "a{sv}")]
         struct TestMissing {
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
             process_id: Option<u32>,
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
             group_id: Option<u32>,
-            #[serde(with = "as_value")]
             user: String,
-            #[serde(with = "as_value")]
             quota: u8,
         }
         let decoded: Result<(TestMissing, _)> = encoded.deserialize();
@@ -1152,24 +1146,18 @@ mod tests {
             Error::Message("missing field `quota`".to_string())
         );
 
-        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
+        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug, Default)]
         #[zvariant(signature = "a{sv}")]
-        #[serde(default)]
         struct TestSkipUnknown {
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
         }
         let _: TestSkipUnknown = encoded.deserialize().unwrap().0;
 
-        #[derive(Serialize, Deserialize, Type, PartialEq, Debug, Default)]
-        #[serde(deny_unknown_fields, default)]
-        #[zvariant(signature = "a{sv}")]
+        #[derive(SerializeDict, DeserializeDict, Type, PartialEq, Debug, Default)]
+        #[zvariant(signature = "a{sv}", deny_unknown_fields)]
         struct TestDenyUnknown {
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             process_id: Option<u32>,
-            #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
             group_id: Option<u32>,
         }
         let decoded: Result<(TestDenyUnknown, _)> = encoded.deserialize();

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -180,17 +180,51 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// [D-Bus](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties)
 /// and GVariant.
 ///
-/// Starting from version `5.5.0`, this macro is deprecated in favor of using the `Serialize` derive
-/// with `zvariant::as_value`. See the relevant [FAQ entry] in our book for more details and
-/// examples.
+/// # Alternative Approaches
+///
+/// There are two approaches to serializing structs as dictionaries:
+///
+/// 1. Using this macro (simpler, but less control).
+/// 2. Using the `Serialize` derive with `zvariant::as_value` (more verbose, but more control).
+///
+/// See the example below and the relevant [FAQ entry] in our book for more details on the
+/// alternative approach.
+///
+/// # Example
+///
+/// ## Approach #1
+///
+/// ```
+/// use zvariant::{SerializeDict, Type};
+///
+/// #[derive(Debug, Default, SerializeDict, Type)]
+/// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
+/// pub struct MyStruct {
+///     field1: Option<u32>,
+///     field2: String,
+/// }
+/// ```
+///
+/// ## Approach #2
+///
+/// ```
+/// use serde::Serialize;
+/// use zvariant::{Type, as_value};
+///
+/// #[derive(Debug, Default, Serialize, Type)]
+/// #[zvariant(signature = "a{sv}")]
+/// #[serde(default, rename_all = "PascalCase")]
+/// pub struct MyStruct {
+///     #[serde(with = "as_value::optional", skip_serializing_if = "Option::is_none")]
+///     field1: Option<u32>,
+///     #[serde(with = "as_value")]
+///     field2: String,
+/// }
+/// ```
 ///
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 /// [FAQ entry]: https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary
 #[proc_macro_derive(SerializeDict, attributes(zbus, zvariant))]
-#[deprecated(
-    since = "5.5.0",
-    note = "See https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary"
-)]
 pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_serialize_derive(input)
@@ -205,17 +239,51 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// [D-Bus](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties)
 /// and GVariant.
 ///
-/// Starting from version `5.5.0`, this macro is deprecated in favor of using the `Deserialize`
-/// derive with `zvariant::as_value`. See the relevant [FAQ entry] in our book for more details
-/// and examples.
+/// # Alternative Approaches
+///
+/// There are two approaches to deserializing dictionaries as structs:
+///
+/// 1. Using this macro (simpler, but less control).
+/// 2. Using the `Deserialize` derive with `zvariant::as_value` (more verbose, but more control).
+///
+/// See the example below and the relevant [FAQ entry] in our book for more details on the
+/// alternative approach.
+///
+/// # Example
+///
+/// ## Approach #1
+///
+/// ```
+/// use zvariant::{DeserializeDict, Type};
+///
+/// #[derive(Debug, Default, DeserializeDict, Type)]
+/// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
+/// pub struct MyStruct {
+///     field1: Option<u32>,
+///     field2: String,
+/// }
+/// ```
+///
+/// ## Approach #2
+///
+/// ```
+/// use serde::Deserialize;
+/// use zvariant::{Type, as_value};
+///
+/// #[derive(Debug, Default, Deserialize, Type)]
+/// #[zvariant(signature = "a{sv}")]
+/// #[serde(default, rename_all = "PascalCase")]
+/// pub struct MyStruct {
+///     #[serde(with = "as_value::optional")]
+///     field1: Option<u32>,
+///     #[serde(with = "as_value")]
+///     field2: String,
+/// }
+/// ```
 ///
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
 /// [FAQ entry]: https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary
 #[proc_macro_derive(DeserializeDict, attributes(zbus, zvariant))]
-#[deprecated(
-    since = "5.5.0",
-    note = "See https://dbus2.github.io/zbus/faq.html#how-to-use-a-struct-as-a-dictionary"
-)]
 pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     dict::expand_deserialize_derive(input)


### PR DESCRIPTION
Turn `SerializeDict` and  `DeserializeDict` wrappers around serde derives and un-deprecate them.

For simpler cases, they're pretty good and now that we've made them wrappers around serde derives, maintainance shouldn't be an issue. We will no longer need to add new attributes because if people would want any, they should just use the serde derives directly.