### PR TITLE
⚡️ Store object interfaces sorted by their interface names

### DIFF
--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -1,7 +1,7 @@
 //! The object server API.
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{btree_map, hash_map, BTreeMap, HashMap},
     fmt::Write,
 };
 
@@ -20,7 +20,7 @@ use super::{ArcInterface, Interface};
 pub(crate) struct Node {
     path: OwnedObjectPath,
     children: HashMap<String, Node>,
-    interfaces: HashMap<InterfaceName<'static>, ArcInterface>,
+    interfaces: BTreeMap<InterfaceName<'static>, ArcInterface>,
 }
 
 impl Node {
@@ -77,7 +77,7 @@ impl Node {
 
             write!(&mut node_path, "/{i}").unwrap();
             match node.children.entry(i.into()) {
-                Entry::Vacant(e) => {
+                hash_map::Entry::Vacant(e) => {
                     if create {
                         let path = node_path.as_str().try_into().expect("Invalid Object Path");
                         node = e.insert(Node::new(path));
@@ -85,7 +85,7 @@ impl Node {
                         return (None, obj_manager_path);
                     }
                 }
-                Entry::Occupied(e) => node = e.into_mut(),
+                hash_map::Entry::Occupied(e) => node = e.into_mut(),
             }
         }
 
@@ -119,11 +119,11 @@ impl Node {
         arc_iface: ArcInterface,
     ) -> bool {
         match self.interfaces.entry(name) {
-            Entry::Vacant(e) => {
+            btree_map::Entry::Vacant(e) => {
                 e.insert(arc_iface);
                 true
             }
-            Entry::Occupied(_) => false,
+            btree_map::Entry::Occupied(_) => false,
         }
     }
 


### PR DESCRIPTION
Within each interface, the introspection information for methods and
properties is sorted syntactically.

Combining non-random order of interfaces with syntactic order for their
methods and properties makes the introspection information yielded by
two invocations of the org.freedesktop.DBus.Introspectable interface's
Introspect method readily comparable via simple textual methods or the
informed glance of a human being.

There's no real benefit to the Introspect method returning the
introspection information for each interface in random order.

Usually, an object path doesn't have all that many interfaces. Since a
the order of the BTreeMap is 11, it is likely that all the interfaces
will fit into a single root node (or there might be two child nodes).
The HashMap size is usually doubled as it reaches capacity, as far as I
have observed, so there may not be much to choose between the two
implementations in terms of space usage.

If the usual case is assumed to be about five interfaces, the standard
freedesktop interfaces and then one or two more, HashMap may do slightly
better in terms of space allocation.

Interfaces can be added or removed, but it doesn't happen with
extraordinary frequency. So the insertion cost, generally higher for the
BTreeMap is likely not worth worrying about in this context.

Using a BTreeMap is likely to be more efficient when iterating over
all elements, since a BTreeMap is designed with keys packed rather tightly
so that all may fit in a single cache line.