### PR TITLE
🚨 zv: Remove unused `serde` imports

### DIFF
--- a/zbus/tests/issue/issue_81.rs
+++ b/zbus/tests/issue/issue_81.rs
@@ -1,6 +1,6 @@
 use test_log::test;
 
-use zvariant::{OwnedObjectPath, OwnedValue, Type};
+use zvariant::OwnedObjectPath;
 
 #[test]
 #[ignore]

--- a/zvariant/tests/enums.rs
+++ b/zvariant/tests/enums.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use zvariant::{serialized::Context, to_bytes_for_signature};
 
 #[macro_use]

--- a/zvariant/tests/struct_with_hashmap.rs
+++ b/zvariant/tests/struct_with_hashmap.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use zvariant::{serialized::Context, to_bytes, Type, LE};
 


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

I can't quite figure out why this didn't go off in any previous CI runs. This file had not been changed for months and I can't see any changes made to CI in any recent commits. 

I will keep in this in draft for now. 
