### PR TITLE
Revert "🤖 renovate: Don't maintain the lock file"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,10 @@
         "cargo"
       ],
       "commitMessageAction": "⬆️  Update",
-      "commitMessageTopic": "{{depName}}"
+      "commitMessageTopic": "{{depName}}",
+      "lockFileMaintenance": {
+        "enabled": true
+      }
     },
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
This reverts commit f41efe9c3ea167ff53f611365113b8635f8c4f6b.

I thought the reverted change will stop renovate from reacting to micro
updates that doesn't matter to a library crate but it only means it
can't update the lock file. 🤷

https://github.com/dbus2/zbus/pull/1522#issuecomment-3334913594
