### PR TITLE
🐛 zv: Don't impl Type for dicts with non-basic keys

### DIFF
--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -275,7 +275,7 @@ macro_rules! to_dict {
     ($ty:ident <K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident)*>) => {
         impl<'k, 'v, K, V $(, $typaram)*> From<$ty<K, V $(, $typaram)*>> for Dict<'k, 'v>
         where
-            K: Type + Into<Value<'k>>,
+            K: Basic + Into<Value<'k>>,
             V: Type + Into<Value<'v>>,
             $($typaram: BuildHasher,)*
         {

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap, hash::BuildHasher, sync::Arc};
 
 #[cfg(feature = "gvariant")]
 use crate::Maybe;
-use crate::{Array, Dict, NoneValue, ObjectPath, Optional, Str, Structure, Type, Value};
+use crate::{Array, Basic, Dict, NoneValue, ObjectPath, Optional, Str, Structure, Type, Value};
 
 #[cfg(unix)]
 use crate::Fd;
@@ -122,7 +122,7 @@ impl<'a, 'k, 'v, K, V, H> From<HashMap<K, V, H>> for Value<'a>
 where
     'k: 'a,
     'v: 'a,
-    K: Type + Into<Value<'k>> + std::hash::Hash + std::cmp::Eq,
+    K: Basic + Into<Value<'k>> + std::hash::Hash + std::cmp::Eq,
     V: Type + Into<Value<'v>>,
     H: BuildHasher + Default,
 {

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::{borrow::Borrow, collections::HashMap, hash::BuildHasher};
 
 use crate::{
-    Array, Dict, NoneValue, ObjectPath, Optional, OwnedObjectPath, Signature, Str, Structure, Type,
-    Value,
+    Array, Basic, Dict, NoneValue, ObjectPath, Optional, OwnedObjectPath, Signature, Str,
+    Structure, Type, Value,
 };
 
 #[cfg(unix)]
@@ -151,7 +151,7 @@ where
 
 impl<K, V, H> From<HashMap<K, V, H>> for OwnedValue
 where
-    K: Type + Into<Value<'static>> + std::hash::Hash + std::cmp::Eq,
+    K: Basic + Into<Value<'static>> + std::hash::Hash + std::cmp::Eq,
     V: Type + Into<Value<'static>>,
     H: BuildHasher + Default,
 {

--- a/zvariant/src/type/libstd.rs
+++ b/zvariant/src/type/libstd.rs
@@ -1,4 +1,4 @@
-use crate::{Signature, Type, impl_type_with_repr};
+use crate::{Basic, Signature, Type, impl_type_with_repr};
 use std::{
     cell::{Cell, RefCell},
     cmp::Reverse,
@@ -204,7 +204,7 @@ macro_rules! map_impl {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound:ident)* >) => {
         impl<K, V $(, $typaram)*> Type for $ty<K, V $(, $typaram)*>
         where
-            K: Type $(+ $kbound1 $(+ $kbound2)*)*,
+            K: Basic $(+ $kbound1 $(+ $kbound2)*)*,
             V: Type,
             $($typaram: $bound,)*
         {


### PR DESCRIPTION
According to the D-Bus (and GVariant) spec, the keys of a dict type can only be a basic type so let's not allow people to construct non-conformant types by allowing keys to be of non-basic types.
    
Strictly speaking, this is very much a breaking change but there is no value in using invalid key types anyways and code doing so, will just get disconnected by the bus w/o any errors, a compile-time error is very much what users would prefer.
    
Fixes #1637.

