### PR TITLE
🔧 xmlgen: use edition from workspace

### DIFF
--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Tim Small <tim@seoss.co.uk>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
-edition = "2024"
+edition = { workspace = true }
 rust-version = { workspace = true }
 
 description = "D-Bus XML interface code generator"


### PR DESCRIPTION
The `zbus_xmlgen` crate used the same edition as the workspace (2024), so switched to the workspace edition for consistency. No functional changes.