### PR TITLE
📝 zm: Document the `Interface` impl methods generated by `#[interface]`

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -886,14 +886,17 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
         impl #generics #zbus::object_server::Interface for #self_ty
         #where_clause
         {
+            #[doc = "Return the name of the interface."]
             fn name() -> #zbus::names::InterfaceName<'static> {
                 #zbus::names::InterfaceName::from_static_str_unchecked(#iface_name)
             }
 
+            #[doc = "Whether each method call will be handled from a different spawned task."]
             fn spawn_tasks_for_methods(&self) -> bool {
                 #with_spawn
             }
 
+            #[doc = "Get a property value. Returns `None` if the property doesn't exist."]
             async fn get(
                 &self,
                 __zbus__property_name: &str,
@@ -908,6 +911,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 }
             }
 
+            #[doc = "Return all the properties."]
             async fn get_all(
                 &self,
                 __zbus__object_server: &#zbus::ObjectServer,
@@ -926,6 +930,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 Ok(props)
             }
 
+            #[doc = "Set a property value (`&self`)."]
             fn set<'call>(
                 &'call self,
                 __zbus__property_name: &'call str,
@@ -941,6 +946,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 }
             }
 
+            #[doc = "Set a property value (`&mut self`). Invoked when `set` returns `RequiresMut`."]
             async fn set_mut(
                 &mut self,
                 __zbus__property_name: &str,
@@ -956,6 +962,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 }
             }
 
+            #[doc = "Call a method (`&self`)."]
             fn call<'call>(
                 &'call self,
                 __zbus__object_server: &'call #zbus::ObjectServer,
@@ -969,6 +976,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 }
             }
 
+            #[doc = "Call a method (`&mut self`). Invoked when `call` returns `RequiresMut`."]
             fn call_mut<'call>(
                 &'call mut self,
                 __zbus__object_server: &'call #zbus::ObjectServer,
@@ -982,6 +990,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 }
             }
 
+            #[doc = "Write introspection XML to the writer, with the given indentation level."]
             fn introspect_to_writer(&self, writer: &mut dyn ::std::fmt::Write, level: usize) {
                 ::std::writeln!(
                     writer,


### PR DESCRIPTION
## What changed

`zbus_macros/src/iface.rs`: add `#[doc = "..."]` attributes to each method generated inside the `impl Interface for ...` block produced by `#[interface]`. The added docs mirror the prose already on the matching trait method declarations in `zbus/src/object_server/interface/mod.rs`:

- `name` -> "Return the name of the interface."
- `spawn_tasks_for_methods` -> "Whether each method call will be handled from a different spawned task."
- `get` -> "Get a property value. Returns `None` if the property doesn't exist."
- `get_all` -> "Return all the properties."
- `set` -> "Set a property value (`&self`)."
- `set_mut` -> "Set a property value (`&mut self`). Invoked when `set` returns `RequiresMut`."
- `call` -> "Call a method (`&self`)."
- `call_mut` -> "Call a method (`&mut self`). Invoked when `call` returns `RequiresMut`."
- `introspect_to_writer` -> "Write introspection XML to the writer, with the given indentation level."

Closes #1542

## Why

The reporter (and a second user a few days later) hit `missing_docs` warnings on every macro expansion site of `#[interface]` even though their own methods carried documentation -- the lint walks into the trait-method items the macro generates, and those had no doc string at all. Per zeenix's reply on #1542 ("I would happily take a PR..."), the simplest unblock is to give those generated items short doc strings rather than ask downstream users to `#[allow(missing_docs)]` around every `#[interface]` block.

The doc strings are short on purpose: they paraphrase the trait declaration so users who hover one of the generated methods get the same one-line summary the trait already shows in rustdoc, without re-stating multi-paragraph notes that would diverge over time from the canonical text.

## Verification

- `cargo build -p zbus_macros` -- clean.
- `cargo check -p zbus` -- clean.
- `cargo test -p zbus_macros` -- 6/8 pass; the 2 failing tests (`test_proxy`, `test_proxy_object_list`) require a live D-Bus session bus per `CLAUDE.md` and panic identically on `master` on macOS without one. The macro-relevant `test_interface` and `test_interface_with_crate_attr` both pass, exercising the `#[interface]` codepath this PR touches.
- `cargo clippy -p zbus_macros -- -D warnings` -- clean.
- I have a small reproducer crate that compiles `#![warn(missing_docs)]` against an `#[interface]`-annotated impl. Before this change it emits 9 `missing_docs` warnings (one per generated method); after it emits 0.
