### PR TITLE
📝 CONTRIBUTING: Better document the emoji tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,12 @@ Same rules apply here as for bug reports and feature requests. Plus:
 * Please try your best to follow
   [these guidelines](https://handbook.gnome.org/development/commit-messages.html) for commit
   messages.
-* We also prefer adding [emoji prefixes to commit messages](https://gitmoji.carloscuesta.me/). Since
-  the `gitmoji` CLI tool can be very [slow](https://github.com/zeenix/gimoji#rationale), we
-  recommend using [`gimoji`](https://github.com/zeenix/gimoji) instead. You can also pick an emoji
-  direcitly from [here](https://zeenix.github.io/gimoji/) (please remember to copy the emoji itself
-  and not the `:emoji-code:` string, by just clicking on it). **NOTE:** This is a curated list of
-  emojis that have specific meanings. Please use one of the methods recommended here to select/fetch
-  the most appropriate one. 🙏
+* We also prefer adding emoji prefixes to commit messages. You can either use
+  [`gimoji`](https://github.com/zeenix/gimoji) CLI tool (which can be installed as a commit hook) or
+  pick one directly from [here](https://zeenix.github.io/gimoji/) (please remember to copy the emoji
+  itself and not the `:emoji-code:` string, by just clicking on it).
+  **NOTE:** This is a curated list of emojis that have specific meanings. Please use one of the
+  methods recommended here to select/fetch the most appropriate one. 🙏
 * Add a prefix indicating the packages being changed. Use either the package name or an abbreviation
   (for example, `zb` for `zbus`, `zv` for `zvariant` etc). If a commit touches multiple packages,
   separate with a comma. For example, for a commit changing the packages `zbus` and `zvariant`,


### PR DESCRIPTION
Contributors often end up just clicking on the first link, that takes them to gitmoji.dev and them clicking on the code rather than the emoji there, copies the code to the clipboard instead. Let's not link to gitmoji but only gimoji's web interface so this can't happen.
