### PR TITLE
🥅 zm: Handle non-String fields in error variant matching

### DIFF
--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -122,6 +122,7 @@ fn test_derive_error() {
         LetItBe {
             desc: String,
         },
+        Timeout(String, u64),
     }
 }
 


### PR DESCRIPTION
This PR updates the `DBusError` derive macro to support enum variants where the first field is not a String.
Previously, such cases resulted in an error when using custom errors. Now, the macro attempts to parse the first field as a String. If parsing fails, it returns None instead.

## Example

```rust
#[derive(Debug, DBusError)]
pub enum ExampleDBusError {
   UnitVariant,
   UnnamedVariant(u32, String),
   UnnamedVariantString(String),
   NamedVariant { code: u32, message: String },
   NamedVariantString { message: String },
}
```

This now compiles and expands the `description` as following
```rust
fn description(&self) -> Option<&str> {
    match self {
        Self::UnitVariant => None,
        Self::UnnamedVariant(..) => None,
        Self::UnnamedVariantString(desc, ..) => Some(desc),
        Self::NamedVariant { .. } => None,
        Self::NamedVariantString { message } => Some(message),
    }
}
```