### PR TITLE
✨ zb: Add Builder::build_message_stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,14 @@ zbus/src/
 
 - **MSRV**: 1.87.0
 - **Commit style**: Emoji prefix + package abbreviation (e.g., "🐛 zb: Fix connection timeout")
+- **Changelog**: `CHANGELOG.md` files are managed by [release-plz] — do **not** hand-edit
+  them. Write a good commit message (conventional-commits-ish) and release-plz will
+  generate the entry at release time.
 - **Testing**: Integration tests require D-Bus session bus
 - **Cross-platform**: Validate changes work on Linux, Windows, macOS
 - **Dependencies**: Check compatibility with async runtimes and optional features
+
+[release-plz]: https://release-plz.ieni.dev/
 
 ## Key Files for Understanding
 

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -264,4 +264,23 @@ impl<'a> Builder<'a> {
     pub fn build(self) -> Result<Connection> {
         block_on(self.0.build()).map(Into::into)
     }
+
+    /// Build the connection and return a [`MessageIterator`] to receive messages from it.
+    ///
+    /// This is the blocking counterpart of [`crate::connection::Builder::build_message_stream`].
+    /// The iterator is set up **before** the socket-reader task is started, so no messages can
+    /// be lost in the window between the connection being built and the iterator being created.
+    /// Use this when the peer may pipeline traffic right after authentication — e.g. a bus
+    /// implementation reading a `Hello` method call from a just-connected client.
+    ///
+    /// To get the [`Connection`] out of the returned iterator, use `Connection::from(&iter)`.
+    ///
+    /// This method is only available when the `bus-impl` feature is enabled.
+    ///
+    /// [`MessageIterator`]: crate::blocking::MessageIterator
+    #[cfg(feature = "bus-impl")]
+    pub fn build_message_iterator(self) -> Result<crate::blocking::MessageIterator> {
+        block_on(self.0.build_message_stream())
+            .map(|azync| crate::blocking::MessageIterator { azync: Some(azync) })
+    }
 }

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -1,3 +1,4 @@
+use async_broadcast::Receiver as ActiveReceiver;
 #[cfg(not(feature = "tokio"))]
 use async_io::Async;
 use enumflags2::BitFlags;
@@ -23,10 +24,13 @@ use vsock::VsockStream;
 
 use zvariant::ObjectPath;
 
+#[cfg(feature = "bus-impl")]
+use crate::MessageStream;
 use crate::{
     Connection, Error, Executor, Guid, OwnedGuid, Result,
     address::{self, Address},
     fdo::RequestNameFlags,
+    message::Message,
     names::{InterfaceName, WellKnownName},
     object_server::{ArcInterface, Interface},
 };
