### PR TITLE
💚 Don't install cargo-fuzz w/ deps locked

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,7 +182,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Fuzz zvariant
         run: |
-          cargo --locked install cargo-fuzz
+          cargo install cargo-fuzz
           cargo --locked fuzz run --fuzz-dir zvariant/fuzz dbus -- -max_total_time=30 -max_len=100M
           cargo --locked fuzz run --fuzz-dir zvariant/fuzz --features gvariant gvariant -- -max_total_time=30 -max_len=100M
 


### PR DESCRIPTION
Otherwise, it fails to build with current nightly:

```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.36.5/src/backend/linux_raw/io/errno.rs:28:25
   |
28 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.36.5/src/backend/linux_raw/io/errno.rs:29:25
   |
29 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find attribute `rustc_layout_scalar_valid_range_start` in this scope
  --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.36.5/src/backend/linux_raw/io/errno.rs:28:25
   |
28 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find attribute `rustc_layout_scalar_valid_range_end` in this scope
  --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.36.5/src/backend/linux_raw/io/errno.rs:29:25
   |
29 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `rustix` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-fuzz v0.13.1`, intermediate artifacts can be found at `/tmp/cargo-installfvTyOC`.
```

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
