### PR TITLE
🎨 zb: Remove unsafe type casting code

### DIFF
--- a/zbus/src/object_server/interface/interface_deref.rs
+++ b/zbus/src/object_server/interface/interface_deref.rs
@@ -20,7 +20,10 @@ where
     type Target = I;
 
     fn deref(&self) -> &I {
-        self.iface.downcast_ref::<I>().unwrap()
+        let any_ref: &dyn std::any::Any = &*self.iface;
+        any_ref
+            .downcast_ref::<I>()
+            .expect("Unexpected interface type")
     }
 }
 
@@ -37,7 +40,10 @@ where
     type Target = I;
 
     fn deref(&self) -> &I {
-        self.iface.downcast_ref::<I>().unwrap()
+        let any_ref: &dyn std::any::Any = &*self.iface;
+        any_ref
+            .downcast_ref::<I>()
+            .expect("Unexpected interface type")
     }
 }
 
@@ -46,6 +52,9 @@ where
     I: Interface,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.iface.downcast_mut::<I>().unwrap()
+        let any_ref: &mut dyn std::any::Any = &mut *self.iface;
+        any_ref
+            .downcast_mut::<I>()
+            .expect("Unexpected interface type")
     }
 }

--- a/zbus/src/object_server/interface/interface_ref.rs
+++ b/zbus/src/object_server/interface/interface_ref.rs
@@ -25,10 +25,6 @@ where
     pub async fn get(&self) -> InterfaceDeref<'_, I> {
         let iface = self.lock.read().await;
 
-        iface
-            .downcast_ref::<I>()
-            .expect("Unexpected interface type");
-
         InterfaceDeref {
             iface,
             phantom: PhantomData,
@@ -80,14 +76,7 @@ where
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
     pub async fn get_mut(&self) -> InterfaceDerefMut<'_, I> {
-        let mut iface = self.lock.write().await;
-
-        iface
-            .downcast_ref::<I>()
-            .expect("Unexpected interface type");
-        iface
-            .downcast_mut::<I>()
-            .expect("Unexpected interface type");
+        let iface = self.lock.write().await;
 
         InterfaceDerefMut {
             iface,

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -6,7 +6,7 @@ mod interface_deref;
 pub use interface_deref::*;
 
 use std::{
-    any::{Any, TypeId},
+    any::Any,
     collections::HashMap,
     fmt::{self, Write},
     sync::Arc,
@@ -165,34 +165,5 @@ impl fmt::Debug for ArcInterface {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Arc<RwLock<dyn Interface>>")
             .finish_non_exhaustive()
-    }
-}
-
-// Note: while it is possible to implement this without `unsafe`, it currently requires a helper
-// trait with a blanket impl that creates `dyn Any` refs.  It's simpler (and more performant) to
-// just check the type ID and do the downcast ourself.
-//
-// See https://github.com/rust-lang/rust/issues/65991 for a rustc feature that will make it
-// possible to get a `dyn Any` ref directly from a `dyn Interface` ref; once that is stable, we can
-// remove this unsafe code.
-impl dyn Interface {
-    /// Return Any of self
-    pub(crate) fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        if <dyn Interface as Any>::type_id(self) == TypeId::of::<T>() {
-            // SAFETY: If type ID matches, it means object is of type T
-            Some(unsafe { &*(self as *const dyn Interface as *const T) })
-        } else {
-            None
-        }
-    }
-
-    /// Return Any of self
-    pub(crate) fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
-        if <dyn Interface as Any>::type_id(self) == TypeId::of::<T>() {
-            // SAFETY: If type ID matches, it means object is of type T
-            Some(unsafe { &mut *(self as *mut dyn Interface as *mut T) })
-        } else {
-            None
-        }
     }
 }

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -1,6 +1,6 @@
 //! The object server API.
 
-use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+use std::{any::Any, collections::HashMap, marker::PhantomData, sync::Arc};
 use tracing::{Instrument, debug, instrument, trace, trace_span};
 
 use zbus_names::InterfaceName;
@@ -274,11 +274,11 @@ impl ObjectServer {
             .instance
             .clone();
 
-        // Ensure what we return can later be dowcasted safely.
-        lock.read()
-            .await
-            .downcast_ref::<I>()
-            .ok_or(Error::InterfaceNotFound)?;
+        {
+            // Ensure what we return can later be downcasted safely.
+            let iface: &dyn Any = &*lock.read().await;
+            iface.downcast_ref::<I>().ok_or(Error::InterfaceNotFound)?;
+        }
 
         let conn = self.connection();
         // SAFETY: We know that there is a valid path on the node as we already converted w/o error.


### PR DESCRIPTION
Rustc 1.86 stabilizes a new features called trait_upcasting. As quoted from the rust docs "Enable upcasts from dyn Trait1 to dyn Trait2 if Trait1 is a subtrait of Trait2". Which is exactly what this unsafe code was doing. I added the new syntax and increased the compiler version to 1.86 to enable this feature and remove these unsafe blocks. There were also multiple places where this check was called without any reason as it's checked at construction (and would just panic either way).

Related to: https://github.com/rust-lang/rust/issues/65991

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/dbus2/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
