### PR TITLE
🐛 macros: ignore r# prefix in parameter names

### DIFF
--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -74,6 +74,20 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     assert!(my_iface.methods().iter().any(|m| m.name() == "Type"));
     assert!(my_iface.properties().iter().any(|p| p.name() == "Let"));
     assert!(my_iface.signals().iter().any(|s| s.name() == "Match"));
+    assert_eq!(
+        my_iface
+            .methods()
+            .iter()
+            .find(|m| m.name() == "RawIdentifierParameter")
+            .unwrap()
+            .args()
+            .iter()
+            .next()
+            .unwrap()
+            .name()
+            .unwrap(),
+        "type"
+    );
 
     let proxy = MyIfaceProxy::builder(&conn)
         .destination("org.freedesktop.MyService")?
@@ -161,6 +175,11 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     assert_eq!(proxy.r#let().await?, 0);
     proxy.set_let(1).await?;
     assert_eq!(proxy.r#let().await?, 1);
+
+    assert_eq!(
+        proxy.raw_identifier_parameter("param").await?,
+        "type: param",
+    );
 
     let err = proxy.fail_property().await;
     assert_eq!(

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -189,6 +189,13 @@ impl MyIface {
         Ok("r# prefix method works".into())
     }
 
+    #[instrument]
+    async fn raw_identifier_parameter(&self, r#type: &str) -> zbus::fdo::Result<String> {
+        debug!("`raw_identifier_parameter` called.");
+        let t = r#type;
+        Ok(format!("type: {t}"))
+    }
+
     #[cfg(feature = "option-as-array")]
     #[instrument]
     async fn optional_args(&self, arg: Option<&str>) -> zbus::fdo::Result<Option<String>> {

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -1179,6 +1179,7 @@ fn introspect_input_args<'i>(
 
             let ident = pat_ident(pat_type).unwrap();
             let arg_name = quote!(#ident).to_string();
+            let arg_name = arg_name.strip_prefix("r#").unwrap_or(arg_name.as_str());
             let dir = if is_signal { "" } else { " direction=\"in\"" };
             let format_str = format!(
                 "{}<arg name=\"{arg_name}\" type=\"{}\"{dir}/>",


### PR DESCRIPTION
The r# prefix of raw identifiers in parameter names is no longer carried over into the dbus introspection XML.

This is a follow-up to #1565, which dealt with method names.

Closes #158
