### PR TITLE
📝 Configure docs.rs to build for all supported targets

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -130,7 +130,14 @@ criterion.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
 
 [lints]
 workspace = true

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -41,5 +41,16 @@ serde.workspace = true
 async-io.workspace = true
 futures-util.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
+
 [lints]
 workspace = true

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -32,7 +32,14 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
 
 [lints]
 workspace = true

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -23,7 +23,14 @@ doc-comment.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
 
 [lints]
 workspace = true

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -39,5 +39,16 @@ clap = { workspace = true, optional = true }
 [dev-dependencies]
 pretty_assertions.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
+
 [lints]
 workspace = true

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -59,6 +59,14 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
 
 [lints]
 workspace = true

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -33,5 +33,16 @@ enumflags2.workspace = true
 serde.workspace = true
 serde_repr.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
+
 [lints]
 workspace = true

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -29,5 +29,16 @@ winnow.workspace = true
 [dev-dependencies]
 zvariant.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "aarch64-linux-android",
+]
+
 [lints]
 workspace = true


### PR DESCRIPTION
docs.rs now only builds for default targets (see https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets). Explicitly list all targets we support (matching CI compile-time checks) so platform-specific items remain visible in the generated documentation.

https://claude.ai/code/session_01S4SrdBpsfivGFkUFnqw5AC