### PR TITLE
🔧 book: Drop use of old tag in the configuration

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Marc-André Lureau", "Zeeshan Ali Khan"]
 language = "en"
-multilingual = false
 src = "src"
 title = "zbus: D-Bus for Rust made easy"
 


### PR DESCRIPTION
It never really did anything and was subsequently removed:

https://github.com/rust-lang/mdBook/issues/2636
