### PR TITLE
🐛 xmlgen: avoid generating duplicate `receive_*_changed` methods

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -1,5 +1,6 @@
 use snakecase::ascii::to_snakecase;
 use std::{
+    collections::HashMap,
     error::Error,
     fmt::{Display, Formatter, Write},
     process::{Command, Stdio},
@@ -185,6 +186,11 @@ impl GenTrait<'_> {
 
         let mut signals = iface.signals().to_vec();
         signals.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
+
+        // collect signal method names for collision detection with implicit property change
+        // receivers
+        let mut changed_suffix_signals = HashMap::new();
+
         for signal in &signals {
             let args = parse_signal_args(signal.args());
             let name = to_identifier(&to_snakecase(signal.name().as_str()));
@@ -196,20 +202,41 @@ impl GenTrait<'_> {
                 writeln!(w, "    #[zbus(signal)]")?;
             }
             writeln!(w, "    fn {name}({args}) -> zbus::Result<()>;",)?;
+
+            if name.ends_with("_changed") {
+                changed_suffix_signals.insert(name, signal.name());
+            }
         }
 
         let mut props = iface.properties().to_vec();
         props.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for p in props {
             let name = to_identifier(&to_snakecase(p.name().as_str()));
-            let fn_attribute = if pascal_case(&name) != p.name().as_str() {
-                format!("    #[zbus(property, name = \"{}\")]", p.name())
+
+            let prop_change_receiver_name = format!("{name}_changed");
+            let signal_collision = changed_suffix_signals.get(&prop_change_receiver_name);
+
+            let (property_args, comment) = if let Some(signal_collision) = signal_collision {
+                (
+                    "(emits_changed_signal = \"false\")",
+                    format!(
+                        "    // Note: change signal is shadowed by `{}` signal.\n",
+                        signal_collision.as_str()
+                    ),
+                )
             } else {
-                "    #[zbus(property)]".to_string()
+                ("", "".to_string())
             };
+            let name_arg = if pascal_case(&name) != p.name().as_str() {
+                format!(", name = \"{}\"", p.name())
+            } else {
+                "".to_string()
+            };
+            let fn_attribute = format!("    #[zbus(property{property_args}{name_arg})]");
 
             writeln!(w)?;
             writeln!(w, "    /// {} property", p.name())?;
+            write!(w, "{comment}")?;
             if p.access().read() {
                 writeln!(w, "{fn_attribute}")?;
                 let output = to_rust_type(p.ty(), false, false);

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -68,6 +68,10 @@ pub trait SampleInterface0 {
     #[zbus(signal)]
     fn signal_value(&self, value: zbus::zvariant::Value<'_>) -> zbus::Result<()>;
 
+    /// StateChanged signal
+    #[zbus(signal)]
+    fn state_changed(&self, state: u32, something_else: u32) -> zbus::Result<()>;
+
     /// Bar property
     #[zbus(property)]
     fn bar(&self) -> zbus::Result<u8>;
@@ -94,4 +98,9 @@ pub trait SampleInterface0 {
             std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
         )>,
     >;
+
+    /// State property
+    // Note: change signal is shadowed by `StateChanged` signal.
+    #[zbus(property(emits_changed_signal = "false"))]
+    fn state(&self) -> zbus::Result<u32>;
 }

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -52,6 +52,12 @@
      <signal name="SignalDictStringToValue">
        <arg type="a{sv}" name="dict"/>
      </signal>
+     <!-- Signal `StateChanged` should override `State`'s implicit `receive_state_changed` method -->
+     <signal name="StateChanged">
+       <arg name="state" type="u"/>
+       <arg name="something_else" type="u"/>
+     </signal>
+     <property name="State" type="u" access="read"/>
      <property name="Bar" type="y" access="readwrite"/>
      <property name="Foo-Bar" type="y" access="readwrite"/>
      <property name="Matryoshkas" type="a(oiasta{sv})" access="read"/>


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

Resolves `Case 2` of #231

I ran into this issue when trying to generate `zbus` bindings for ModemManager, which has four such naming collisions. This resolves the issue there and should help for others who have commented on #231.