### PR TITLE
🐛 zx: Allow parsing very big introspection xml

### DIFF
--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -545,7 +545,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     debug!("Created: {:?}", root_introspect_proxy);
 
     let root_xml = root_introspect_proxy.introspect().await?;
-    let root_node = zbus_xml::Node::from_reader(root_xml.as_bytes())
+    let root_node = zbus_xml::Node::from_reader(root_xml.as_bytes(), 1024)
         .map_err(|e| Error::Failure(e.to_string()))?;
     let mut node = &root_node;
     for name in ["org", "freedesktop", "MyService"] {
@@ -649,8 +649,8 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
 
     let xml = proxy.inner().introspect().await?;
     debug!("Introspection: {}", xml);
-    let node =
-        zbus_xml::Node::from_reader(xml.as_bytes()).map_err(|e| Error::Failure(e.to_string()))?;
+    let node = zbus_xml::Node::from_reader(xml.as_bytes(), 1024)
+        .map_err(|e| Error::Failure(e.to_string()))?;
     let ifaces = node.interfaces();
     let iface = ifaces
         .iter()

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -545,7 +545,9 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     debug!("Created: {:?}", root_introspect_proxy);
 
     let root_xml = root_introspect_proxy.introspect().await?;
-    let root_node = zbus_xml::Node::from_reader(root_xml.as_bytes())
+    let limit = zbus_xml::NodeEventLimit::new(4096);
+    let root_node = limit
+        .read(root_xml.as_bytes())
         .map_err(|e| Error::Failure(e.to_string()))?;
     let mut node = &root_node;
     for name in ["org", "freedesktop", "MyService"] {
@@ -649,8 +651,10 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
 
     let xml = proxy.inner().introspect().await?;
     debug!("Introspection: {}", xml);
-    let node =
-        zbus_xml::Node::from_reader(xml.as_bytes()).map_err(|e| Error::Failure(e.to_string()))?;
+    let limit = zbus_xml::NodeEventLimit::new(4096);
+    let node = limit
+        .read(xml.as_bytes())
+        .map_err(|e| Error::Failure(e.to_string()))?;
     let ifaces = node.interfaces();
     let iface = ifaces
         .iter()

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -545,7 +545,7 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
     debug!("Created: {:?}", root_introspect_proxy);
 
     let root_xml = root_introspect_proxy.introspect().await?;
-    let root_node = zbus_xml::Node::from_reader(root_xml.as_bytes(), 1024)
+    let root_node = zbus_xml::Node::from_reader(root_xml.as_bytes())
         .map_err(|e| Error::Failure(e.to_string()))?;
     let mut node = &root_node;
     for name in ["org", "freedesktop", "MyService"] {
@@ -649,8 +649,8 @@ async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> {
 
     let xml = proxy.inner().introspect().await?;
     debug!("Introspection: {}", xml);
-    let node = zbus_xml::Node::from_reader(xml.as_bytes(), 1024)
-        .map_err(|e| Error::Failure(e.to_string()))?;
+    let node =
+        zbus_xml::Node::from_reader(xml.as_bytes()).map_err(|e| Error::Failure(e.to_string()))?;
     let ifaces = node.interfaces();
     let iface = ifaces
         .iter()

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -2,7 +2,7 @@ use quick_xml::de::DeError;
 use std::{convert::Infallible, error, fmt};
 use zvariant::Error as VariantError;
 
-/// The error type for `zbus_names`.
+/// The error type for `zbus_xml`.
 ///
 /// The various errors that can be reported by this crate.
 #[derive(Clone, Debug)]

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -266,6 +266,13 @@ impl<'a> Node<'a> {
         Ok(Node::deserialize(&mut deserializer)?)
     }
 
+    /// Parse the introspection XML document from trusted reader without limiting the number of
+    /// events.
+    pub fn from_trusted_reader<R: Read>(reader: R) -> Result<Node<'a>> {
+        let mut deserializer = Deserializer::from_reader(BufReader::new(reader));
+        Ok(Node::deserialize(&mut deserializer)?)
+    }
+
     /// Write the XML document to writer.
     pub fn to_writer<W: Write>(&self, writer: W) -> Result<()> {
         // Need this wrapper until this is resolved: https://github.com/tafia/quick-xml/issues/499

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -260,9 +260,9 @@ pub struct Node<'a> {
 
 impl<'a> Node<'a> {
     /// Parse the introspection XML document from reader.
-    pub fn from_reader<R: Read>(reader: R, limit: usize) -> Result<Node<'a>> {
+    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'a>> {
         let mut deserializer = Deserializer::from_reader(BufReader::new(reader));
-        deserializer.event_buffer_size(Some(limit.try_into().unwrap()));
+        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
         Ok(Node::deserialize(&mut deserializer)?)
     }
 
@@ -301,13 +301,13 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> TryFrom<(&'a str, usize)> for Node<'a> {
+impl<'a> TryFrom<&'a str> for Node<'a> {
     type Error = Error;
 
-    /// Parse the introspection XML document from tuple with slice and limit.
-    fn try_from(value: (&'a str, usize)) -> std::result::Result<Self, Self::Error> {
-        let mut deserializer = Deserializer::from_str(value.0);
-        deserializer.event_buffer_size(Some(value.1.try_into().unwrap()));
+    /// Parse the introspection XML document from `s`.
+    fn try_from(s: &'a str) -> Result<Node<'a>> {
+        let mut deserializer = Deserializer::from_str(s);
+        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
         Ok(Node::deserialize(&mut deserializer)?)
     }
 }

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -266,13 +266,6 @@ impl<'a> Node<'a> {
         Ok(Node::deserialize(&mut deserializer)?)
     }
 
-    /// Parse the introspection XML document from trusted reader without limiting the number of
-    /// events.
-    pub fn from_trusted_reader<R: Read>(reader: R) -> Result<Node<'a>> {
-        let mut deserializer = Deserializer::from_reader(BufReader::new(reader));
-        Ok(Node::deserialize(&mut deserializer)?)
-    }
-
     /// Write the XML document to writer.
     pub fn to_writer<W: Write>(&self, writer: W) -> Result<()> {
         // Need this wrapper until this is resolved: https://github.com/tafia/quick-xml/issues/499

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -260,9 +260,9 @@ pub struct Node<'a> {
 
 impl<'a> Node<'a> {
     /// Parse the introspection XML document from reader.
-    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'a>> {
+    pub fn from_reader<R: Read>(reader: R, limit: usize) -> Result<Node<'a>> {
         let mut deserializer = Deserializer::from_reader(BufReader::new(reader));
-        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
+        deserializer.event_buffer_size(Some(limit.try_into().unwrap()));
         Ok(Node::deserialize(&mut deserializer)?)
     }
 
@@ -301,13 +301,13 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a str> for Node<'a> {
+impl<'a> TryFrom<(&'a str, usize)> for Node<'a> {
     type Error = Error;
 
-    /// Parse the introspection XML document from `s`.
-    fn try_from(s: &'a str) -> Result<Node<'a>> {
-        let mut deserializer = Deserializer::from_str(s);
-        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
+    /// Parse the introspection XML document from tuple with slice and limit.
+    fn try_from(value: (&'a str, usize)) -> std::result::Result<Self, Self::Error> {
+        let mut deserializer = Deserializer::from_str(value.0);
+        deserializer.event_buffer_size(Some(value.1.try_into().unwrap()));
         Ok(Node::deserialize(&mut deserializer)?)
     }
 }

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -1,13 +1,14 @@
 use quick_xml::de::DeError;
 use std::error::Error;
 
-use zbus_xml::{ArgDirection, Node};
+use zbus_xml::{ArgDirection, Node, NodeEventLimit};
 
 #[test]
 fn serde() -> Result<(), Box<dyn Error>> {
     let example = include_str!("data/sample_object0.xml");
-    let node_r = Node::from_reader(example.as_bytes())?;
-    let node = Node::try_from(example)?;
+    let limit = NodeEventLimit::new(28);
+    let node_r = limit.read(example.as_bytes())?;
+    let node = limit.parse(example)?;
     assert_eq!(node, node_r);
     assert_eq!(node.interfaces().len(), 1);
     assert_eq!(node.interfaces()[0].methods().len(), 3);
@@ -31,8 +32,19 @@ fn serde() -> Result<(), Box<dyn Error>> {
 #[test]
 fn invalid_arg_type() {
     let input = include_str!("data/invalid_arg_type.xml");
+    let limit = NodeEventLimit::new(1024);
     assert!(matches!(
-        Node::try_from(input),
+        limit.parse(input),
         Err(zbus_xml::Error::QuickXml(DeError::Custom(_)))
+    ));
+}
+
+#[test]
+fn small_limit() {
+    let input = include_str!("data/sample_object0.xml");
+    let limit = NodeEventLimit::new(27);
+    assert!(matches!(
+        limit.parse(input),
+        Err(zbus_xml::Error::QuickXml(DeError::TooManyEvents(_)))
     ));
 }

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -6,8 +6,8 @@ use zbus_xml::{ArgDirection, Node};
 #[test]
 fn serde() -> Result<(), Box<dyn Error>> {
     let example = include_str!("data/sample_object0.xml");
-    let node_r = Node::from_reader(example.as_bytes(), 28)?;
-    let node = Node::try_from((example, 28))?;
+    let node_r = Node::from_reader(example.as_bytes())?;
+    let node = Node::try_from(example)?;
     assert_eq!(node, node_r);
     assert_eq!(node.interfaces().len(), 1);
     assert_eq!(node.interfaces()[0].methods().len(), 3);
@@ -19,7 +19,7 @@ fn serde() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(node.nodes().len(), 4);
 
-    let node_str: Node<'_> = (example, 28).try_into()?;
+    let node_str: Node<'_> = example.try_into()?;
     assert_eq!(node_str.interfaces().len(), 1);
     assert_eq!(node_str.nodes().len(), 4);
 
@@ -32,7 +32,7 @@ fn serde() -> Result<(), Box<dyn Error>> {
 fn invalid_arg_type() {
     let input = include_str!("data/invalid_arg_type.xml");
     assert!(matches!(
-        Node::try_from((input, 1024)),
+        Node::try_from(input),
         Err(zbus_xml::Error::QuickXml(DeError::Custom(_)))
     ));
 }

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -6,8 +6,8 @@ use zbus_xml::{ArgDirection, Node};
 #[test]
 fn serde() -> Result<(), Box<dyn Error>> {
     let example = include_str!("data/sample_object0.xml");
-    let node_r = Node::from_reader(example.as_bytes())?;
-    let node = Node::try_from(example)?;
+    let node_r = Node::from_reader(example.as_bytes(), 28)?;
+    let node = Node::try_from((example, 28))?;
     assert_eq!(node, node_r);
     assert_eq!(node.interfaces().len(), 1);
     assert_eq!(node.interfaces()[0].methods().len(), 3);
@@ -19,7 +19,7 @@ fn serde() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(node.nodes().len(), 4);
 
-    let node_str: Node<'_> = example.try_into()?;
+    let node_str: Node<'_> = (example, 28).try_into()?;
     assert_eq!(node_str.interfaces().len(), 1);
     assert_eq!(node_str.nodes().len(), 4);
 
@@ -32,7 +32,7 @@ fn serde() -> Result<(), Box<dyn Error>> {
 fn invalid_arg_type() {
     let input = include_str!("data/invalid_arg_type.xml");
     assert!(matches!(
-        Node::try_from(input),
+        Node::try_from((input, 1024)),
         Err(zbus_xml::Error::QuickXml(DeError::Custom(_)))
     ));
 }

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         cli::Command::File { path } => {
             let input_src = path.file_name().unwrap().to_string_lossy().to_string();
             let f = File::open(path)?;
-            DBusInfo(Node::from_reader(f)?, None, None, input_src)
+            DBusInfo(Node::from_reader(f, 1024)?, None, None, input_src)
         }
     };
 
@@ -141,7 +141,7 @@ impl DBusInfo<'_> {
             .introspect()?;
 
         Ok(DBusInfo(
-            Node::from_reader(xml.as_bytes())?,
+            Node::from_reader(xml.as_bytes(), 1024)?,
             Some(service),
             Some(path),
             input_src,

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         cli::Command::File { path } => {
             let input_src = path.file_name().unwrap().to_string_lossy().to_string();
             let f = File::open(path)?;
-            DBusInfo(Node::from_reader(f, 1024)?, None, None, input_src)
+            DBusInfo(Node::from_reader(f)?, None, None, input_src)
         }
     };
 
@@ -141,7 +141,7 @@ impl DBusInfo<'_> {
             .introspect()?;
 
         Ok(DBusInfo(
-            Node::from_reader(xml.as_bytes(), 1024)?,
+            Node::from_reader(xml.as_bytes())?,
             Some(service),
             Some(path),
             input_src,

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -10,7 +10,7 @@ macro_rules! gen_diff {
         let expected = include_str!(concat!("data/", $outfile));
         #[cfg(windows)]
         let expected = expected.replace("\r\n", "\n");
-        let node = Node::from_reader(input.as_bytes())?;
+        let node = Node::from_reader(input.as_bytes(), 1024)?;
         let gen = GenTrait {
             interface: &node.interfaces()[0],
             path: None,

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use std::{env, error::Error, io::Write, path::Path};
 
-use zbus_xml::Node;
+use zbus_xml::NodeEventLimit;
 use zbus_xmlgen::GenTrait;
 
 macro_rules! gen_diff {
@@ -10,7 +10,8 @@ macro_rules! gen_diff {
         let expected = include_str!(concat!("data/", $outfile));
         #[cfg(windows)]
         let expected = expected.replace("\r\n", "\n");
-        let node = Node::from_reader(input.as_bytes())?;
+        let limit = NodeEventLimit::new(4096);
+        let node = limit.read(input.as_bytes())?;
         let gen = GenTrait {
             interface: &node.interfaces()[0],
             path: None,

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -10,7 +10,7 @@ macro_rules! gen_diff {
         let expected = include_str!(concat!("data/", $outfile));
         #[cfg(windows)]
         let expected = expected.replace("\r\n", "\n");
-        let node = Node::from_reader(input.as_bytes(), 1024)?;
+        let node = Node::from_reader(input.as_bytes())?;
         let gen = GenTrait {
             interface: &node.interfaces()[0],
             path: None,


### PR DESCRIPTION
Some applications pass very large lists via d-bus, this fix allows you to successfully complete your tasks by trusting these applications.