### PR TITLE
🚑️ zv: Check signature before serializing struct as a u8

### DIFF
--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -326,22 +326,19 @@ where
     }
 
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        if len == 0 {
-            return StructSerializer::unit(self).map(StructSeqSerializer::Struct);
-        }
-
         self.0
             .add_padding(self.0.signature.alignment(self.0.ctxt.format()))?;
         match &self.0.signature {
             Signature::Variant => StructSerializer::variant(self).map(StructSeqSerializer::Struct),
             Signature::Array(_) => self.serialize_seq(Some(len)).map(StructSeqSerializer::Seq),
+            Signature::U8 => StructSerializer::unit(self).map(StructSeqSerializer::Struct),
             Signature::Structure(_) => {
                 StructSerializer::structure(self).map(StructSeqSerializer::Struct)
             }
             Signature::Dict { .. } => self.serialize_map(Some(len)).map(StructSeqSerializer::Map),
             _ => Err(Error::SignatureMismatch(
                 self.0.signature.clone(),
-                "a struct, array or variant".to_string(),
+                "a struct, array, u8 or variant".to_string(),
             )),
         }
     }

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -327,15 +327,12 @@ where
     }
 
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        if len == 0 {
-            return StructSerializer::unit(self).map(StructSeqSerializer::Struct);
-        }
-
         self.0
             .add_padding(self.0.signature.alignment(self.0.ctxt.format()))?;
         match &self.0.signature {
             Signature::Variant => StructSerializer::variant(self).map(StructSeqSerializer::Struct),
             Signature::Array(_) => self.serialize_seq(Some(len)).map(StructSeqSerializer::Seq),
+            Signature::U8 => StructSerializer::unit(self).map(StructSeqSerializer::Struct),
             Signature::Structure(_) => {
                 StructSerializer::structure(self).map(StructSeqSerializer::Struct)
             }
@@ -343,7 +340,7 @@ where
             _ => {
                 return Err(Error::SignatureMismatch(
                     self.0.signature.clone(),
-                    "a struct, array or variant".to_string(),
+                    "a struct, array, u8 or variant".to_string(),
                 ));
             }
         }

--- a/zvariant/tests/dict_value.rs
+++ b/zvariant/tests/dict_value.rs
@@ -235,4 +235,10 @@ fn dict_value() {
     #[derive(Default, Debug, SerializeDict, DeserializeDict, Type)]
     #[zvariant(signature = "dict")]
     struct TestEmpty {}
+
+    // Empty dict should be serialized to contain 4 bytes for the ARRAY length and 4 bytes for the
+    // DICT_ENTRY alignment to 8 bytes boundary.
+    let data = to_bytes(ctxt, &TestEmpty::default()).unwrap();
+
+    assert_eq!(data.bytes(), &[0, 0, 0, 0, 0, 0, 0, 0]);
 }


### PR DESCRIPTION
This fixes a regression that was exposed by 56cbb1f64.
    
Fixes #1417.
