### PR TITLE
🚸 xmlgen: make error compatible with anyhow

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -19,7 +19,7 @@ pub fn write_interfaces(
     input_src: &str,
     cargo_bin_name: &str,
     cargo_bin_version: &str,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, Box<dyn Error + 'static>> {
     let mut unformatted = String::new();
 
     write_doc_header(


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

Make the returned error compatible with `anyhow`.