@@ -432,11 +436,87 @@ impl<'a> Builder<'a> {
     /// Until server-side bus connection is supported, attempting to build such a connection will
     /// result in a [`Error::Unsupported`] error.
     pub async fn build(self) -> Result<Connection> {
+        let (conn, _) = self.build_inner(false).await?;
+        Ok(conn)
+    }
+
+    /// Build the connection and return a [`MessageStream`] to receive messages from it.
+    ///
+    /// This is equivalent to [`Self::build`] followed by `MessageStream::from(&conn)`, except
+    /// that the stream is set up **before** the socket-reader task is started. No messages can
+    /// therefore be lost in the window between `build()` returning and `MessageStream::from`
+    /// being called. Use this when the peer may pipeline traffic right after authentication —
+    /// e.g. a bus implementation reading a `Hello` method call from a just-connected client.
+    ///
+    /// To get the [`Connection`] out of the returned stream, use `Connection::from(&stream)` —
+    /// this is cheap (an `Arc` clone).
+    ///
+    /// This method is only available when the `bus-impl` feature is enabled.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use futures_util::StreamExt;
+    /// # use zbus::{
+    /// #     Connection, Guid, block_on,
+    /// #     connection::{Builder, socket::Channel},
+    /// #     message::Message,
+    /// # };
+    /// #
+    /// # block_on(async {
+    /// let guid = Guid::generate();
+    /// let (c1, c2) = Channel::pair();
+    ///
+    /// // Bus client sends a method call right away (simulates pipelining after auth).
+    /// let client = Builder::authenticated_socket(c1, guid.clone())
+    ///     .unwrap()
+    ///     .build()
+    ///     .await
+    ///     .unwrap();
+    /// let hello = Message::method_call("/org/freedesktop/DBus", "Hello")
+    ///     .unwrap()
+    ///     .destination("org.freedesktop.DBus")
+    ///     .unwrap()
+    ///     .build(&())
+    ///     .unwrap();
+    /// client.send(&hello).await.unwrap();
+    ///
+    /// // Server builds *after* the client has already sent.
+    /// let mut stream = Builder::authenticated_socket(c2, guid)
+    ///     .unwrap()
+    ///     .p2p()
+    ///     .build_message_stream()
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let msg = stream.next().await.unwrap().unwrap();
+    /// assert_eq!(msg.header().member().unwrap().as_str(), "Hello");
+    ///
+    /// let _conn: Connection = (&stream).into();
+    /// # });
+    /// ```
+    #[cfg(feature = "bus-impl")]
+    pub async fn build_message_stream(self) -> Result<MessageStream> {
+        let (conn, msg_receiver) = self.build_inner(true).await?;
+        let msg_receiver = msg_receiver.expect("build_inner(true) always returns Some");
+
+        Ok(MessageStream::for_subscription_channel(
+            msg_receiver,
+            None,
+            &conn,
+        ))
+    }
+
+    async fn build_inner(
+        self,
+        activate_msg_stream: bool,
+    ) -> Result<(Connection, Option<ActiveReceiver<Result<Message>>>)> {
         let executor = Executor::new();
         #[cfg(not(feature = "tokio"))]
         let internal_executor = self.internal_executor;
         // Box the future as it's large and can cause stack overflow.
-        let conn = Box::pin(executor.run(self.build_(executor.clone()))).await?;
+        let conn =
+            Box::pin(executor.run(self.build_(executor.clone(), activate_msg_stream))).await?;
 
         #[cfg(not(feature = "tokio"))]
         start_internal_executor(&executor, internal_executor)?;
@@ -444,7 +524,11 @@ impl<'a> Builder<'a> {
         Ok(conn)
     }
 
-    async fn build_(mut self, executor: Executor<'static>) -> Result<Connection> {
+    async fn build_(
+        mut self,
+        executor: Executor<'static>,
+        activate_msg_stream: bool,
+    ) -> Result<(Connection, Option<ActiveReceiver<Result<Message>>>)> {
         #[cfg(feature = "p2p")]
         let is_bus_conn = !self.p2p;
         #[cfg(not(feature = "p2p"))]
@@ -481,6 +565,10 @@ impl<'a> Builder<'a> {
             listener.await;
         }
 
+        // Set up a message receiver before the socket-reader task is spawned so that the
+        // caller cannot miss early messages due to a race with the reader task.
+        let msg_receiver = activate_msg_stream.then(|| conn.inner.msg_receiver.activate_cloned());
+
         // Start the socket reader task.
         conn.init_socket_reader(
             socket_read,
@@ -494,7 +582,7 @@ impl<'a> Builder<'a> {
                 .await?;
         }
 
-        Ok(conn)
+        Ok((conn, msg_receiver))
     }
 
     fn new(target: Target) -> Self {

--- a/zbus/tests/builder_message_stream.rs
+++ b/zbus/tests/builder_message_stream.rs
@@ -1,0 +1,53 @@
+//! Tests for [`zbus::connection::Builder::build_message_stream`].
+//!
+//! Simulates the busd scenario: a bus client pipelines a `Hello` method call as part of its
+//! SASL handshake, before the server (bus-impl) has started polling for messages. With plain
+//! `build()` + `MessageStream::from`, the Hello can be lost; `build_message_stream` fixes
+//! this by setting up the stream before the socket reader task starts.
+
+#![cfg(all(unix, feature = "bus-impl"))]
+
+use std::os::unix::net::UnixStream;
+
+use futures_util::StreamExt;
+use ntest::timeout;
+use test_log::test;
+use zbus::{Connection, Guid, block_on, connection::Builder};
+
+/// Simulates the busd race: a bus client pipelines Hello during SASL auth, before the server
+/// has started polling. `build_message_stream` must still deliver it.
+#[test]
+#[timeout(15000)]
+fn build_message_stream_does_not_drop_pipelined_hello() {
+    block_on(async {
+        let (s0, s1) = UnixStream::pair().unwrap();
+        let guid = Guid::generate();
+
+        // Server: SASL auth, set up stream, receive Hello, reply to it.
+        let server = async {
+            let mut stream = Builder::unix_stream(s0)
+                .server(guid)
+                .unwrap()
+                .p2p()
+                .build_message_stream()
+                .await
+                .unwrap();
+
+            let hello = stream
+                .next()
+                .await
+                .expect("stream terminated unexpectedly")
+                .unwrap();
+            assert_eq!(hello.header().member().unwrap().as_str(), "Hello");
+
+            // Reply so the client's build() can complete.
+            let conn = Connection::from(stream);
+            conn.reply(&hello.header(), &(":1.1",)).await.unwrap();
+        };
+
+        // Run both concurrently so the SASL handshake completes cooperatively.
+        // The client is a bus connection whose build() pipelines Hello during SASL auth.
+        let ((), client) = futures_util::join!(server, Builder::unix_stream(s1).build());
+        let _client_conn = client.unwrap();
+    });
+}


### PR DESCRIPTION
Add `connection::Builder::build_message_stream` (and the blocking
counterpart `build_message_iterator`) for callers that must not lose
messages arriving immediately after the connection is built — most
notably bus implementations handling `Hello` from just-authenticated
clients that pipeline traffic.

The existing `build()` + `MessageStream::from(&conn)` path has a race
window: between `build()` returning and a receiver being activated on
the unfiltered broadcast channel, the socket reader task may run,
broadcast incoming messages, and find no active receivers — silently
dropping them. This has been observed in practice under tokio's LIFO
steal scheduling.

The fix is to activate a receiver on the inner broadcast channel
before the socket reader task is spawned. `build_()` now takes an
`activate_msg_stream` flag and returns the activated receiver alongside
the `Connection`; `build_message_stream` wraps it via the existing
`MessageStream::for_subscription_channel` helper. The `build()` fast
path is unchanged.

A regression test covers both the async and blocking APIs using
`Channel::pair()`, verifying that a message sent before the stream is
polled is still delivered.