### PR TITLE
Revert "🐛 zm: Apply out_args to single outputs in introspection XML"

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -1307,24 +1307,7 @@ fn introspect_add_output_args(
                 args.extend(introspect_output_arg(&t.elems[i], name, cfg_attrs));
             }
         } else {
-            // Handle single output case - check if out_args was specified
-            let name = match arg_names {
-                Some(names) => match names.len() {
-                    1 => Some(&names[0]),
-                    0 => None,
-                    _ => {
-                        return Err(Error::new_spanned(
-                            ty,
-                            format!(
-                                "out_args specifies {} names but method has a single output",
-                                names.len()
-                            ),
-                        ));
-                    }
-                },
-                None => None,
-            };
-            args.extend(introspect_output_arg(ty, name, cfg_attrs));
+            args.extend(introspect_output_arg(ty, None, cfg_attrs));
         }
     }
 


### PR DESCRIPTION
This reverts commit 53d053edf92d68f23c3397079fe6e8bd2e65081a, which
broke the build for types with custom D-Bus struct signatures (e.g.,
`#[zvariant(signature = "(ua{sv})")]`).

We'll try to bring back this fix later in a way that it doesn't break this
use case.
