### PR TITLE
🐛 zb: Fix build on Android by limiting PeerPidfd to linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.MSRV }}
-          targets: x86_64-pc-windows-gnu, x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd
+          targets: x86_64-pc-windows-gnu, x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd, aarch64-linux-android
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Check build with MSRV
@@ -27,6 +27,7 @@ jobs:
           cargo --locked check --target x86_64-apple-darwin
           cargo --locked check --target x86_64-unknown-freebsd
           cargo --locked check --target x86_64-unknown-netbsd
+          cargo --locked check --target aarch64-linux-android
         # This would be nice but some optional deps (e.g `time`) move very fast wrt to MSRV.
         # cargo --locked check --all-features
 
@@ -43,7 +44,7 @@ jobs:
           # We use some nightly fmt options.
           toolchain: nightly
           components: rustfmt
-          targets: x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd x86_64-pc-windows-gnu
+          targets: x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd, x86_64-pc-windows-gnu, aarch64-linux-android
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: |
@@ -52,6 +53,7 @@ jobs:
           cargo --locked check --target x86_64-unknown-freebsd
           cargo --locked check --target x86_64-unknown-netbsd
           cargo --locked check --target x86_64-pc-windows-gnu
+          cargo --locked check --target aarch64-linux-android
 
   clippy:
     runs-on: ubuntu-latest
@@ -65,7 +67,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-          targets: x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd x86_64-pc-windows-gnu
+          targets: x86_64-apple-darwin, x86_64-unknown-freebsd, x86_64-unknown-netbsd, x86_64-pc-windows-gnu, aarch64-linux-android
       - uses: Swatinem/rust-cache@v2
       - name: Catch common mistakes and unwrap calls
         run: |
@@ -74,6 +76,7 @@ jobs:
           cargo --locked clippy --target x86_64-unknown-freebsd
           cargo --locked clippy --target x86_64-unknown-netbsd
           cargo --locked clippy --target x86_64-pc-windows-gnu
+          cargo --locked clippy --target aarch64-linux-android
 
   linux_test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,25 +407,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -438,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -759,12 +756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,17 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.1",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +889,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1201,7 +1190,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ serde = { version = "1.0.200", features = ["derive"] }
 serde_repr = "0.1.19"
 serde_bytes = "0.11.14"
 serde_json = "1.0.116"
-criterion = "0.5.1"
+criterion = "0.6.0"
 doc-comment = "0.3.3"
 proc-macro2 = "1.0.81"
 proc-macro-crate = "3.2.0"

--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -336,15 +336,10 @@ fn get_unix_peer_creds_blocking(fd: RawFd) -> io::Result<crate::fdo::ConnectionC
     #[cfg(any(target_os = "android", target_os = "linux"))]
     {
         use nix::{
-            errno::Errno,
-            sys::socket::{
-                getsockopt,
-                sockopt::{PeerCredentials, PeerPidfd},
-            },
+            sys::socket::{getsockopt, sockopt::PeerCredentials},
             unistd::{getgrouplist, Gid, Uid, User},
         };
         use std::ffi::CString;
-        use zvariant::OwnedFd;
 
         let (uid, gid, pid) = {
             let unix_creds = getsockopt(&fd, PeerCredentials)?;
@@ -372,11 +367,17 @@ fn get_unix_peer_creds_blocking(fd: RawFd) -> io::Result<crate::fdo::ConnectionC
             creds = creds.add_unix_group_id(group.as_raw());
         }
 
-        match getsockopt(&fd, PeerPidfd) {
-            Err(Errno::ENOPROTOOPT) => (),
-            Ok(pidfd) => creds = creds.set_process_fd(OwnedFd::from(pidfd)),
-            Err(e) => return Err(e.into()),
-        };
+        #[cfg(target_os = "linux")]
+        {
+            use nix::{errno::Errno, sys::socket::sockopt::PeerPidfd};
+            use zvariant::OwnedFd;
+
+            match getsockopt(&fd, PeerPidfd) {
+                Err(Errno::ENOPROTOOPT) => (),
+                Ok(pidfd) => creds = creds.set_process_fd(OwnedFd::from(pidfd)),
+                Err(e) => return Err(e.into()),
+            };
+        }
     }
 
     #[cfg(any(

--- a/zbus/src/win32.rs
+++ b/zbus/src/win32.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::{CStr, OsStr},
-    io::{Error, ErrorKind},
+    io::Error,
     net::SocketAddr,
     os::windows::{
         io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle},
