### PR TITLE
🐛 zx: Emit owned types for Variant/Structure property setters

### DIFF
--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -219,7 +219,7 @@ impl GenTrait<'_> {
 
             if p.access().write() {
                 writeln!(w, "{fn_attribute}")?;
-                let input = to_rust_type(p.ty(), true, true);
+                let input = to_property_setter_type(p.ty());
                 writeln!(
                     w,
                     "    fn set_{name}(&self, value: {input}) -> zbus::Result<()>;",
@@ -418,6 +418,38 @@ fn to_rust_type(ty: &Signature, input: bool, as_ref: bool) -> String {
     }
 
     signature_to_rust_type(ty, input, as_ref)
+}
+
+// Like `to_rust_type` for an input parameter, but tailored to property setters.
+//
+// `Proxy::set_property` requires the value to satisfy `T: Into<Value<'t>>`. For most
+// types, the `&T` form already implements this (via `From<&T> for Value`). For `Variant`
+// and `Structure`, the `&T` form does not, so the owned form is emitted instead, also
+// when these appear nested inside an `Array` or `Dict`.
+fn to_property_setter_type(ty: &Signature) -> String {
+    fn inner(signature: &Signature) -> String {
+        match signature {
+            Signature::Variant => "zbus::zvariant::Value<'_>".into(),
+            Signature::Structure(fields) => {
+                let fields = fields.iter().map(inner).collect::<Vec<_>>();
+                if fields.len() > 1 {
+                    format!("({})", fields.join(", "))
+                } else {
+                    format!("({},)", fields[0])
+                }
+            }
+            Signature::Array(child) => format!("&[{}]", inner(child)),
+            Signature::Dict { key, value } => {
+                format!(
+                    "std::collections::HashMap<{}, {}>",
+                    inner(key),
+                    inner(value),
+                )
+            }
+            _ => to_rust_type(signature, true, true),
+        }
+    }
+    inner(ty)
 }
 
 static KWORDS: &[&str] = &[

--- a/zbus_xmlgen/tests/compile.rs
+++ b/zbus_xmlgen/tests/compile.rs
@@ -1,0 +1,18 @@
+//! Verify that the generated code in test fixtures compiles against the current
+//! zbus types. Catches regressions where xmlgen emits code that no longer
+//! satisfies the trait bounds expected by the `#[proxy]` macro.
+
+mod sample_object0 {
+    use zbus::proxy;
+    include!("data/sample_object0.rs");
+}
+
+mod struct_return {
+    use zbus::proxy;
+    include!("data/struct_return.rs");
+}
+
+mod property_setters {
+    use zbus::proxy;
+    include!("data/property_setters.rs");
+}

--- a/zbus_xmlgen/tests/data/property_setters.rs
+++ b/zbus_xmlgen/tests/data/property_setters.rs
@@ -1,0 +1,52 @@
+#[proxy(interface = "com.example.PropertySetters", assume_defaults = true)]
+pub trait PropertySetters {
+    /// ArrayOfStruct property
+    #[zbus(property)]
+    fn array_of_struct(&self) -> zbus::Result<Vec<(i32, i32)>>;
+    #[zbus(property)]
+    fn set_array_of_struct(&self, value: &[(i32, i32)]) -> zbus::Result<()>;
+
+    /// ArrayOfVariant property
+    #[zbus(property)]
+    fn array_of_variant(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedValue>>;
+    #[zbus(property)]
+    fn set_array_of_variant(&self, value: &[zbus::zvariant::Value<'_>]) -> zbus::Result<()>;
+
+    /// DictStrToVariant property
+    #[zbus(property)]
+    fn dict_str_to_variant(
+        &self,
+    ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;
+    #[zbus(property)]
+    fn set_dict_str_to_variant(
+        &self,
+        value: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    /// StructPair property
+    #[zbus(property)]
+    fn struct_pair(&self) -> zbus::Result<(i32, i32)>;
+    #[zbus(property)]
+    fn set_struct_pair(&self, value: (i32, i32)) -> zbus::Result<()>;
+
+    /// StructSingle property
+    #[zbus(property)]
+    fn struct_single(&self) -> zbus::Result<(i32,)>;
+    #[zbus(property)]
+    fn set_struct_single(&self, value: (i32,)) -> zbus::Result<()>;
+
+    /// StructWithArrayOfVariant property
+    #[zbus(property)]
+    fn struct_with_array_of_variant(&self) -> zbus::Result<(Vec<zbus::zvariant::OwnedValue>,)>;
+    #[zbus(property)]
+    fn set_struct_with_array_of_variant(
+        &self,
+        value: (&[zbus::zvariant::Value<'_>],),
+    ) -> zbus::Result<()>;
+
+    /// Variant property
+    #[zbus(property)]
+    fn variant(&self) -> zbus::Result<zbus::zvariant::OwnedValue>;
+    #[zbus(property)]
+    fn set_variant(&self, value: zbus::zvariant::Value<'_>) -> zbus::Result<()>;
+}

--- a/zbus_xmlgen/tests/data/property_setters.xml
+++ b/zbus_xmlgen/tests/data/property_setters.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<node>
+  <interface name="com.example.PropertySetters">
+    <property name="Variant" type="v" access="readwrite"/>
+    <property name="StructPair" type="(ii)" access="readwrite"/>
+    <property name="StructSingle" type="(i)" access="readwrite"/>
+    <property name="ArrayOfVariant" type="av" access="readwrite"/>
+    <property name="ArrayOfStruct" type="a(ii)" access="readwrite"/>
+    <property name="DictStrToVariant" type="a{sv}" access="readwrite"/>
+    <property name="StructWithArrayOfVariant" type="(av)" access="readwrite"/>
+  </interface>
+</node>

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -47,3 +47,8 @@ fn sample_object0() -> Result<(), Box<dyn Error>> {
 fn struct_return() -> Result<(), Box<dyn Error>> {
     gen_diff!("struct_return.xml", "struct_return.rs")
 }
+
+#[test]
+fn property_setters() -> Result<(), Box<dyn Error>> {
+    gen_diff!("property_setters.xml", "property_setters.rs")
+}


### PR DESCRIPTION
`Proxy::set_property` requires `T: Into<Value<'t>>`. The generated
`&Value<'_>` for variant properties (and `&(T0, T1)` for struct ones,
plus their nested forms under `Array`/`Dict`) does not satisfy this
bound, since no `From<&Value> for Value` or `From<&(...)> for Structure`
impl exists.

Use a new `to_property_setter_type` helper that emits the owned form for
those types while keeping `&str`, `&[T]`, `&ObjectPath`, etc. unchanged.

Add a fixture and a `compile.rs` sanity-check that includes all
fixtures, so future regressions are caught at test time.

Fixes #1770

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
