### PR TITLE
zv: Use Fields::get(i) for O(1) field signature lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -23,7 +23,7 @@ camino = ["dep:camino"]
 
 [dependencies]
 zvariant_derive = { path = "../zvariant_derive", version = "5.11.0" }
-zvariant_utils = { path = "../zvariant_utils", version = "3.3.1" }
+zvariant_utils = { path = "../zvariant_utils", version = "3.4.0" }
 endi.workspace = true
 serde.workspace = true
 winnow.workspace = true

--- a/zvariant/src/dbus/de.rs
+++ b/zvariant/src/dbus/de.rs
@@ -599,7 +599,7 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> SeqAccess<'de>
         let signature = self.de.0.signature;
         let field_signature = match signature {
             Signature::Structure(fields) => {
-                let signature = fields.iter().nth(self.field_idx).ok_or_else(|| {
+                let signature = fields.get(self.field_idx).ok_or_else(|| {
                     Error::SignatureMismatch(signature.clone(), "a struct".to_string())
                 })?;
                 self.field_idx += 1;

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -473,7 +473,7 @@ where
                 "a struct".to_string(),
             ));
         };
-        let struct_field = fields.iter().nth(1).and_then(|f| {
+        let struct_field = fields.get(1).and_then(|f| {
             if matches!(f, Signature::Structure(_)) {
                 Some(f)
             } else {
@@ -511,7 +511,7 @@ where
                 }
             }
             Signature::Structure(fields) => {
-                let signature = fields.iter().nth(self.field_idx).ok_or_else(|| {
+                let signature = fields.get(self.field_idx).ok_or_else(|| {
                     Error::SignatureMismatch(signature.clone(), "a struct".to_string())
                 })?;
                 self.field_idx += 1;

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -506,7 +506,7 @@ where
                 "a struct".to_string(),
             ));
         };
-        let struct_field = fields.iter().nth(1).and_then(|f| {
+        let struct_field = fields.get(1).and_then(|f| {
             if matches!(f, Signature::Structure(_)) {
                 Some(f)
             } else {
@@ -546,7 +546,7 @@ where
                 }
             }
             Signature::Structure(fields) => {
-                let signature = fields.iter().nth(self.field_idx).ok_or_else(|| {
+                let signature = fields.get(self.field_idx).ok_or_else(|| {
                     Error::SignatureMismatch(signature.clone(), "a struct".to_string())
                 })?;
                 self.field_idx += 1;

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",

--- a/zvariant_utils/src/signature/fields.rs
+++ b/zvariant_utils/src/signature/fields.rs
@@ -38,6 +38,16 @@ impl Fields {
         }
     }
 
+    /// The field signature at index `i`, or `None` if `i >= self.len()`.
+    ///
+    /// Constant-time positional access.
+    pub fn get(&self, i: usize) -> Option<&Signature> {
+        match self {
+            Self::Static { fields } => fields.get(i).copied(),
+            Self::Dynamic { fields } => fields.get(i),
+        }
+    }
+
     /// The number of fields.
     pub const fn len(&self) -> usize {
         match self {


### PR DESCRIPTION
Fixes the O(N²) field signature lookup in struct (de)serialization called out in #1800.

## Summary

Struct (de)serializer state machines reached the i-th field signature via `fields.iter().nth(self.field_idx)`. `Fields::iter()` returned a custom iterator that only implemented `next`, so `nth` fell back to the default `next`-in-a-loop — O(N²) cumulative across all fields of a struct.

This PR:
- Adds `Fields::get(i: usize) -> Option<&Signature>` in `zvariant_utils`, delegating to slice indexing (O(1)).
- Migrates the five `fields.iter().nth(…)` call sites in `zvariant` to `fields.get(…)`. Three are the hot-loop sites in `dbus/ser.rs`, `dbus/de.rs`, `gvariant/ser.rs`; the other two are `nth(1)` lookups in the enum-variant paths, migrated for consistency.

## Measurement

Originally found while reworking the cross-library D-Bus marshal benchmarks at https://github.com/KillingSpark/rust-dbus-comparisons to a flat-encoded body (60 inline top-level params per Mixed body). For that struct shape, the cumulative `next()` count in the (de)serializer's field-lookup loop drops from ~1830 to 0. At 1–2 ns per `slice::Iter::next()` that's roughly 2–3 µs saved per marshal on a Ryzen 3800X — matching the regression I'd previously been unable to explain.

The benefit scales as O(N²) in field count, so it's invisible for small structs and grows with wide ones.

Fixes #1800.