### PR TITLE
✅ zb: Explicitly choose host endianess in a test

### DIFF
--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -310,7 +310,7 @@ impl<'m> From<Header<'m>> for Builder<'m> {
 
 #[cfg(test)]
 mod tests {
-    use super::Message;
+    use super::{Endian, Message};
     use crate::Error;
     use test_log::test;
 
@@ -318,6 +318,7 @@ mod tests {
     fn test_raw() -> Result<(), Error> {
         let raw_body: &[u8] = &[16, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0];
         let message_builder = Message::signal("/", "test.test", "test")?;
+        let message_builder = message_builder.endian(Endian::Little);
         let message = unsafe {
             message_builder.build_raw_body(
                 raw_body,


### PR DESCRIPTION
Specify endian in `test_raw`. Otherwise on big endian architectures, the test tries to construct a message with a big endian header but a little endian body.

