### PR TITLE
🩹 zbus: Fix error name for fallible setters

### DIFF
--- a/zbus/src/fdo/error.rs
+++ b/zbus/src/fdo/error.rs
@@ -169,6 +169,21 @@ pub enum Error {
     NotContainer(String),
 }
 
+impl Error {
+    /// Collapse redundant nesting of errors.
+    ///
+    /// Collapses a nested data structure like `zbus::fdo::Error::ZBus(zbus::Error::FDO(_))`
+    /// into a `zbus::fdo::Error`. `zbus::fdo::Error::ZBus(zbus::error::Failure(s))` will
+    /// also be converted to `zbus::fdo::Error::Failed(s)`.
+    pub fn flatten(self) -> Self {
+        match self {
+            Error::ZBus(zbus::Error::FDO(e)) => *e,
+            Error::ZBus(zbus::Error::Failure(s)) => Error::Failed(s),
+            e => e,
+        }
+    }
+}
+
 /// Alias for a `Result` with the error type [`zbus::fdo::Error`].
 ///
 /// [`zbus::fdo::Error`]: enum.Error.html

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -4,6 +4,7 @@
 //! be useful across various D-Bus applications. This module provides their proxy.
 
 use std::{borrow::Cow, collections::HashMap};
+use zbus::fdo;
 use zbus_names::InterfaceName;
 use zvariant::{OwnedValue, Value};
 
@@ -64,7 +65,7 @@ impl Properties {
         #[zbus(connection)] connection: &Connection,
         #[zbus(header)] header: Header<'_>,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
-    ) -> Result<()> {
+    ) -> fdo::Result<()> {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
@@ -89,7 +90,7 @@ impl Properties {
                 )));
             }
             zbus::object_server::DispatchResult::Async(f) => {
-                return f.await.map_err(Into::into);
+                return f.await.map_err(|e| fdo::Error::ZBus(e).flatten());
             }
         }
         let res = iface

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -313,10 +313,7 @@ impl ObjectServer {
                 )));
             }
             DispatchResult::Async(f) => {
-                return f.await.map_err(|e| match e {
-                    Error::FDO(e) => *e,
-                    e => fdo::Error::Failed(format!("{e}")),
-                });
+                return f.await.map_err(|e| fdo::Error::ZBus(e).flatten());
             }
             DispatchResult::RequiresMut => {}
         }
@@ -328,10 +325,7 @@ impl ObjectServer {
             DispatchResult::NotFound => {}
             DispatchResult::RequiresMut => {}
             DispatchResult::Async(f) => {
-                return f.await.map_err(|e| match e {
-                    Error::FDO(e) => *e,
-                    e => fdo::Error::Failed(format!("{e}")),
-                });
+                return f.await.map_err(|e| fdo::Error::ZBus(e).flatten());
             }
         }
         drop(write_lock);

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -3,7 +3,7 @@ use futures_util::{StreamExt, TryStreamExt};
 use std::convert::TryInto;
 use tracing::{debug, instrument};
 use zbus::{
-    Connection, Error, Message, MessageStream,
+    Connection, DBusError, Error, Message, MessageStream,
     fdo::{ObjectManagerProxy, PropertiesProxy},
     message,
     proxy::CacheProperties,
@@ -108,6 +108,14 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
             .await
             .is_err()
     );
+
+    proxy.set_fallible_setter_prop(60).await?;
+    if let Err(e) = proxy.set_fallible_setter_prop(61).await {
+        assert_eq!(
+            zbus::fdo::Error::from(e).name(),
+            "org.freedesktop.DBus.Error.Failed"
+        )
+    }
 
     let props_proxy = PropertiesProxy::builder(&conn)
         .destination("org.freedesktop.MyService")?

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, instrument};
 use zbus::{
@@ -21,6 +24,7 @@ pub struct MyIface {
     emits_changed_const: u32,
     emits_changed_false: u32,
     r#let: u32,
+    fallible_setter_prop: AtomicU32,
 }
 
 impl MyIface {
@@ -34,6 +38,7 @@ impl MyIface {
             emits_changed_const: 0,
             emits_changed_false: 0,
             r#let: 0,
+            fallible_setter_prop: AtomicU32::new(0),
         }
     }
 }
@@ -482,6 +487,26 @@ impl MyIface {
     fn set_let(&mut self, val: u32) -> zbus::fdo::Result<()> {
         debug!("`Let` setter called.");
         self.r#let = val;
+        Ok(())
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    fn fallible_setter_prop(&self) -> u32 {
+        debug!("`fallible_setter_prop` getter called.");
+        self.fallible_setter_prop.load(Ordering::SeqCst)
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    async fn set_fallible_setter_prop(&self, val: u32) -> zbus::Result<()> {
+        debug!("`fallible_setter_prop` setter called.");
+        if val > 60 {
+            return Err(zbus::Error::Failure(format!(
+                "Provided value is {val}; values above 60 not accepted"
+            )));
+        }
+        self.fallible_setter_prop.store(val, Ordering::SeqCst);
         Ok(())
     }
 

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -146,13 +146,28 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
             quote! {
                 impl ::std::convert::From<#zbus::Error> for #name {
                     fn from(value: #zbus::Error) -> #name {
-                        if let #zbus::Error::MethodError(name, desc, _) = &value {
-                            match name.as_str() {
-                                #error_converts
-                                _ => Self::#ident(value),
+                        match &value {
+                            #zbus::Error::MethodError(name, desc, _) => {
+                                match name.as_str() {
+                                    #error_converts
+                                    _ => Self::#ident(value),
+                                }
                             }
-                        } else {
-                            Self::#ident(value)
+                            #zbus::Error::FDO(e) => {
+                                // Handle FDO errors by extracting name and description
+                                // and converting similarly to MethodError
+                                let e_ref = ::std::convert::AsRef::as_ref(e);
+                                let name = #zbus::DBusError::name(e_ref);
+                                let desc = &::std::option::Option::map(
+                                    #zbus::DBusError::description(e_ref),
+                                    ::std::string::ToString::to_string,
+                                );
+                                match name.as_str() {
+                                    #error_converts
+                                    _ => Self::#ident(value),
+                                }
+                            }
+                            _ => Self::#ident(value),
                         }
                     }
                 }


### PR DESCRIPTION
Currently zbus returns an error name referencing zbus when a setter fails to set a property. This commit allows collapsing nesting structures like:

zbus::fdo::Error::ZBus(zbus::Error::FDO(zbus::fdo::Error))

into a zbus::fdo::Error. This works around the problem where DispatchResult expects a zbus::Error for all futures that it wraps, resulting in this nesting when the zbus::Error is converted to an FDO error.

The change provides a flatten method to collapse these errors into a final error that is a non-nested FDO error with the appropriate name on the D-Bus. This method is used in all places where the DispatchResult::Async variant is unwound.

Closes #992

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
