### PR TITLE
✅ zx: Add regression test for bare struct arg signatures

### DIFF
--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -2,6 +2,7 @@ use quick_xml::de::DeError;
 use std::error::Error;
 
 use zbus_xml::{ArgDirection, Node};
+use zvariant::Signature;
 
 #[test]
 fn serde() -> Result<(), Box<dyn Error>> {
@@ -35,4 +36,31 @@ fn invalid_arg_type() {
         Node::try_from(input),
         Err(zbus_xml::Error::QuickXml(DeError::Custom(_)))
     ));
+}
+
+#[test]
+fn multi_complete_arg_type() -> Result<(), Box<dyn Error>> {
+    let input = r#"
+        <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        <node>
+            <interface name="org.test.testinterface">
+                <method name="testmethod">
+                    <arg name="testarg" direction="out" type="tt"/>
+                </method>
+            </interface>
+        </node>
+    "#;
+
+    let node = Node::try_from(input)?;
+    let arg = &node.interfaces()[0].methods()[0].args()[0];
+    let Signature::Structure(fields) = arg.ty().inner() else {
+        panic!("expected `tt` to parse as a structure");
+    };
+
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields.get(0), Some(&Signature::U64));
+    assert_eq!(fields.get(1), Some(&Signature::U64));
+
+    Ok(())
 }

--- a/zbus_xmlgen/tests/data/struct_return.rs
+++ b/zbus_xmlgen/tests/data/struct_return.rs
@@ -1,5 +1,8 @@
 #[proxy(interface = "test.StructReturn", assume_defaults = true)]
 pub trait StructReturn {
+    /// ReturnsBareStruct method
+    fn returns_bare_struct(&self) -> zbus::Result<((u64, u64),)>;
+
     /// ReturnsNestedStruct method
     fn returns_nested_struct(&self) -> zbus::Result<(((String, String), i32),)>;
 

--- a/zbus_xmlgen/tests/data/struct_return.xml
+++ b/zbus_xmlgen/tests/data/struct_return.xml
@@ -2,6 +2,9 @@
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="test.StructReturn">
+    <method name="ReturnsBareStruct">
+      <arg name="result" type="tt" direction="out" />
+    </method>
     <method name="ReturnsStruct">
       <arg name="result" type="(ss)" direction="out" />
     </method>


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
This PR adds regression coverage for introspection args with multi-complete signatures like `type="tt"`.

Related: #495 