### PR TITLE
👽️ zb,zv,zn: Use `std::hint::black_box` in benchmarks code

### DIFF
--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, vec};
+use std::{collections::HashMap, hint::black_box, vec};
 use zbus::Message;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use zvariant::{Type, Value};
 

--- a/zbus_names/benches/benchmarks.rs
+++ b/zbus_names/benches/benchmarks.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
 fn name_parse(c: &mut Criterion) {
     const WELL_KNOWN_NAME: &str = "a.very.loooooooooooooooooo-ooooooo_0000o0ng.Name.\

--- a/zvariant/benches/benchmarks.rs
+++ b/zvariant/benches/benchmarks.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde_bytes")]
 use serde_bytes::ByteBuf;
-use std::{collections::HashMap, vec};
+use std::{collections::HashMap, hint::black_box, vec};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use zvariant::{serialized::Context, to_bytes, Type, Value, LE};
 


### PR DESCRIPTION
Instead of deprecated `criterion::black_box`.
