### PR TITLE
🔊 zb: log GetAll error during property cache init

### DIFF
--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -13,7 +13,7 @@ use std::{
     sync::{Arc, OnceLock, RwLock, RwLockReadGuard},
     task::{Context, Poll},
 };
-use tracing::{Instrument, debug, info_span, instrument, trace};
+use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use zbus_names::{BusName, InterfaceName, MemberName, UniqueName};
 use zvariant::{ObjectPath, OwnedValue, Str, Value};
@@ -298,6 +298,10 @@ impl PropertiesCache {
                         (prop_changes, interface, uncached_properties)
                     }
                     Err(e) => {
+                        warn!(
+                            "Failed to populate properties cache via GetAll: {e}. \
+                             Property change streams will not produce values."
+                        );
                         ready.notify(usize::MAX);
                         *caching_result = CachingResult::Cached { result: Err(e) };
 


### PR DESCRIPTION
Closes #1325.

`PropertiesCache::init()` stashes GetAll failures in `caching_result` but never logs them, so a misbehaving daemon causes property streams to silently produce nothing (#1325).

Per @zeenix's suggestion in the issue thread, emit a `tracing::error!` in the spawned caching task before stashing the error so the failure shows up under `RUST_LOG`.
