### PR TITLE
✨ zm: add special handling for ao DBus signatures

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -58,6 +58,7 @@ def_attrs! {
                 object str,
                 async_object str,
                 blocking_object str,
+                object_vec none,
                 no_reply none,
                 no_autostart none,
                 allow_interactive_auth none
@@ -1555,6 +1556,9 @@ impl Proxy {
             }
             if let Some(blocking_object) = attrs.blocking_object {
                 proxy_method_attrs.extend(quote! { blocking_object = #blocking_object, });
+            }
+            if attrs.object_vec {
+                proxy_method_attrs.extend(quote! { object_vec, });
             }
             if attrs.no_reply {
                 proxy_method_attrs.extend(quote! { no_reply, });

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -99,6 +99,10 @@ mod utils;
 /// * `blocking_object` - if the assumptions made by `object` attribute about naming of the blocking
 ///   proxy type, don't fit your bill, you can use this to specify its exact name.
 ///
+/// * `object_vec` - this method returns a list of [`ObjectPath`]s (DBus signature `ao`) that should
+///   be converted to the proxy object type named by `object`, `async_object` and `blocking_object`
+///   attributes, and returned as a `Vec<_>`.
+///
 ///   NB: Any doc comments provided shall be appended to the ones added by the macro.
 ///
 /// # Signals


### PR DESCRIPTION
Extend the support for the `object` attribute to return a `Vec<_>` if the `object_vec` attribute is also present.

This simplifies use of APIs like [NetworkManager's `GetDevices`](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.html#gdbus-method-org-freedesktop-NetworkManager.GetDevices) by allowing you to ask the macro to do the conversion from `Vec<OwnedObjectPath>` to `Vec<SuitableProxyType>`.

Fixes #332.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
