### PR TITLE
➖ Drop `nix` dependency in favor of `rustix` & `libc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.7",
+ "rustix 1.1.2",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -188,7 +188,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.7",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -657,7 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1097,9 +1097,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1186,7 +1186,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1514,20 +1513,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1734,7 +1733,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1744,7 +1743,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.7",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2128,7 +2127,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2309,9 +2308,10 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "hex",
- "nix 0.30.1",
+ "libc",
  "ntest",
  "ordered-stream",
+ "rustix 1.1.2",
  "serde",
  "serde_repr",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,14 @@ static_assertions = "1.1.0"
 async-recursion = "1.1.1"
 winnow = "0.7"
 uds_windows = "1.1.0"
-nix = { version = "0.30", default-features = false, features = [
-    "socket",
-    "uio",
-    "user",
+rustix = { version = "1.1.2", default-features = false, features = [
+    "net",
+    "process",
+    "std",
 ] }
+# FIXME: Remove when rustix provides the needed API. See `FIXME` comments in
+# `zbus::connection::socket::unix` module.
+libc = { version = "0.2", default-features = false }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -96,7 +96,8 @@ windows-sys.workspace = true
 uds_windows.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-nix.workspace = true
+rustix.workspace = true
+libc.workspace = true
 
 [target.'cfg(any(target_os = "macos", windows))'.dependencies]
 async-recursion.workspace = true

--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -13,7 +13,7 @@ pub mod transport;
 
 use crate::{Error, Guid, OwnedGuid, Result};
 #[cfg(all(unix, not(target_os = "macos")))]
-use nix::unistd::Uid;
+use rustix::process::geteuid;
 use std::{collections::HashMap, env, str::FromStr};
 
 use std::fmt::{Display, Formatter};
@@ -72,7 +72,7 @@ impl Address {
                 #[cfg(all(unix, not(target_os = "macos")))]
                 {
                     let runtime_dir = env::var("XDG_RUNTIME_DIR")
-                        .unwrap_or_else(|_| format!("/run/user/{}", Uid::effective()));
+                        .unwrap_or_else(|_| format!("/run/user/{}", geteuid().as_raw()));
                     let path = format!("unix:path={runtime_dir}/bus");
 
                     Self::from_str(&path)

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -7,7 +7,7 @@ mod server;
 
 use async_trait::async_trait;
 #[cfg(unix)]
-use nix::unistd::Uid;
+use rustix::process::geteuid;
 use std::fmt::Debug;
 use zbus_names::OwnedUniqueName;
 
@@ -99,7 +99,7 @@ fn sasl_auth_id() -> Result<String> {
     let id = {
         #[cfg(unix)]
         {
-            Uid::effective().to_string()
+            geteuid().as_raw().to_string()
         }
 
         #[cfg(windows)]
@@ -158,8 +158,7 @@ mod tests {
 
         let guid = OwnedGuid::from(Guid::generate());
         let client = Client::new(p0.into(), None, Some(guid.clone()), false);
-        let server =
-            Server::new(p1.into(), guid, Some(Uid::effective().into()), None, None).unwrap();
+        let server = Server::new(p1.into(), guid, Some(geteuid().as_raw()), None, None).unwrap();
 
         // proceed to the handshakes
         let (client, server) = crate::utils::block_on(join(
@@ -178,7 +177,7 @@ mod tests {
         let server = Server::new(
             p1.into(),
             Guid::generate().into(),
-            Some(Uid::effective().into()),
+            Some(geteuid().as_raw()),
             None,
             None,
         )
@@ -206,7 +205,7 @@ mod tests {
         let server = Server::new(
             p1.into(),
             Guid::generate().into(),
-            Some(Uid::effective().into()),
+            Some(geteuid().as_raw()),
             None,
             None,
         )
@@ -232,7 +231,7 @@ mod tests {
         let server = Server::new(
             p1.into(),
             Guid::generate().into(),
-            Some(Uid::effective().into()),
+            Some(geteuid().as_raw()),
             None,
             None,
         )
@@ -249,7 +248,7 @@ mod tests {
         let server = Server::new(
             p1.into(),
             Guid::generate().into(),
-            Some(Uid::effective().into()),
+            Some(geteuid().as_raw()),
             Some(AuthMechanism::Anonymous),
             None,
         )
@@ -266,7 +265,7 @@ mod tests {
         let server = Server::new(
             p1.into(),
             Guid::generate().into(),
-            Some(Uid::effective().into()),
+            Some(geteuid().as_raw()),
             Some(AuthMechanism::Anonymous),
             None,
         )

--- a/zbus/src/connection/socket/channel.rs
+++ b/zbus/src/connection/socket/channel.rs
@@ -126,11 +126,11 @@ async fn self_credentials() -> io::Result<ConnectionCredentials> {
 
     #[cfg(unix)]
     {
-        use nix::unistd::{Gid, Uid};
+        use rustix::process::{getegid, geteuid};
 
         creds = creds
-            .set_unix_user_id(Uid::effective().into())
-            .add_unix_group_id(Gid::effective().into());
+            .set_unix_user_id(geteuid().as_raw())
+            .add_unix_group_id(getegid().as_raw());
     }
     #[cfg(windows)]
     {

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -222,13 +222,6 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(unix)]
-impl From<nix::Error> for Error {
-    fn from(val: nix::Error) -> Self {
-        io::Error::from_raw_os_error(val as i32).into()
-    }
-}
-
 impl From<VariantError> for Error {
     fn from(val: VariantError) -> Self {
         Error::Variant(val)

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -16,7 +16,7 @@ fn issue_813() {
     // 1 FD each. Before a fix for this issue, the server handshake would fail with an
     // `Unexpected FDs during handshake` error.
     use futures_util::try_join;
-    use nix::unistd::Uid;
+    use rustix::process::geteuid;
     #[cfg(not(feature = "tokio"))]
     use std::os::unix::net::UnixStream;
     use std::{os::fd::AsFd, vec};
@@ -79,7 +79,7 @@ fn issue_813() {
         let client = async move {
             let commands = format!(
                 "\0AUTH EXTERNAL {}\r\nNEGOTIATE_UNIX_FD\r\nBEGIN\r\n",
-                hex::encode(Uid::effective().to_string())
+                hex::encode(geteuid().as_raw().to_string())
             );
             let mut bytes: Vec<u8> = commands.bytes().collect();
             let fd = std::io::stdin();


### PR DESCRIPTION
Both `rustix` and `libc` are already indirect dependencies. `nix` is still an indirect dependency if the (non-default) `vsock` feature is enabled and it remains to be a dev-dependency through Codspeed.