@@ -156,7 +156,7 @@ impl ProcessToken {
         let sid = unsafe { (*token_info.as_ptr().cast::<TOKEN_USER>()).User.Sid };
 
         if unsafe { IsValidSid(sid.cast()) == FALSE } {
-            return Err(Error::new(ErrorKind::Other, "Invalid SID"));
+            return Err(Error::other("Invalid SID"));
         }
 
         let mut pstr = ptr::null_mut();
@@ -167,7 +167,7 @@ impl ProcessToken {
         let sid = unsafe { CStr::from_ptr(pstr.cast()) };
         let ret = sid
             .to_str()
-            .map_err(|_| Error::new(ErrorKind::Other, "Invalid SID"))?
+            .map_err(|_| Error::other("Invalid SID"))?
             .to_owned();
         unsafe {
             LocalFree(pstr.cast());
@@ -219,7 +219,7 @@ pub fn socket_addr_get_pid(addr: &SocketAddr) -> Result<u32, Error> {
         }
     }
 
-    Err(Error::new(ErrorKind::Other, "PID of TCP address not found"))
+    Err(Error::other("PID of TCP address not found"))
 }
 
 /// Get the process ID of the connected peer.

--- a/zvariant/src/utils.rs
+++ b/zvariant/src/utils.rs
@@ -44,7 +44,9 @@ pub const MAYBE_SIGNATURE_CHAR: char = 'm';
 #[cfg(feature = "gvariant")]
 pub const MAYBE_SIGNATURE_STR: &str = "m";
 
-pub(crate) fn padding_for_n_bytes(value: usize, align: usize) -> usize {
+// Public only for tests.
+#[doc(hidden)]
+pub fn padding_for_n_bytes(value: usize, align: usize) -> usize {
     let len_rounded_up = value.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
 
     len_rounded_up.wrapping_sub(value)

--- a/zvariant/src/utils.rs
+++ b/zvariant/src/utils.rs
@@ -44,9 +44,21 @@ pub const MAYBE_SIGNATURE_CHAR: char = 'm';
 #[cfg(feature = "gvariant")]
 pub const MAYBE_SIGNATURE_STR: &str = "m";
 
+/// Calculates the padding needed to align `value` to the next multiple of `align`.
+///
+/// # Parameters
+/// - `value`: The value to align.
+/// - `align`: The alignment boundary. Must be a positive power of two.
+///
+/// # Panics
+/// Panics if `align` is not a positive power of two.
 // Public only for tests.
 #[doc(hidden)]
 pub fn padding_for_n_bytes(value: usize, align: usize) -> usize {
+    assert!(
+        align > 0 && align.is_power_of_two(),
+        "`align` must be a positive power of two"
+    );
     let len_rounded_up = value.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
 
     len_rounded_up.wrapping_sub(value)

--- a/zvariant/tests/common.rs
+++ b/zvariant/tests/common.rs
@@ -6,11 +6,8 @@ macro_rules! basic_type_test {
         let ctxt =
             zvariant::serialized::Context::new(zvariant::serialized::Format::$format, $endian, 1);
         let encoded = zvariant::to_bytes(ctxt, &$test_value).unwrap();
-        let padding = if 1 % $align == 0 {
-            0
-        } else {
-            $align - (1 % $align)
-        };
+        let padding = zvariant::padding_for_n_bytes(1, $align);
+
         assert_eq!(
             encoded.len(),
             $expected_len + padding,
@@ -87,11 +84,7 @@ macro_rules! fd_value_test {
         let ctxt =
             zvariant::serialized::Context::new(zvariant::serialized::Format::$format, $endian, 1);
         let encoded = zvariant::to_bytes(ctxt, &$test_value).unwrap();
-        let padding = if 1 % $align == 0 {
-            0
-        } else {
-            $align - (1 % $align)
-        };
+        let padding = zvariant::padding_for_n_bytes(1, $align);
         assert_eq!(
             encoded.len(),
             $expected_len + padding,

--- a/zvariant/tests/number/f64_value.rs
+++ b/zvariant/tests/number/f64_value.rs
@@ -20,7 +20,7 @@ fn f64_type_test(
     // Lie that we're starting at byte 1 in the overall message to test padding
     let ctxt = Context::new(format, NATIVE_ENDIAN, 1);
     let encoded = to_bytes(ctxt, &value).unwrap();
-    let padding = if 1 % 8 == 0 { 0 } else { 8 - (1 % 8) };
+    let padding = zvariant::padding_for_n_bytes(1, 8);
     assert_eq!(
         encoded.len(),
         expected_len + padding,

--- a/zvariant/tests/number/mod.rs
+++ b/zvariant/tests/number/mod.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-pub(self) mod common {
+mod common {
     include!("../common.rs");
 }
 


### PR DESCRIPTION
For whatever reason the nix::sys::socket::sockopt::PeerPidfd is only available to target_os = "linux", so properly guard the code using it against that.

Fixes: 3602dcbb ("✨ zb: Add ProcessFD/pidfd to peer ConnectionCredentials")

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
