### PR TITLE
✨ zb: Support multiple auth mechanisms on server side

### DIFF
--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -126,6 +126,13 @@ impl<'a> Builder<'a> {
         Self(self.0.auth_mechanism(auth_mechanism))
     }
 
+    /// Specify multiple mechanisms to accept during authentication.
+    ///
+    /// See [`crate::connection::Builder::auth_mechanisms`] for details.
+    pub fn auth_mechanisms(self, auth_mechanisms: impl Into<Vec<AuthMechanism>>) -> Self {
+        Self(self.0.auth_mechanisms(auth_mechanisms))
+    }
+
     /// Specify the user id during authentication.
     ///
     /// This can be useful when using [`AuthMechanism::External`] with `socat`

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -83,7 +83,7 @@ pub struct Builder<'a> {
     internal_executor: bool,
     interfaces: Interfaces<'a>,
     names: HashSet<WellKnownName<'a>>,
-    auth_mechanism: Option<AuthMechanism>,
+    auth_mechanisms: Option<Vec<AuthMechanism>>,
     #[cfg(feature = "bus-impl")]
     unique_name: Option<crate::names::UniqueName<'a>>,
     request_name_flags: BitFlags<RequestNameFlags>,
@@ -247,7 +247,23 @@ impl<'a> Builder<'a> {
 
     /// Specify the mechanism to use during authentication.
     pub fn auth_mechanism(mut self, auth_mechanism: AuthMechanism) -> Self {
-        self.auth_mechanism = Some(auth_mechanism);
+        self.auth_mechanisms = Some(vec![auth_mechanism]);
+
+        self
+    }
+
+    /// Specify multiple mechanisms to accept during authentication.
+    ///
+    /// This is particularly useful on the server side, where you may want to accept more than one
+    /// authentication mechanism. The server will accept whichever mechanism the client offers, as
+    /// long as it is in this list. If the client's mechanism is not supported, the server responds
+    /// with a `REJECTED` message listing all supported mechanisms, allowing the client to retry.
+    ///
+    /// This is fully compliant with the [D-Bus specification].
+    ///
+    /// [D-Bus specification]: https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms
+    pub fn auth_mechanisms(mut self, auth_mechanisms: impl Into<Vec<AuthMechanism>>) -> Self {
+        self.auth_mechanisms = Some(auth_mechanisms.into());
 
         self
     }
@@ -595,7 +611,7 @@ impl<'a> Builder<'a> {
             internal_executor: true,
             interfaces: HashMap::new(),
             names: HashSet::new(),
-            auth_mechanism: None,
+            auth_mechanisms: None,
             #[cfg(feature = "bus-impl")]
             unique_name: None,
             request_name_flags: BitFlags::default(),
@@ -634,7 +650,7 @@ impl<'a> Builder<'a> {
                     Authenticated::client(
                         stream,
                         server_guid,
-                        self.auth_mechanism,
+                        self.auth_mechanisms.as_ref().map(|m| m[0]),
                         is_bus_conn,
                         self.user_id,
                     )
@@ -658,7 +674,7 @@ impl<'a> Builder<'a> {
                         client_uid,
                         #[cfg(windows)]
                         client_sid,
-                        self.auth_mechanism,
+                        self.auth_mechanisms.take(),
                         unique_name,
                     )
                     .await
@@ -669,7 +685,7 @@ impl<'a> Builder<'a> {
             Authenticated::client(
                 stream,
                 server_guid,
-                self.auth_mechanism,
+                self.auth_mechanisms.as_ref().map(|m| m[0]),
                 is_bus_conn,
                 self.user_id,
             )

--- a/zbus/src/connection/handshake/client.rs
+++ b/zbus/src/connection/handshake/client.rs
@@ -32,7 +32,7 @@ impl Client {
         let mechanism = mechanism.unwrap_or_else(|| socket.read().auth_mechanism());
 
         Client {
-            common: Common::new(socket, mechanism),
+            common: Common::new(socket, vec![mechanism]),
             server_guid,
             bus,
             user_id: match user_id {

--- a/zbus/src/connection/handshake/common.rs
+++ b/zbus/src/connection/handshake/common.rs
@@ -11,20 +11,22 @@ pub(super) struct Common {
     #[cfg(unix)]
     received_fds: Vec<std::os::fd::OwnedFd>,
     cap_unix_fd: bool,
-    mechanism: AuthMechanism,
+    mechanisms: Vec<AuthMechanism>,
     first_command: bool,
 }
 
 impl Common {
     /// Start a handshake on this client socket
-    pub fn new(socket: BoxedSplit, mechanism: AuthMechanism) -> Self {
+    pub fn new(socket: BoxedSplit, mechanisms: impl Into<Vec<AuthMechanism>>) -> Self {
+        let mechanisms = mechanisms.into();
+        debug_assert!(!mechanisms.is_empty());
         Self {
             socket,
             recv_buffer: Vec::new(),
             #[cfg(unix)]
             received_fds: Vec::new(),
             cap_unix_fd: false,
-            mechanism,
+            mechanisms,
             first_command: true,
         }
     }
@@ -43,7 +45,12 @@ impl Common {
     }
 
     pub fn mechanism(&self) -> AuthMechanism {
-        self.mechanism
+        self.mechanisms[0]
+    }
+
+    #[cfg(feature = "p2p")]
+    pub fn mechanisms(&self) -> &[AuthMechanism] {
+        &self.mechanisms
     }
 
     pub fn into_components(self) -> IntoComponentsReturn {
@@ -53,7 +60,7 @@ impl Common {
             #[cfg(unix)]
             self.received_fds,
             self.cap_unix_fd,
-            self.mechanism,
+            self.mechanisms,
         )
     }
 
@@ -180,7 +187,7 @@ type IntoComponentsReturn = (
     Vec<u8>,
     Vec<std::os::fd::OwnedFd>,
     bool,
-    AuthMechanism,
+    Vec<AuthMechanism>,
 );
 #[cfg(not(unix))]
-type IntoComponentsReturn = (BoxedSplit, Vec<u8>, bool, AuthMechanism);
+type IntoComponentsReturn = (BoxedSplit, Vec<u8>, bool, Vec<AuthMechanism>);

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -69,7 +69,7 @@ impl Authenticated {
         guid: OwnedGuid,
         #[cfg(unix)] client_uid: Option<u32>,
         #[cfg(windows)] client_sid: Option<String>,
-        auth_mechanism: Option<AuthMechanism>,
+        auth_mechanisms: Option<Vec<AuthMechanism>>,
         unique_name: Option<OwnedUniqueName>,
     ) -> Result<Self> {
         Server::new(
@@ -79,7 +79,7 @@ impl Authenticated {
             client_uid,
             #[cfg(windows)]
             client_sid,
-            auth_mechanism,
+            auth_mechanisms,
             unique_name,
         )?
         .perform()
@@ -250,7 +250,7 @@ mod tests {
             p1.into(),
             Guid::generate().into(),
             Some(geteuid().as_raw()),
-            Some(AuthMechanism::Anonymous),
+            Some(vec![AuthMechanism::Anonymous]),
             None,
         )
         .unwrap();
@@ -267,13 +267,75 @@ mod tests {
             p1.into(),
             Guid::generate().into(),
             Some(geteuid().as_raw()),
-            Some(AuthMechanism::Anonymous),
+            Some(vec![AuthMechanism::Anonymous]),
             None,
         )
         .unwrap();
 
         crate::utils::block_on(p0.write_all(b"\0AUTH ANONYMOUS\r\nDATA abcd\r\nBEGIN\r\n"))
             .unwrap();
+        crate::utils::block_on(server.perform()).unwrap();
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn multi_mechanism_anonymous() {
+        let (mut p0, p1) = create_async_socket_pair();
+        let server = Server::new(
+            p1.into(),
+            Guid::generate().into(),
+            Some(geteuid().as_raw()),
+            Some(vec![AuthMechanism::External, AuthMechanism::Anonymous]),
+            None,
+        )
+        .unwrap();
+
+        crate::utils::block_on(p0.write_all(b"\0AUTH ANONYMOUS abcd\r\nBEGIN\r\n")).unwrap();
+        crate::utils::block_on(server.perform()).unwrap();
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn multi_mechanism_external() {
+        let (p0, p1) = create_async_socket_pair();
+
+        let guid = OwnedGuid::from(Guid::generate());
+        let client = Client::new(p0.into(), None, Some(guid.clone()), false, None);
+        let server = Server::new(
+            p1.into(),
+            guid,
+            Some(geteuid().as_raw()),
+            Some(vec![AuthMechanism::External, AuthMechanism::Anonymous]),
+            None,
+        )
+        .unwrap();
+
+        let (client, server) = crate::utils::block_on(join(
+            async move { client.perform().await.unwrap() },
+            async move { server.perform().await.unwrap() },
+        ));
+
+        assert_eq!(client.server_guid, server.server_guid);
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn multi_mechanism_rejected_then_retry() {
+        let (mut p0, p1) = create_async_socket_pair();
+        let server = Server::new(
+            p1.into(),
+            Guid::generate().into(),
+            Some(geteuid().as_raw()),
+            Some(vec![AuthMechanism::Anonymous]),
+            None,
+        )
+        .unwrap();
+
+        // Client tries EXTERNAL (unsupported), gets REJECTED, then retries with ANONYMOUS.
+        crate::utils::block_on(
+            p0.write_all(b"\0AUTH EXTERNAL 30\r\nAUTH ANONYMOUS abcd\r\nBEGIN\r\n"),
+        )
+        .unwrap();
         crate::utils::block_on(server.perform()).unwrap();
     }
 }

--- a/zbus/src/connection/handshake/server.rs
+++ b/zbus/src/connection/handshake/server.rs
@@ -40,13 +40,18 @@ impl Server {
         guid: OwnedGuid,
         #[cfg(unix)] client_uid: Option<u32>,
         #[cfg(windows)] client_sid: Option<String>,
-        mechanism: Option<AuthMechanism>,
+        mechanisms: Option<Vec<AuthMechanism>>,
         unique_name: Option<OwnedUniqueName>,
     ) -> Result<Self> {
-        let mechanism = mechanism.unwrap_or_else(|| socket.read().auth_mechanism());
+        let mechanisms = mechanisms.unwrap_or_else(|| vec![socket.read().auth_mechanism()]);
+        if mechanisms.is_empty() {
+            return Err(Error::Handshake(
+                "No authentication mechanisms provided".into(),
+            ));
+        }
 
         Ok(Server {
-            common: Common::new(socket, mechanism),
+            common: Common::new(socket, mechanisms),
             step: ServerHandshakeStep::WaitingForAuth,
             #[cfg(unix)]
             client_uid,
@@ -102,7 +107,14 @@ impl Server {
 
     #[instrument(skip(self))]
     async fn rejected_error(&mut self) -> Result<()> {
-        let cmd = Command::Rejected(self.common.mechanism().as_str().into());
+        let mechs = self
+            .common
+            .mechanisms()
+            .iter()
+            .map(|m| m.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let cmd = Command::Rejected(mechs.into());
         trace!("Sending authentication error");
         self.common.write_command(cmd).await?;
         self.step = ServerHandshakeStep::WaitingForAuth;
@@ -132,12 +144,12 @@ impl Server {
         let reply = self.common.read_command().await?;
         match reply {
             Command::Auth(requested_mech, resp) => {
-                let mech = self.common.mechanism();
-                if requested_mech != Some(mech) {
+                let mech = requested_mech.filter(|m| self.common.mechanisms().contains(m));
+                let Some(mech) = mech else {
                     self.rejected_error().await?;
 
                     return Ok(());
-                }
+                };
 
                 match &resp {
                     None => {


### PR DESCRIPTION
The D-Bus specification allows servers to support multiple SASL authentication mechanisms on a single socket, listing them all in the `REJECTED` response so the client can retry with an alternative. Until now, zbus only supported configuring a single mechanism per server.

This adds `Builder::auth_mechanisms()` to accept a list of mechanisms, while the existing `auth_mechanism()` continues to work unchanged.