### PR TITLE
🧵 zb: Launch a multi-threaded tokio runtime for blocking

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -77,6 +77,7 @@ async-task = { workspace = true, optional = true }
 async-process = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
     "rt",
+    "rt-multi-thread",
     "net",
     "time",
     "fs",

--- a/zbus/src/utils.rs
+++ b/zbus/src/utils.rs
@@ -43,7 +43,7 @@ pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
 
     TOKIO_RT
         .get_or_init(|| {
-            tokio::runtime::Builder::new_current_thread()
+            tokio::runtime::Builder::new_multi_thread()
                 .enable_io()
                 .enable_time()
                 .build()


### PR DESCRIPTION
Otherwise, any blocking calls in the application code can block our
internal tasks. This is breaking our "we won't launch threads behind
your back" promise a little but its only limited to blocking API and
therefore worth the benefit of not unexpectedly stopping to work.

Fixes #1512.
