### PR TITLE
➖ xmlgen: Make the library part not depend on clap

### DIFF
--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -20,17 +20,21 @@ license = "MIT"
 categories = ["os::unix-apis", "development-tools"]
 readme = "README.md"
 
+[features]
+default = ["cli"]
+cli = ["dep:clap"]
+
 [[bin]]
 name = "zbus-xmlgen"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [dependencies]
 zbus = { path = "../zbus", features = ["blocking-api"], version = "5.5.0" }
 zbus_xml = { path = "../zbus_xml", version = "5.0.2" }
 
 snakecase.workspace = true
-clap.workspace = true
-
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true


### PR DESCRIPTION
By making clap an optional dependency and requiring it as a feature by
the binary, we ensure that by default the library doesn't depend on clap
but the binary does.

This supersedes PR #1585 and solves the same issue but in a simpler/less
intrusive way.

