### PR TITLE
🚸 Implement `to_string_lossy()` for `FilePath`

### DIFF
--- a/zvariant/src/file_path.rs
+++ b/zvariant/src/file_path.rs
@@ -41,6 +41,13 @@ impl<'f> FilePath<'f> {
     pub fn new(cow: Cow<'f, CStr>) -> Self {
         Self(cow)
     }
+
+    /// Returns a lossy UTF-8 representation of the file path.
+    ///
+    /// Invalid UTF-8 sequences are replaced with `U+FFFD REPLACEMENT CHARACTER`.
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
+        self.0.to_string_lossy()
+    }
 }
 
 impl From<CString> for FilePath<'_> {


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

~~`ObjectPath` implements `Display`, but `FilePath` doesn't. Figured this could help make it a bit more ergonomic.~~

This was silly of me- the lossiness should be explicit. This should be better 