### PR TITLE
🦺 zv: Add `debug_assert` and docs for `Fd` deserialization safety

### DIFF
--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -9,6 +9,18 @@ use crate::{Basic, Type};
 /// do not implement  [`Serialize`] and [`Deserialize`]. So we provide a
 /// wrapper for both that implements these traits.
 ///
+/// # D-Bus FD Encoding
+///
+/// In D-Bus, file descriptors are **not** encoded as their raw numeric values on the wire.
+/// Instead, the message body contains a `u32` **index** into an out-of-band array of file
+/// descriptors that is transferred alongside the message via `SCM_RIGHTS` on Unix sockets.
+///
+/// The [`Deserialize`] implementation on this type is designed for zvariant's D-Bus
+/// deserializer, which resolves that index through the message's FD list before calling the
+/// serde visitor. **Using this type with other deserializers (JSON, CBOR, etc.) is not
+/// supported** — you would receive a `BorrowedFd` pointing to whatever FD number happened to
+/// be in the payload, which is almost certainly not what you want.
+///
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
 #[derive(Debug)]

--- a/zvariant/src/fd.rs
+++ b/zvariant/src/fd.rs
@@ -136,6 +136,7 @@ impl<'de> Deserialize<'de> for Fd<'de> {
         D: Deserializer<'de>,
     {
         let raw = i32::deserialize(deserializer)?;
+        debug_assert!(raw >= 0);
         // SAFETY: The `'de` lifetimes will ensure the borrow won't outlive the raw FD.
         let fd = unsafe { BorrowedFd::borrow_raw(raw) };
 

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -830,6 +830,7 @@ where
         let v = match &self.signature {
             #[cfg(unix)]
             Signature::Fd => {
+                debug_assert!(value >= 0);
                 // SAFETY: The `'de` lifetimes will ensure the borrow won't outlive the raw FD.
                 let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(value) };
                 Fd::Borrowed(fd).into()


### PR DESCRIPTION
`BorrowedFd::borrow_raw(-1)` is undefined behavior per std's contract. Both `Fd::deserialize` and `ValueSeed::visit_i32` (for `Signature::Fd`) were passing the raw wire integer directly to `borrow_raw` without checking it, meaning any deserializer other than zvariant's own D-Bus one (which resolves the wire index through the message's FD list before calling `visit_i32`) could trigger UB in safe code by supplying `-1`.

This PR adds a `debug_assert!(raw >= 0)` at both call sites, and documents on `Fd` that the `Deserialize` impl is designed for the D-Bus path and using it with other formats is unsupported.
<!--


Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
