### PR TITLE
👷CI: use vcpkg to install win32 deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,8 +120,6 @@ jobs:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
       RUST_LOG: trace
-      PKG_CONFIG: C:\vcpkg\installed\x64-windows\tools\pkgconf\pkgconf.exe
-      PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
       ErrorActionPreference: Stop
       WarningPreference: Stop
     steps:
@@ -147,20 +145,9 @@ jobs:
         shell: cmd
         run: |
           C:\vcpkg\vcpkg.exe install ^
-            glib:x64-windows ^
-            pkgconf:x64-windows ^
-            expat:x64-windows ^
             dbus:x64-windows
           C:\vcpkg\vcpkg.exe integrate install
           echo C:\vcpkg\installed\x64-windows\tools\dbus>> %GITHUB_PATH%
-
-      - name: Install Meson and Ninja
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: pip3 install meson ninja
-
-      - name: Setup MSVC Environment
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        uses: ilammy/msvc-dev-cmd@v1
 
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Testing this on github CI, see if it helps building win32 version more reliably.