### PR TITLE
📝 zn: doc typo

### DIFF
--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -13,7 +13,7 @@ use zvariant::{NoneValue, OwnedValue, Str, Type, Value};
 
 /// String that identifies an [error name][en] on the bus.
 ///
-/// Error names have same constraints as error names.
+/// Error names have same constraints as interface names.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Error names have same constraints as *interface* names.

Trivial update resolving tautological statement, now matches dbus spec.