### PR TITLE
🔊 zb: lower trace/instrument verbosity

### DIFF
--- a/zbus/src/connection/handshake/client.rs
+++ b/zbus/src/connection/handshake/client.rs
@@ -52,7 +52,7 @@ impl Client {
 
     // The dbus daemon on some platforms requires sending the zero byte as a
     // separate message with SCM_CREDS.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
     async fn send_zero_byte(&mut self) -> Result<()> {
         let write = self.common.socket_mut().write_mut();
@@ -76,7 +76,7 @@ impl Client {
     }
 
     /// Perform the authentication handshake with the server.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     async fn authenticate(&mut self) -> Result<()> {
         let mechanism = self.common.mechanism();
         trace!("Trying {mechanism} mechanism");
@@ -109,7 +109,7 @@ impl Client {
     }
 
     /// Sends out all commands after authentication.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     async fn send_secondary_commands(&mut self) -> Result<usize> {
         let mut commands = Vec::with_capacity(4);
 
@@ -148,7 +148,7 @@ impl Client {
         Ok(commands.len() - 1)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     async fn receive_secondary_responses(&mut self, expected_n_responses: usize) -> Result<()> {
         for response in self.common.read_commands(expected_n_responses).await? {
             match response {
@@ -172,7 +172,7 @@ impl Client {
 
 #[async_trait]
 impl Handshake for Client {
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     async fn perform(mut self) -> Result<Authenticated> {
         trace!("Initializing");
 

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -44,7 +44,7 @@ impl SocketReader {
     }
 
     // Keep receiving messages and put them on the queue.
-    #[instrument(name = "socket reader", skip(self))]
+    #[instrument(name = "socket reader", skip(self), level = "trace")]
     async fn receive_msg(mut self) {
         loop {
             trace!("Waiting for message on the socket..");
@@ -98,7 +98,7 @@ impl SocketReader {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "trace")]
     async fn read_socket(&mut self) -> crate::Result<Message> {
         self.activity_event.notify(usize::MAX);
         let seq = self.prev_seq + 1;

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -265,7 +265,7 @@ enum CachingResult {
 }
 
 impl PropertiesCache {
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "trace")]
     fn new(
         proxy: PropertiesProxy<'static>,
         interface: InterfaceName<'static>,
@@ -390,7 +390,7 @@ impl PropertiesCache {
     }
 
     /// new() runs this in a task it spawns for keeping the cache in sync.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "trace")]
     async fn keep_updated(
         &self,
         mut prop_changes: PropertiesChangedStream,


### PR DESCRIPTION
When starting zed in debug mode, you get a pretty loud output during startup by default:

```
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::handshake::client] perform;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::handshake::client] authenticate;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::handshake::common] read_command;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::handshake::client] send_secondary_commands;
    2025-12-05T14:16:14+04:00 INFO  [zbus::proxy] new;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] socket reader;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::connection::socket_reader] read_socket;
    2025-12-05T14:16:14+04:00 INFO  [zbus::proxy] keep_updated;
```

Let's lower those  to trace level, which seems more appropriate.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
