### PR TITLE
🐛 zx: Wrap single struct returns in tuple to distinguish from multiple returns

### DIFF
--- a/zbus_xmlgen/tests/data/struct_return.rs
+++ b/zbus_xmlgen/tests/data/struct_return.rs
@@ -1,0 +1,14 @@
+#[proxy(interface = "test.StructReturn", assume_defaults = true)]
+pub trait StructReturn {
+    /// ReturnsNestedStruct method
+    fn returns_nested_struct(&self) -> zbus::Result<(((String, String), i32),)>;
+
+    /// ReturnsOneString method
+    fn returns_one_string(&self) -> zbus::Result<String>;
+
+    /// ReturnsStruct method
+    fn returns_struct(&self) -> zbus::Result<((String, String),)>;
+
+    /// ReturnsTwoStrings method
+    fn returns_two_strings(&self) -> zbus::Result<(String, String)>;
+}

--- a/zbus_xmlgen/tests/data/struct_return.xml
+++ b/zbus_xmlgen/tests/data/struct_return.xml
@@ -1,0 +1,19 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="test.StructReturn">
+    <method name="ReturnsStruct">
+      <arg name="result" type="(ss)" direction="out" />
+    </method>
+    <method name="ReturnsTwoStrings">
+      <arg name="result1" type="s" direction="out" />
+      <arg name="result2" type="s" direction="out" />
+    </method>
+    <method name="ReturnsOneString">
+      <arg name="result" type="s" direction="out" />
+    </method>
+    <method name="ReturnsNestedStruct">
+      <arg name="result" type="((ss)i)" direction="out" />
+    </method>
+  </interface>
+</node>

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -42,3 +42,8 @@ macro_rules! gen_diff {
 fn sample_object0() -> Result<(), Box<dyn Error>> {
     gen_diff!("sample_object0.xml", "sample_object0.rs")
 }
+
+#[test]
+fn struct_return() -> Result<(), Box<dyn Error>> {
+    gen_diff!("struct_return.xml", "struct_return.rs")
+}


### PR DESCRIPTION
When a method has a single output argument that is a struct type (e.g., type="(ss)"), we now wrap it in a tuple to distinguish it from multiple return values. This ensures type="(ss)" generates Result<((String, String),)> while two separate string outputs generate Result<(String, String)>.

Fixes #1241

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
