### PR TITLE
🐛 Do not use SendFlags::NOSIGNAL on Redox

### DIFF
--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -326,9 +326,9 @@ fn fd_sendmsg(fd: BorrowedFd<'_>, buffer: &[u8], fds: &[BorrowedFd<'_>]) -> std:
         ));
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "redox")))]
     let flags = SendFlags::NOSIGNAL;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "redox"))]
     let flags = SendFlags::empty();
 
     let sent = sendmsg(fd, &iov, &mut ancillary, flags)?;


### PR DESCRIPTION
For now, this is not available on Redox. If it is implemented and exposed in rustix in the future, I will make another PR to revert this change.