### PR TITLE
✨ zb: Allow overriding some request name flags

### DIFF
--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -171,6 +171,18 @@ impl<'a> Builder<'a> {
         self.0.name(well_known_name).map(Self)
     }
 
+    /// Whether the [`zbus::fdo::RequestNameFlags::AllowReplacement`] flag will be set when
+    /// requesting names.
+    pub fn allow_name_replacements(self, allow_replacement: bool) -> Self {
+        Self(self.0.allow_name_replacements(allow_replacement))
+    }
+
+    /// Whether the [`zbus::fdo::RequestNameFlags::ReplaceExisting`] flag will be set when
+    /// requesting names.
+    pub fn replace_existing_names(self, replace_existing: bool) -> Self {
+        Self(self.0.replace_existing_names(replace_existing))
+    }
+
     /// Set the unique name of the connection.
     ///
     /// This method is only available when the `bus-impl` feature is enabled.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -526,12 +526,9 @@ impl Connection {
         W: TryInto<WellKnownName<'w>>,
         W::Error: Into<Error>,
     {
-        self.request_name_with_flags(
-            well_known_name,
-            RequestNameFlags::ReplaceExisting | RequestNameFlags::DoNotQueue,
-        )
-        .await
-        .map(|_| ())
+        self.request_name_with_flags(well_known_name, BitFlags::default())
+            .await
+            .map(|_| ())
     }
 
     /// Register a well-known name for this connection.

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -20,7 +20,9 @@ use crate::{proxy, OwnedGuid};
 /// The flags used by the bus [`request_name`] method.
 ///
 /// [`request_name`]: struct.DBusProxy.html#method.request_name
-#[bitflags]
+// TODO: Revisit this choice of defaults. See
+// https://github.com/dbus2/zbus/issues/1413
+#[bitflags(default = ReplaceExisting | DoNotQueue)]
 #[repr(u32)]
 #[derive(Type, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RequestNameFlags {


### PR DESCRIPTION
By default names are requested with ReplaceExisting and DoNotQueue. We add to builder methods to control whether the ReplaceExisting and AllowReplacement bits are set.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
