### PR TITLE
👷zb: exclude unixexec test on win32

### DIFF
--- a/zbus/tests/unixexec.rs
+++ b/zbus/tests/unixexec.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "windows"))]
+
 use ntest::timeout;
 use test_log::test;
 


### PR DESCRIPTION
ssia
