### PR TITLE
interface property setters can now return fdo::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "async-io",
  "futures-util",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -48,7 +48,7 @@ serde_bytes = ["zvariant/serde_bytes"]
 async-fs = []
 
 [dependencies]
-zbus_macros = { path = "../zbus_macros", version = "5.14.0" }
+zbus_macros = { path = "../zbus_macros", version = "5.15.0" }
 zvariant = { path = "../zvariant", features = [
     "enumflags2",
 ], version = "5.10.0" }

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -82,14 +82,14 @@ impl Properties {
             Some(&header),
             &emitter,
         ) {
-            zbus::object_server::DispatchResult::RequiresMut => {}
-            zbus::object_server::DispatchResult::NotFound => {
+            zbus::object_server::DispatchResult2::RequiresMut => {}
+            zbus::object_server::DispatchResult2::NotFound => {
                 return Err(Error::UnknownProperty(format!(
                     "Unknown property '{property_name}'"
                 )));
             }
-            zbus::object_server::DispatchResult::Async(f) => {
-                return f.await.map_err(Into::into);
+            zbus::object_server::DispatchResult2::Async(f) => {
+                return f.await;
             }
         }
         let res = iface

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -7,6 +7,7 @@ use crate::{Connection, Result, fdo, message::Message};
 use tracing::trace;
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
+#[deprecated(since = "5.15.0", note = "Use `DispatchResult2` instead.")]
 pub enum DispatchResult<'a> {
     /// This interface does not support the given method.
     NotFound,
@@ -20,6 +21,7 @@ pub enum DispatchResult<'a> {
     Async(Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>),
 }
 
+#[allow(deprecated)]
 impl<'a> DispatchResult<'a> {
     /// Helper for creating the Async variant.
     pub fn new_async<F, T, E>(conn: &'a Connection, msg: &'a Message, f: F) -> Self

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin};
 use zbus::message::Flags;
 use zvariant::DynamicType;
 
-use crate::{Connection, Result, message::Message};
+use crate::{Connection, Result, fdo, message::Message};
 use tracing::trace;
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
@@ -37,6 +37,52 @@ impl<'a> DispatchResult<'a> {
                     Err(e) => conn.reply_dbus_error(&hdr, e).await,
                 }
                 .map(|_seq| ())
+            } else {
+                trace!("No reply expected for {:?} by the caller.", msg);
+                Ok(())
+            }
+        }))
+    }
+}
+
+/// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
+///
+/// Unlike [`DispatchResult`], the [`Async`](DispatchResult2::Async) variant uses
+/// [`fdo::Result`] so that D-Bus error names are preserved without nesting through
+/// intermediate [`crate::Error`] conversions.
+///
+/// This is an unstable type — compatibility may break in minor version bumps.
+pub enum DispatchResult2<'a> {
+    /// This interface does not support the given method.
+    NotFound,
+
+    /// Retry with [`Interface::call_mut`](`crate::object_server::Interface::call_mut`).
+    ///
+    /// This is equivalent to NotFound if returned by call_mut.
+    RequiresMut,
+
+    /// The method was found and will be completed by running this Future.
+    Async(Pin<Box<dyn Future<Output = fdo::Result<()>> + Send + 'a>>),
+}
+
+impl<'a> DispatchResult2<'a> {
+    /// Helper for creating the Async variant.
+    pub fn new_async<F, T, E>(conn: &'a Connection, msg: &'a Message, f: F) -> Self
+    where
+        F: Future<Output = ::std::result::Result<T, E>> + Send + 'a,
+        T: serde::Serialize + DynamicType + Send + Sync,
+        E: zbus::DBusError + Send,
+    {
+        DispatchResult2::Async(Box::pin(async move {
+            let hdr = msg.header();
+            let ret = f.await;
+            if !hdr.primary().flags().contains(Flags::NoReplyExpected) {
+                match ret {
+                    Ok(r) => conn.reply(&hdr, &r).await,
+                    Err(e) => conn.reply_dbus_error(&hdr, e).await,
+                }
+                .map(|_seq| ())
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
             } else {
                 trace!("No reply expected for {:?} by the caller.", msg);
                 Ok(())

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -73,8 +73,8 @@ pub trait Interface: Any + Send + Sync {
 
     /// Set a property value.
     ///
-    /// Return [`DispatchResult::NotFound`] if the property doesn't exist, or
-    /// [`DispatchResult::RequiresMut`] if `set_mut` should be used instead. The default
+    /// Return [`DispatchResult2::NotFound`] if the property doesn't exist, or
+    /// [`DispatchResult2::RequiresMut`] if `set_mut` should be used instead. The default
     /// implementation just returns `RequiresMut`.
     fn set<'call>(
         &'call self,
@@ -84,7 +84,7 @@ pub trait Interface: Any + Send + Sync {
         connection: &'call Connection,
         header: Option<&'call message::Header<'_>>,
         emitter: &'call SignalEmitter<'_>,
-    ) -> DispatchResult<'call> {
+    ) -> DispatchResult2<'call> {
         let _ = (
             property_name,
             value,
@@ -93,7 +93,7 @@ pub trait Interface: Any + Send + Sync {
             header,
             emitter,
         );
-        DispatchResult::RequiresMut
+        DispatchResult2::RequiresMut
     }
 
     /// Set a property value.
@@ -113,8 +113,8 @@ pub trait Interface: Any + Send + Sync {
 
     /// Call a method.
     ///
-    /// Return [`DispatchResult::NotFound`] if the method doesn't exist, or
-    /// [`DispatchResult::RequiresMut`] if `call_mut` should be used instead.
+    /// Return [`DispatchResult2::NotFound`] if the method doesn't exist, or
+    /// [`DispatchResult2::RequiresMut`] if `call_mut` should be used instead.
     ///
     /// It is valid, though inefficient, for this to always return `RequiresMut`.
     fn call<'call>(
@@ -123,7 +123,7 @@ pub trait Interface: Any + Send + Sync {
         connection: &'call Connection,
         msg: &'call Message,
         name: MemberName<'call>,
-    ) -> DispatchResult<'call>;
+    ) -> DispatchResult2<'call>;
 
     /// Call a `&mut self` method.
     ///
@@ -134,7 +134,7 @@ pub trait Interface: Any + Send + Sync {
         connection: &'call Connection,
         msg: &'call Message,
         name: MemberName<'call>,
-    ) -> DispatchResult<'call>;
+    ) -> DispatchResult2<'call>;
 
     /// Write introspection XML to the writer, with the given indentation level.
     fn introspect_to_writer(&self, writer: &mut dyn Write, level: usize);

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -17,9 +17,9 @@ use crate::{
 
 mod interface;
 pub(crate) use interface::ArcInterface;
-pub use interface::{
-    DispatchResult, DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef,
-};
+#[allow(deprecated)]
+pub use interface::DispatchResult;
+pub use interface::{DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef};
 
 mod signal_emitter;
 pub use signal_emitter::SignalEmitter;

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -309,31 +309,25 @@ impl ObjectServer {
         let read_lock = iface.read().await;
         trace!("acquired read lock on interface `{}`", iface_name);
         match read_lock.call(self, connection, msg, member.as_ref()) {
-            DispatchResult::NotFound => {
+            DispatchResult2::NotFound => {
                 return Err(fdo::Error::UnknownMethod(format!(
                     "Unknown method '{member}'"
                 )));
             }
-            DispatchResult::Async(f) => {
-                return f.await.map_err(|e| match e {
-                    Error::FDO(e) => *e,
-                    e => fdo::Error::Failed(format!("{e}")),
-                });
+            DispatchResult2::Async(f) => {
+                return f.await;
             }
-            DispatchResult::RequiresMut => {}
+            DispatchResult2::RequiresMut => {}
         }
         drop(read_lock);
         trace!("acquiring write lock on interface `{}`", iface_name);
         let mut write_lock = iface.write().await;
         trace!("acquired write lock on interface `{}`", iface_name);
         match write_lock.call_mut(self, connection, msg, member.as_ref()) {
-            DispatchResult::NotFound => {}
-            DispatchResult::RequiresMut => {}
-            DispatchResult::Async(f) => {
-                return f.await.map_err(|e| match e {
-                    Error::FDO(e) => *e,
-                    e => fdo::Error::Failed(format!("{e}")),
-                });
+            DispatchResult2::NotFound => {}
+            DispatchResult2::RequiresMut => {}
+            DispatchResult2::Async(f) => {
+                return f.await;
             }
         }
         drop(write_lock);

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -17,7 +17,9 @@ use crate::{
 
 mod interface;
 pub(crate) use interface::ArcInterface;
-pub use interface::{DispatchResult, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef};
+pub use interface::{
+    DispatchResult, DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef,
+};
 
 mod signal_emitter;
 pub use signal_emitter::SignalEmitter;

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -3,7 +3,7 @@ use futures_util::{StreamExt, TryStreamExt};
 use std::convert::TryInto;
 use tracing::{debug, instrument};
 use zbus::{
-    Connection, Error, Message, MessageStream,
+    Connection, DBusError, Error, Message, MessageStream,
     fdo::{ObjectManagerProxy, PropertiesProxy},
     message,
     proxy::CacheProperties,
@@ -177,6 +177,26 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     assert_eq!(proxy.r#let().await?, 0);
     proxy.set_let(1).await?;
     assert_eq!(proxy.r#let().await?, 1);
+
+    // Test that fallible property setters preserve the D-Bus error name (regression test for
+    // #992).
+    proxy.set_fallible_prop(60).await?;
+    let err = proxy
+        .set_fallible_prop(61)
+        .await
+        .expect_err("Setting value above 60 should fail");
+    let Error::FDO(fdo_err) = err else {
+        panic!("Expected Error::FDO, got {err:?}");
+    };
+    assert!(matches!(*fdo_err, zbus::fdo::Error::InvalidArgs(_)));
+    assert_eq!(fdo_err.name(), "org.freedesktop.DBus.Error.InvalidArgs");
+
+    // Setter returning `zbus::Result<()>` keeps working; verify the error round-trips.
+    proxy.set_fallible_zbus_prop(60).await?;
+    proxy
+        .set_fallible_zbus_prop(61)
+        .await
+        .expect_err("Setting value above 60 should fail");
 
     assert_eq!(
         proxy.raw_identifier_parameter("param").await?,

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -485,6 +485,47 @@ impl MyIface {
         Ok(())
     }
 
+    /// A property with a fallible setter that preserves the D-Bus error name on failure.
+    #[instrument]
+    #[zbus(property)]
+    fn fallible_prop(&self) -> u32 {
+        debug!("`FallibleProp` getter called.");
+        0
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    async fn set_fallible_prop(&self, val: u32) -> zbus::fdo::Result<()> {
+        debug!("`FallibleProp` setter called.");
+        if val > 60 {
+            return Err(zbus::fdo::Error::InvalidArgs(format!(
+                "Provided value is {val}; values above 60 not accepted"
+            )));
+        }
+        Ok(())
+    }
+
+    /// A property whose setter returns `zbus::Result<()>`, to keep the broader return-type
+    /// variant covered.
+    #[instrument]
+    #[zbus(property)]
+    fn fallible_zbus_prop(&self) -> u32 {
+        debug!("`FallibleZbusProp` getter called.");
+        0
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    async fn set_fallible_zbus_prop(&self, val: u32) -> zbus::Result<()> {
+        debug!("`FallibleZbusProp` setter called.");
+        if val > 60 {
+            return Err(zbus::Error::Failure(format!(
+                "Provided value is {val}; values above 60 not accepted"
+            )));
+        }
+        Ok(())
+    }
+
     async fn never_return(&self) {
         debug!("`NeverReturn` called.");
 

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zbus_macros"
 # Keep version in sync with zbus crate
-version = "5.14.0"
+version = "5.15.0"
 authors = [
     "Marc-André Lureau <marcandre.lureau@redhat.com>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -117,7 +117,9 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
                     #fqn => Self::#ident,
                 },
                 Fields::Unnamed(_) => quote! {
-                    #fqn => { Self::#ident(::std::clone::Clone::clone(desc).unwrap_or_default()) },
+                    #fqn => Self::#ident(
+                        desc.map(::std::string::String::from).unwrap_or_default(),
+                    ),
                 },
                 Fields::Named(n) => {
                     let f = &n
@@ -126,11 +128,9 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
                         .ok_or_else(|| Error::new(n.span(), "expected at least one field"))?
                         .ident;
                     quote! {
-                        #fqn => {
-                            let desc = ::std::clone::Clone::clone(desc).unwrap_or_default();
-
-                            Self::#ident { #f: desc }
-                        }
+                        #fqn => Self::#ident {
+                            #f: desc.map(::std::string::String::from).unwrap_or_default(),
+                        },
                     }
                 }
             };
@@ -146,13 +146,24 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
             quote! {
                 impl ::std::convert::From<#zbus::Error> for #name {
                     fn from(value: #zbus::Error) -> #name {
-                        if let #zbus::Error::MethodError(name, desc, _) = &value {
-                            match name.as_str() {
-                                #error_converts
-                                _ => Self::#ident(value),
+                        match &value {
+                            #zbus::Error::MethodError(name, desc, _) => {
+                                let desc = desc.as_deref();
+                                match name.as_str() {
+                                    #error_converts
+                                    _ => Self::#ident(value),
+                                }
                             }
-                        } else {
-                            Self::#ident(value)
+                            #zbus::Error::FDO(e) => {
+                                let e = ::std::convert::AsRef::as_ref(e);
+                                let name = #zbus::DBusError::name(e);
+                                let desc = #zbus::DBusError::description(e);
+                                match name.as_str() {
+                                    #error_converts
+                                    _ => Self::#ident(value),
+                                }
+                            }
+                            _ => Self::#ident(value),
                         }
                     }
                 }

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -511,11 +511,15 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                         quote!(self.#ident(#args_names)#method_await)
                     } else if is_async {
                         quote!(
-                            ::std::result::Result::Ok(self.#ident(#args_names).await)
+                            ::std::result::Result::<_, #zbus::fdo::Error>::Ok(
+                                self.#ident(#args_names).await,
+                            )
                         )
                     } else {
                         quote!(
-                            ::std::result::Result::Ok(self.#ident(#args_names))
+                            ::std::result::Result::<_, #zbus::fdo::Error>::Ok(
+                                self.#ident(#args_names),
+                            )
                         )
                     };
 
@@ -591,7 +595,6 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                     .#prop_changed_method_name(&__zbus__signal_emitter)
                                     .await
                                     .map(|_| set_result)
-                                    .map_err(Into::into)
                             })
                         }
                         PropertyEmitsChangedSignal::Invalidates => {
@@ -600,11 +603,10 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                     .#prop_invalidate_method_name(&__zbus__signal_emitter)
                                     .await
                                     .map(|_| set_result)
-                                    .map_err(Into::into)
                             })
                         }
                         PropertyEmitsChangedSignal::False | PropertyEmitsChangedSignal::Const => {
-                            quote!({ Ok(()) })
+                            quote!({ ::std::result::Result::<_, #zbus::Error>::Ok(()) })
                         }
                     };
                     let do_set = quote!({
@@ -614,8 +616,13 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             ::std::result::Result::Ok(val) => {
                                 let #value_param_name = val;
                                 match #set_call {
-                                    ::std::result::Result::Ok(set_result) => #prop_changed_method
-                                    e => e,
+                                    ::std::result::Result::Ok(set_result) => {
+                                        (#prop_changed_method)
+                                            .map_err(|e| #zbus::fdo::Error::from(e))
+                                    }
+                                    ::std::result::Result::Err(e) => {
+                                        ::std::result::Result::Err(#zbus::fdo::Error::from(e))
+                                    }
                                 }
                             }
                             ::std::result::Result::Err(e) => {
@@ -637,14 +644,14 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
 
                         let q = quote!(
                             #(#cfg_attrs)*
-                            #member_name => #zbus::object_server::DispatchResult::RequiresMut,
+                            #member_name => #zbus::object_server::DispatchResult2::RequiresMut,
                         );
                         set_dispatch.extend(q);
                     } else {
                         let q = quote!(
                             #(#cfg_attrs)*
                             #member_name => {
-                                #zbus::object_server::DispatchResult::Async(::std::boxed::Box::pin(async move {
+                                #zbus::object_server::DispatchResult2::Async(::std::boxed::Box::pin(async move {
                                     #do_set
                                 }))
                             }
@@ -795,8 +802,11 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 #reply
                             }
                         };
-                        #zbus::object_server::DispatchResult::Async(::std::boxed::Box::pin(async move {
-                            future.await
+                        #zbus::object_server::DispatchResult2::Async(::std::boxed::Box::pin(async move {
+                            future.await.map_err(|e| match e {
+                                #zbus::Error::FDO(e) => *e,
+                                e => #zbus::fdo::Error::Failed(::std::format!("{e}")),
+                            })
                         }))
                     },
                 };
@@ -804,7 +814,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 if is_mut {
                     call_dispatch.extend(quote! {
                         #(#cfg_attrs)*
-                        #member_name => #zbus::object_server::DispatchResult::RequiresMut,
+                        #member_name => #zbus::object_server::DispatchResult2::RequiresMut,
                     });
                     call_mut_dispatch.extend(m);
                 } else {
@@ -924,10 +934,10 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &'call #zbus::Connection,
                 __zbus__header: Option<&'call #zbus::message::Header<'_>>,
                 __zbus__signal_emitter: &'call #zbus::object_server::SignalEmitter<'_>,
-            ) -> #zbus::object_server::DispatchResult<'call> {
+            ) -> #zbus::object_server::DispatchResult2<'call> {
                 match __zbus__property_name {
                     #set_dispatch
-                    _ => #zbus::object_server::DispatchResult::NotFound,
+                    _ => #zbus::object_server::DispatchResult2::NotFound,
                 }
             }
 
@@ -952,10 +962,10 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &'call #zbus::Connection,
                 __zbus__message: &'call #zbus::message::Message,
                 name: #zbus::names::MemberName<'call>,
-            ) -> #zbus::object_server::DispatchResult<'call> {
+            ) -> #zbus::object_server::DispatchResult2<'call> {
                 match name.as_str() {
                     #call_dispatch
-                    _ => #zbus::object_server::DispatchResult::NotFound,
+                    _ => #zbus::object_server::DispatchResult2::NotFound,
                 }
             }
 
@@ -965,10 +975,10 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &'call #zbus::Connection,
                 __zbus__message: &'call #zbus::message::Message,
                 name: #zbus::names::MemberName<'call>,
-            ) -> #zbus::object_server::DispatchResult<'call> {
+            ) -> #zbus::object_server::DispatchResult2<'call> {
                 match name.as_str() {
                     #call_mut_dispatch
-                    _ => #zbus::object_server::DispatchResult::NotFound,
+                    _ => #zbus::object_server::DispatchResult2::NotFound,
                 }
             }
 


### PR DESCRIPTION
 The derived From<zbus::Error> impl only matched MethodError. When a property setter returns a typed fdo::Error, the client receives it as zbus::Error::FDO(Box<fdo::Error>), which the conversion did not unwrap, so the original D-Bus error name was discarded.

This is an alternative to the flatten()-based approach proposed in PR #1743. Handling the unwrap inside the derive lets each downstream error type get a concrete variant, without relying on pattern-matching specific nesting shapes that may vary across error variants.

Fixes #992.
