### PR TITLE
docs: Fix broken intra-doc links

### DIFF
--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -139,7 +139,8 @@ impl ObjectServer {
         }
     }
 
-    /// Register a D-Bus [`Interface`] at a given path (see the example above).
+    /// Register a D-Bus [`crate::object_server::Interface`] at a given path (see the example
+    /// above).
     ///
     /// Typically you'd want your interfaces to be registered immediately after the associated
     /// connection is established and therefore use
@@ -148,8 +149,6 @@ impl ObjectServer {
     /// method becomes useful.
     ///
     /// If the interface already exists at this path, returns false.
-    ///
-    /// [`Interface`]: trait.Interface.html
     pub fn at<'p, P, I>(&self, path: P, iface: I) -> Result<bool>
     where
         I: Interface,
@@ -159,12 +158,10 @@ impl ObjectServer {
         block_on(self.azync.at(path, iface))
     }
 
-    /// Unregister a D-Bus [`Interface`] at a given path.
+    /// Unregister a D-Bus [`crate::object_server::Interface`] at a given path.
     ///
     /// If there are no more interfaces left at that path, destroys the object as well.
     /// Returns whether the object was destroyed.
-    ///
-    /// [`Interface`]: trait.Interface.html
     pub fn remove<'p, I, P>(&self, path: P) -> Result<bool>
     where
         I: Interface,

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -50,14 +50,13 @@ pub use builder::Builder;
 ///
 /// # Note
 ///
-/// It is recommended to use the [`proxy`] macro, which provides a more convenient and
-/// type-safe *façade* `Proxy` derived from a Rust trait.
+/// It is recommended to use the [`macro@crate::proxy`] macro, which provides a more
+/// convenient and type-safe *façade* `Proxy` derived from a Rust trait.
 ///
 /// ## Current limitations:
 ///
 /// At the moment, `Proxy` doesn't prevent [auto-launching][al].
 ///
-/// [`proxy`]: attr.proxy.html
 /// [al]: https://github.com/z-galaxy/zbus/issues/54
 #[derive(Clone)]
 pub struct Proxy<'a> {

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -102,7 +102,8 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 ///
 /// For higher-level message handling (typed functions, introspection, documentation reasons etc),
 /// it is recommended to wrap the low-level D-Bus messages into Rust functions with the
-/// [`proxy`] and [`interface`] macros instead of doing it directly on a `Connection`.
+/// [`macro@crate::proxy`] and [`macro@crate::interface`] macros instead of doing it directly on a
+/// `Connection`.
 ///
 /// Typically, a connection is made to the session bus with [`Connection::session`], or to the
 /// system bus with [`Connection::system`]. Then the connection is used with [`crate::Proxy`]
@@ -132,8 +133,6 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 ///
 /// [method calls]: struct.Connection.html#method.call_method
 /// [signals]: struct.Connection.html#method.emit_signal
-/// [`proxy`]: attr.proxy.html
-/// [`interface`]: attr.interface.html
 /// [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
 /// [`set_max_queued`]: struct.Connection.html#method.set_max_queued
 ///
@@ -823,7 +822,7 @@ impl Connection {
 
     /// The unique name of the connection, if set/applicable.
     ///
-    /// The unique name is assigned by the message bus or set manually using
+    /// The unique name is assigned by the message bus, or set manually using
     /// [`Connection::set_unique_name`].
     pub fn unique_name(&self) -> Option<&OwnedUniqueName> {
         self.inner.unique_name.get()

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -12,10 +12,9 @@ use zvariant::{Str, Type};
 ///
 /// See the D-Bus specification [UUIDs chapter] for details.
 ///
-/// You can create a `Guid` from an existing string with [`Guid::try_from::<&str>`][TryFrom].
+/// You can create a `Guid` from an existing string with [`Guid::try_from::<&str>`].
 ///
 /// [UUIDs chapter]: https://dbus.freedesktop.org/doc/dbus-specification.html#uuids
-/// [TryFrom]: #impl-TryFrom%3C%26%27_%20str%3E
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Type, Serialize)]
 pub struct Guid<'g>(Str<'g>);
 

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -45,13 +45,12 @@ impl Sequence {
 ///
 /// Also provided are constructors for messages of different types. These will mainly be useful for
 /// very advanced use cases as typically you will want to create a message for immediate dispatch
-/// and hence use the API provided by [`Connection`], even when using the low-level API.
+/// and hence use the API provided by [`crate::connection::Connection::call_method`], even when
+/// using the low-level API.
 ///
 /// **Note**: The message owns the received FDs and will close them when dropped. You can
 /// deserialize the body (that you get using [`Message::body`]) to [`zvariant::OwnedFd`] if you want
 /// to keep the FDs around after the containing message is dropped.
-///
-/// [`Connection`]: struct.Connection#method.call_method
 #[derive(Clone)]
 pub struct Message {
     pub(super) inner: Arc<Inner>,

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -3,10 +3,8 @@ use zvariant::ObjectPath;
 
 /// Trait for the default associated values of a proxy.
 ///
-/// The trait is automatically implemented by the [`proxy`] macro on your behalf, and may be later
-/// used to retrieve the associated constants.
-///
-/// [`proxy`]: attr.proxy.html
+/// The trait is automatically implemented by the [`macro@crate::proxy`] macro on your behalf, and
+/// may be later used to retrieve the associated constants.
 pub trait Defaults {
     const INTERFACE: &'static Option<InterfaceName<'static>>;
     const DESTINATION: &'static Option<BusName<'static>>;

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -62,11 +62,8 @@ pub use defaults::Defaults;
 ///
 /// # Note
 ///
-/// It is recommended to use the [`proxy`] macro, which provides a more convenient and
-/// type-safe *façade* `Proxy` derived from a Rust trait.
-///
-/// [`futures` crate]: https://crates.io/crates/futures
-/// [`proxy`]: attr.proxy.html
+/// It is recommended to use the [`macro@crate::proxy`] macro, which provides a more
+/// convenient and type-safe *façade* `Proxy` derived from a Rust trait.
 #[derive(Clone, Debug)]
 pub struct Proxy<'a> {
     pub(crate) inner: Arc<ProxyInner<'a>>,

--- a/zvariant/src/as_value/deserialize.rs
+++ b/zvariant/src/as_value/deserialize.rs
@@ -8,7 +8,7 @@ use crate::{Signature, Type};
 /// A wrapper to deserialize a value to `T: Type + serde::Deserialize`.
 ///
 /// When the type of a value is well-known, you may avoid the cost and complexity of wrapping to a
-/// generic [`Value`] and instead use this wrapper.
+/// generic [`enum@crate::Value`] and instead use this wrapper.
 ///
 /// ```
 /// # use zvariant::{to_bytes, serialized::Context, as_value::{Deserialize, Serialize}, LE};
@@ -20,8 +20,6 @@ use crate::{Signature, Type};
 /// let decoded: Deserialize<[u8; 3]> = encoded.deserialize().unwrap().0;
 /// # assert_eq!(decoded.0, array);
 /// ```
-///
-/// [`Value`]: enum.Value.html
 pub struct Deserialize<'de, T: Type + serde::Deserialize<'de>>(
     pub T,
     std::marker::PhantomData<&'de T>,

--- a/zvariant/src/as_value/serialize.rs
+++ b/zvariant/src/as_value/serialize.rs
@@ -5,7 +5,7 @@ use crate::Type;
 /// A wrapper to serialize `T: Type + serde::Serialize` as a value.
 ///
 /// When the type of a value is well-known, you may avoid the cost and complexity of wrapping to a
-/// generic [`Value`] and instead use this wrapper.
+/// generic [`enum@crate::Value`] and instead use this wrapper.
 ///
 /// ```
 /// # use zvariant::{to_bytes, serialized::Context, as_value::Serialize, LE};
@@ -13,8 +13,6 @@ use crate::Type;
 /// # let ctxt = Context::new_dbus(LE, 0);
 /// let _ = to_bytes(ctxt, &Serialize(&[0, 1, 2])).unwrap();
 /// ```
-///
-/// [`Value`]: enum.Value.html
 pub struct Serialize<'a, T: Type + serde::Serialize>(pub &'a T);
 
 impl<T: Type + serde::Serialize> serde::Serialize for Serialize<'_, T> {

--- a/zvariant/src/ser.rs
+++ b/zvariant/src/ser.rs
@@ -208,11 +208,8 @@ where
 /// Serialize `T` that has the given signature, to a new byte vector.
 ///
 /// Use this function instead of [`to_bytes`] if the value being serialized does not implement
-/// [`DynamicType`]. See [`from_slice_for_signature`] documentation for an example of how to use
-/// this function.
-///
-/// [`to_bytes`]: fn.to_bytes.html
-/// [`from_slice_for_signature`]: fn.from_slice_for_signature.html#examples
+/// [`DynamicType`]. See [`Data::deserialize_for_signature`] documentation for an example of how to
+/// use this function.
 pub fn to_bytes_for_signature<S, T>(
     ctxt: Context,
     signature: S,

--- a/zvariant/src/serialized/context.rs
+++ b/zvariant/src/serialized/context.rs
@@ -1,6 +1,6 @@
 use crate::{serialized::Format, Endian};
 
-/// The encoding context to use with the [serialization and deserialization] API.
+/// The encoding context to use with the [serialization] and [deserialization] API.
 ///
 /// The encoding is dependent on the position of the encoding in the entire message and hence the
 /// need to [specify] the byte position of the data being serialized or deserialized. Simply pass
@@ -24,8 +24,9 @@ use crate::{serialized::Format, Endian};
 /// assert_eq!(decoded, "World");
 /// ```
 ///
-/// [serialization and deserialization]: index.html#functions
-/// [specify]: #method.new
+/// [serialization]: zvariant#functions
+/// [deserialization]: zvariant::serialized::Data::deserialize
+/// [specify]: Context::new
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Context {
     format: Format,

--- a/zvariant/src/type/mod.rs
+++ b/zvariant/src/type/mod.rs
@@ -16,24 +16,21 @@ use crate::Signature;
 /// Trait implemented by all serializable types.
 ///
 /// This very simple trait provides the signature for the implementing type. Since the [D-Bus type
-/// system] relies on these signatures, our [serialization and deserialization] API requires this
-/// trait in addition to [`Serialize`] and [`Deserialize`], respectively.
+/// system] relies on these signatures, our [serialization] and [deserialization] API requires this
+/// trait in addition to [`trait@serde::Serialize`] and [`serde::de::Deserialize`], respectively.
 ///
-/// Implementation is provided for all the [basic types] and blanket implementations for common
-/// container types, such as, arrays, slices, tuples, [`Vec`] and [`HashMap`]. For easy
-/// implementation for custom types, use `Type` derive macro from [zvariant_derive] crate.
+/// Implementation is provided for all the [basic types](crate::Basic) and blanket implementations
+/// for common container types, such as, arrays, slices, tuples, [`Vec`] and
+/// [`std::collections::HashMap`]. For easy implementation for custom types, use `Type` derive macro
+/// from [zvariant_derive] crate.
 ///
 /// If your type's signature cannot be determined statically, you should implement the
-/// [DynamicType] trait instead, which is otherwise automatically implemented if you implement this
-/// trait.
+/// [`DynamicType`] trait instead, which is otherwise automatically implemented if you implement
+/// this trait.
 ///
 /// [D-Bus type system]: https://dbus.freedesktop.org/doc/dbus-specification.html#type-system
-/// [serialization and deserialization]: index.html#functions
-/// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
-/// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
-/// [basic types]: trait.Basic.html
-/// [`Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html
-/// [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+/// [serialization]: zvariant#functions
+/// [deserialization]: zvariant::serialized::Data::deserialize
 /// [zvariant_derive]: https://docs.rs/zvariant_derive/latest/zvariant_derive/
 pub trait Type {
     /// The signature for the implementing type, in parsed format.

--- a/zvariant_derive/src/lib.rs
+++ b/zvariant_derive/src/lib.rs
@@ -466,7 +466,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// `dict` or `a{sv}` values. All other values will be ignored.
 ///
 /// [`Value`]: https://docs.rs/zvariant/latest/zvariant/enum.Value.html
-/// [`Type`]: derive.Type.html#custom-types
+/// [`Type`]: crate::Type#custom-signatures
 #[proc_macro_derive(Value, attributes(zbus, zvariant))]
 pub fn value_macro_derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();


### PR DESCRIPTION
Fixes most broken intra-doc links (identified with cargo-deadlinks).

Mostly this replaces manual path links with rustdoc intra-doc links - I _think_ I've identified the correct thing to link to in each case but in some cases I've had to infer a bit. Please do check the links make sense!

There are still some broken links:
```
Found invalid urls in proxy/enum.MethodFlags.html:
	Fragment #tymethod.bits at proxy/enum.MethodFlags.html does not exist!
Found invalid urls in fdo/enum.RequestNameFlags.html:
	Fragment #tymethod.bits at fdo/enum.RequestNameFlags.html does not exist!
Found invalid urls in message/enum.Flags.html:
	Fragment #tymethod.bits at message/enum.Flags.html does not exist!
Found invalid urls in struct.Optional.html:
	Linked file at path /Users/samw/prog/tmp/zbus/target/std/string/struct.String.html does not exist!
Found invalid urls in serialized/index.html:
	Fragment #functions at serialized/index.html does not exist!
Found invalid urls in serialized/struct.Context.html:
	Fragment #functions at serialized/index.html does not exist!
```

but I ran out of time to really dig into them/couldn't work out what they were intended to link to.

Would definitely suggest running cargo-deadlinks as part of CI, if that sounds good I could probably be convinced to add it...

