### PR TITLE
Add an interface_unchecked function to object_server

### DIFF
--- a/zbus/tests/issue/issue_1430.rs
+++ b/zbus/tests/issue/issue_1430.rs
@@ -1,0 +1,46 @@
+use zbus::{interface, Connection};
+
+struct TestInterface {
+    dbus_connection: Connection,
+    count: u8,
+}
+
+#[interface(name = "org.zbus.MyGreeter1")]
+impl TestInterface {
+    // Can be `async` as well.
+    async fn say_hello(&mut self, name: &str) -> String {
+        self.count += 1;
+        let _interface = self
+            .dbus_connection
+            .object_server()
+            .interface_unchecked::<_, TestInterface>("/test")
+            .await
+            .unwrap();
+        format!("Hello {}! I have been called {} times.", name, self.count)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::issue::issue_1430::TestInterface;
+
+    #[tokio::test]
+    async fn test_deadlock() {
+        let connection = zbus::connection::Connection::session().await.unwrap();
+        let test_interface = TestInterface {
+            count: 0,
+            dbus_connection: connection.clone(),
+        };
+        connection
+            .object_server()
+            .at("/test", test_interface)
+            .await
+            .unwrap();
+        let interface = connection
+            .object_server()
+            .interface::<_, TestInterface>("/test")
+            .await
+            .unwrap();
+        let _ = interface.get_mut().await.say_hello("deadlock").await;
+    }
+}

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -3,6 +3,7 @@ mod issue_104;
 mod issue_121;
 #[cfg(feature = "blocking-api")]
 mod issue_122;
+mod issue_1430;
 mod issue_173;
 mod issue_260;
 mod issue_466;


### PR DESCRIPTION
The current interface function requires a read lock to be acquired on the interface before returning the references. It needs this to check if the interface can be safely downcasted. This new function does not contain that check allowing it be used both internally and externally, to acquire a shared reference to the current interface. This is especially useful when annotating the functions with signalreceiver is not possible or desired.

I have some very niche usecases where annotating our function with SignalReceiver is not viable and this function would help a lot for my usecase so I hope you'll consider accepting this PR.
