### PR TITLE
✨ zm: Support cfg attributes on properties in the `interface` macro

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -689,7 +689,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     get_dispatch.extend(q);
 
                     let q = if is_fallible_property {
-                        quote!({
+                        quote!(#(#cfg_attrs)* {
                             #args_from_msg
                             if let Ok(prop) = self.#ident(#args_names)#method_await {
                             props.insert(
@@ -703,7 +703,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             );
                         }})
                     } else {
-                        quote!({
+                        quote!(#(#cfg_attrs)* {
                             #args_from_msg
                             props.insert(
                         ::std::string::ToString::to_string(#member_name),
@@ -732,6 +732,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                              its setter method."
                         );
                         let prop_changed_method = quote!(
+                            #(#cfg_attrs)*
                             #[doc = #changed_doc]
                             pub async fn #prop_changed_method_name(
                                 &self,


### PR DESCRIPTION
Enhance the interface macro to support cfg attributes on properties, similar to the behavior in the `proxy` macro. The current limitation is due to the `get_all` and `*_changed` methods not respecting cfg attributes, resulting in compilation errors.

Tested with the `#[zbus::interface(proxy)]` option.

Error before:
```rust
// #[interface(proxy, ..)]
// impl Test {
#[cfg(feature = "not_enabled")]
#[zbus(property)]
fn my_custom_property(&self) -> MyCustomPropertyType {
    unimplemented!()
}
```
```plain
error[E0599]: no method named `my_custom_property` found for reference `&test_interface::Test<T>` in the current scope
   --> zbus_macros/tests/tests.rs:175:12
    |
175 |         fn my_custom_property(&self) -> MyCustomPropertyType {
    |            ^^^^^^^^^^^^^^^^^^
    |
help: there is a method `set_my_custom_property` with a similar name, but with different arguments
   --> zbus_macros/tests/tests.rs:181:9
    |
181 |         fn set_my_custom_property(&self, mut _value: MyCustomPropertyType) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

TODO: Solving `*_changed` calls in the `set` method.

It's weird that <https://github.com/dbus2/zbus/pull/1394/files#diff-43a2e53b8de7776ea27dd141513cf075f24db06d6612dd519ff04780a301807cR651> is an empty `cfg_attrs` list even if the cfg attributes are pasted in "get_all" method.