### PR TITLE
📝 zv: Show catch-all enum variant in docs

### DIFF
--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -309,6 +309,9 @@ enum StrEnum {
     Variant1,
     Variant2,
     Variant3,
+    // Catch-all that preserves the raw value for any variant we don't know about.
+    #[serde(untagged)]
+    Other(String),
 }
 
 let ctxt = Context::new_dbus(LE, 0);

--- a/zvariant/README.md
+++ b/zvariant/README.md
@@ -124,6 +124,9 @@ enum StrEnum {
     Variant1,
     Variant2,
     Variant3,
+    // Catch-all that preserves the raw value for any variant we don't know about.
+    #[serde(untagged)]
+    Other(String),
 }
 
 assert_eq!(StrEnum::SIGNATURE, "s");


### PR DESCRIPTION
A `#[serde(untagged)]` variant carrying the underlying type preserves unknown values from the wire instead of silently dropping them, which addresses the use case raised in https://github.com/z-galaxy/zbus/issues/1781. Fold the pattern into the existing string-enum example in the zvariant crate-level docs and the FAQ so the catch-all line is annotated where readers will encounter it.