### PR TITLE
🧑‍💻 cargo: Set resolver to 3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
-      MSRV: 1.85.0
+      MSRV: 1.87.0
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ zbus/src/
 
 ## Development Guidelines
 
-- **MSRV**: 1.85.0
+- **MSRV**: 1.87.0
 - **Commit style**: Emoji prefix + package abbreviation (e.g., "🐛 zb: Fix connection timeout")
 - **Testing**: Integration tests require D-Bus session bus
 - **Cross-platform**: Validate changes work on Linux, Windows, macOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.87"
 license = "MIT"
 repository = "https://github.com/z-galaxy/zbus/"
 


### PR DESCRIPTION
This is the default since rust 2024. See https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html for more details.