### PR TITLE
🐛 zbn: Add inherent `as_ref()` to owned types

### DIFF
--- a/zbus_names/src/utils.rs
+++ b/zbus_names/src/utils.rs
@@ -263,6 +263,11 @@ macro_rules! define_name_type_impls {
             pub fn inner(&self) -> &$name<'static> {
                 &self.0
             }
+
+            /// This is faster than `Clone::clone` when `self` contains owned data.
+            pub fn as_ref(&self) -> $name<'_> {
+                self.0.as_ref()
+            }
         }
 
         impl std::ops::Deref for $owned_name {


### PR DESCRIPTION
Restores behavior where `x.as_ref()` on owned name types returns the borrowed type, not `&str`.

As discussed in #1626

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
