### PR TITLE
Limit "vsock" feature to Linux-only

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -129,7 +129,24 @@ tempfile.workspace = true
 criterion.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
+# we can't use:
+# all-features = true
+# because some features (such as vsock) are target-specific
+features = [
+    "async-io",
+    "blocking-api",
+    "uuid",
+    "url",
+    "time",
+    "chrono",
+    "heapless",
+    "option-as-array",
+    "camino",
+    "bus-impl",
+    "p2p",
+    "tokio",
+    "serde_bytes",
+]
 targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-pc-windows-gnu",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -88,6 +88,8 @@ tokio = { workspace = true, optional = true, features = [
     "sync",
     "tracing",
 ] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 vsock = { workspace = true, optional = true }
 tokio-vsock = { workspace = true, optional = true }
 

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -40,6 +40,12 @@ mod error_message {
     compile_error!("Either \"async-io\" (default) or \"tokio\" must be enabled.");
 }
 
+#[cfg(all(
+    any(feature = "vsock", feature = "tokio-vsock"),
+    not(target_os = "linux")
+))]
+compile_error!("The \"vsock\" and \"tokio-vsock\" features are only supported on Linux.");
+
 #[cfg(windows)]
 mod win32;
 


### PR DESCRIPTION
Currently vsock feature is only available on Linux.