### PR TITLE
Retry invalidated cache property get after cache is invalidated

### DIFF
--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -253,6 +253,9 @@ where
 pub(crate) struct PropertiesCache {
     values: RwLock<HashMap<String, PropertyValue>>,
     caching_result: RwLock<CachingResult>,
+    /// Notified to wake the background populate task and request another `init` attempt
+    /// after a prior failure (e.g. when a direct `Get` succeeded out-of-band).
+    retry_kick: Event,
 }
 
 #[derive(Debug)]
@@ -274,6 +277,7 @@ impl PropertiesCache {
             caching_result: RwLock::new(CachingResult::Caching {
                 ready: Event::new(),
             }),
+            retry_kick: Event::new(),
         });
 
         let task_name = format!("{interface} proxy caching");
@@ -283,7 +287,15 @@ impl PropertiesCache {
         (cache, task)
     }
 
-    /// Spawn the cache population task. This calls `init` then `keep_updated`.
+    /// Spawn the cache population task.
+    ///
+    /// This task tries `init`; on success it proceeds to `keep_updated`. On failure it marks the
+    /// cache as failed (so callers fall back to direct `Get` calls) and waits for a signal
+    /// indicating the service / interface may now be available — currently
+    /// `org.freedesktop.DBus.NameOwnerChanged` (when the destination is a well-known name) and
+    /// `org.freedesktop.DBus.ObjectManager.InterfacesAdded` (when the service exposes an
+    /// ObjectManager) — or for an explicit kick via [`Self::kick_retry`] (used when a direct `Get`
+    /// succeeds while the cache is in a failed state). When woken, it re-attempts `init`.
     fn spawn_populate(
         self: &Arc<Self>,
         proxy: PropertiesProxy<'static>,
@@ -292,47 +304,109 @@ impl PropertiesCache {
         uncached_properties: HashSet<zvariant::Str<'static>>,
         task_name: &str,
     ) -> Task<()> {
-        let cache_clone = self.clone();
-        let proxy_caching = async move {
-            let result = cache_clone
-                .init(proxy, interface, uncached_properties)
+        let cache = self.clone();
+        let proxy_caching = cache
+            .populate_loop(proxy, interface, uncached_properties)
+            .instrument(info_span!("{}", task_name));
+        executor.spawn(proxy_caching, task_name)
+    }
+
+    async fn populate_loop(
+        self: Arc<Self>,
+        proxy: PropertiesProxy<'static>,
+        interface: InterfaceName<'static>,
+        uncached_properties: HashSet<zvariant::Str<'static>>,
+    ) {
+        use futures_lite::FutureExt as _;
+        use futures_lite::StreamExt as _;
+
+        // Best-effort subscriptions used to wake the task on relevant bus activity.
+        let (mut owner_changed, mut interfaces_added) = build_appearance_streams(
+            proxy.inner().connection(),
+            proxy.inner().destination(),
+            proxy.inner().path(),
+        )
+        .await;
+
+        let mut first_attempt = true;
+        loop {
+            let result = self
+                .init(proxy.clone(), interface.clone(), uncached_properties.clone())
                 .await;
-            let (prop_changes, interface, uncached_properties) = {
-                let mut caching_result = cache_clone.caching_result.write().expect("lock poisoned");
-                let ready = match &*caching_result {
-                    CachingResult::Caching { ready } => ready,
-                    // Another concurrent populate beat us; nothing to do.
-                    CachingResult::Cached { .. } => return,
-                };
+
+            let next = {
+                let mut caching_result = self.caching_result.write().expect("lock poisoned");
                 match result {
                     Ok((prop_changes, interface, uncached_properties)) => {
-                        ready.notify(usize::MAX);
+                        if let CachingResult::Caching { ready } = &*caching_result {
+                            ready.notify(usize::MAX);
+                        }
                         *caching_result = CachingResult::Cached { result: Ok(()) };
-
-                        (prop_changes, interface, uncached_properties)
+                        Some((prop_changes, interface, uncached_properties))
                     }
                     Err(e) => {
-                        warn!(
-                            "Failed to populate properties cache via GetAll: {e}. \
-                             Property change streams will not produce values."
-                        );
-                        ready.notify(usize::MAX);
+                        if first_attempt {
+                            warn!(
+                                "Failed to populate properties cache via GetAll: {e}. \
+                                 Will retry when the service / interface appears."
+                            );
+                            if let CachingResult::Caching { ready } = &*caching_result {
+                                ready.notify(usize::MAX);
+                            }
+                        } else {
+                            debug!("Retry to populate properties cache failed: {e}");
+                        }
                         *caching_result = CachingResult::Cached { result: Err(e) };
-
-                        return;
+                        None
                     }
                 }
             };
 
-            if let Err(e) = cache_clone
-                .keep_updated(prop_changes, interface, uncached_properties)
-                .await
-            {
-                debug!("Error keeping properties cache updated: {e}");
+            first_attempt = false;
+
+            match next {
+                Some((prop_changes, interface, uncached_properties)) => {
+                    if let Err(e) = self
+                        .keep_updated(prop_changes, interface, uncached_properties)
+                        .await
+                    {
+                        debug!("Error keeping properties cache updated: {e}");
+                    }
+                    return;
+                }
+                None => {
+                    // Wait for any signal that suggests the interface may now be available, or
+                    // for an explicit kick from a successful out-of-band `Get`.
+                    let kick = self.retry_kick.listen();
+                    let wait_kick = async move {
+                        kick.await;
+                    };
+                    let wait_owner = async {
+                        if let Some(s) = owner_changed.as_mut() {
+                            let _ = s.next().await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    };
+                    let wait_ifaces = async {
+                        if let Some(s) = interfaces_added.as_mut() {
+                            let _ = s.next().await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    };
+                    wait_kick.or(wait_owner).or(wait_ifaces).await;
+                }
             }
         }
-        .instrument(info_span!("{}", task_name));
-        executor.spawn(proxy_caching, task_name)
+    }
+
+    /// Kick the background populate task to retry `init` immediately.
+    ///
+    /// Used when a direct `Get` succeeded while the cache was in a failed state, indicating
+    /// the interface is now available even if no relevant bus signal was emitted.
+    pub(crate) fn kick_retry(&self) {
+        self.retry_kick.notify(usize::MAX);
     }
 
     /// new() runs this in a task it spawns for initialization of properties cache.
@@ -496,35 +570,6 @@ impl PropertiesCache {
             CachingResult::Cached { result } => result.clone(),
         }
     }
-
-    /// Re-attempt cache population after a prior failure.
-    ///
-    /// Resets the caching state to `Caching` and spawns a new initialization task. If the cache
-    /// is not in a failed state, this is a no-op.
-    fn retry(
-        self: &Arc<Self>,
-        proxy: PropertiesProxy<'static>,
-        interface: InterfaceName<'static>,
-        executor: &Executor<'_>,
-        uncached_properties: HashSet<zvariant::Str<'static>>,
-    ) {
-        {
-            let mut caching_result = self.caching_result.write().expect("lock poisoned");
-            match &*caching_result {
-                CachingResult::Cached { result: Err(_) } => {
-                    // Reset to Caching so that `ready()` will wait for the new attempt.
-                    *caching_result = CachingResult::Caching {
-                        ready: Event::new(),
-                    };
-                }
-                _ => return,
-            }
-        }
-
-        let task_name = format!("{interface} proxy caching (retry)");
-        self.spawn_populate(proxy, interface, executor, uncached_properties, &task_name)
-            .detach();
-    }
 }
 
 impl<'a> ProxyInner<'a> {
@@ -610,6 +655,61 @@ impl<'a> ProxyInner<'a> {
 }
 
 const MAX_NAME_OWNER_CHANGED_SIGNALS_QUEUED: usize = 8;
+
+/// Build best-effort `MessageStream` subscriptions used to wake the populate task when the
+/// destination service / interface may have appeared on the bus.
+///
+/// - `NameOwnerChanged` (filtered by the destination name) covers the case where the proxy is
+///   created before the service connects to the bus.
+/// - `InterfacesAdded` (filtered by `arg_path` matching the proxy's path) covers services that
+///   expose an `org.freedesktop.DBus.ObjectManager` and register interfaces dynamically.
+///
+/// Returns `None` slots when the corresponding subscription is not applicable or could not be
+/// installed; failures are non-fatal — the [`PropertiesCache::kick_retry`] mechanism provides a
+/// fallback for services that emit neither signal.
+async fn build_appearance_streams(
+    conn: &Connection,
+    destination: &BusName<'_>,
+    path: &ObjectPath<'_>,
+) -> (Option<MessageStream>, Option<MessageStream>) {
+    let owner_changed = match destination {
+        BusName::WellKnown(name) => MatchRule::builder()
+            .msg_type(Type::Signal)
+            .sender("org.freedesktop.DBus")
+            .ok()
+            .and_then(|b| b.path("/org/freedesktop/DBus").ok())
+            .and_then(|b| b.interface("org.freedesktop.DBus").ok())
+            .and_then(|b| b.member("NameOwnerChanged").ok())
+            .and_then(|b| b.add_arg(name.as_str()).ok())
+            .map(|b| b.build().to_owned())
+            .map(|rule| {
+                MessageStream::for_match_rule(
+                    rule,
+                    conn,
+                    Some(MAX_NAME_OWNER_CHANGED_SIGNALS_QUEUED),
+                )
+            }),
+        BusName::Unique(_) => None,
+    };
+    let owner_changed = match owner_changed {
+        Some(fut) => fut.await.ok(),
+        None => None,
+    };
+
+    let interfaces_added = MatchRule::builder()
+        .msg_type(Type::Signal)
+        .interface("org.freedesktop.DBus.ObjectManager")
+        .ok()
+        .and_then(|b| b.member("InterfacesAdded").ok())
+        .and_then(|b| b.arg_path(0, path.clone()).ok())
+        .map(|b| b.build().to_owned());
+    let interfaces_added = match interfaces_added {
+        Some(rule) => MessageStream::for_match_rule(rule, conn, Some(1)).await.ok(),
+        None => None,
+    };
+
+    (owner_changed, interfaces_added)
+}
 
 impl<'a> Proxy<'a> {
     /// Create a new `Proxy` for the given destination/path/interface.
@@ -829,34 +929,27 @@ impl<'a> Proxy<'a> {
         T: TryFrom<OwnedValue>,
         T::Error: Into<Error>,
     {
-        let mut should_retry_cache = true;
-        if let Some(cache) = self.get_property_cache() {
+        let cache = self.get_property_cache();
+        let cache_ok = match &cache {
             // If the cache failed to populate (e.g. the interface wasn't registered yet when the
             // proxy was created), don't fail permanently — fall through to a direct `Get` call.
-            if cache.ready().await.is_ok() {
-                should_retry_cache = false;
-                if let Some(value) = self.cached_property(property_name)? {
-                    return Ok(value);
-                }
+            Some(cache) => cache.ready().await.is_ok(),
+            None => false,
+        };
+        if cache_ok {
+            if let Some(value) = self.cached_property(property_name)? {
+                return Ok(value);
             }
         }
 
         let value = self.get_proxy_property(property_name).await?;
 
-        // The direct Get succeeded, so the interface is now available. If the cache previously
-        // failed to populate, kick off a retry so subsequent calls can use the cache.
-        if should_retry_cache {
-            if let Some(cache) = self.get_property_cache() {
-                let proxy = self.owned_properties_proxy();
-                let interface = self.inner.interface.to_owned();
-                let uncached_properties: HashSet<zvariant::Str<'static>> = self
-                    .inner
-                    .uncached_properties
-                    .iter()
-                    .map(|s| s.to_owned())
-                    .collect();
-                let executor = self.connection().executor();
-                cache.retry(proxy, interface, executor, uncached_properties);
+        // The direct Get succeeded. If the cache is in a failed state, kick the background
+        // populate task to retry now — covers services that emit neither `NameOwnerChanged`
+        // (already on the bus) nor `InterfacesAdded` (no `ObjectManager` exposed).
+        if !cache_ok {
+            if let Some(cache) = cache {
+                cache.kick_retry();
             }
         }
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -276,8 +276,23 @@ impl PropertiesCache {
             }),
         });
 
-        let cache_clone = cache.clone();
         let task_name = format!("{interface} proxy caching");
+        let task =
+            cache.spawn_populate(proxy, interface, executor, uncached_properties, &task_name);
+
+        (cache, task)
+    }
+
+    /// Spawn the cache population task. This calls `init` then `keep_updated`.
+    fn spawn_populate(
+        self: &Arc<Self>,
+        proxy: PropertiesProxy<'static>,
+        interface: InterfaceName<'static>,
+        executor: &Executor<'_>,
+        uncached_properties: HashSet<zvariant::Str<'static>>,
+        task_name: &str,
+    ) -> Task<()> {
+        let cache_clone = self.clone();
         let proxy_caching = async move {
             let result = cache_clone
                 .init(proxy, interface, uncached_properties)
@@ -286,9 +301,8 @@ impl PropertiesCache {
                 let mut caching_result = cache_clone.caching_result.write().expect("lock poisoned");
                 let ready = match &*caching_result {
                     CachingResult::Caching { ready } => ready,
-                    // SAFETY: This is the only part of the code that changes this state and it's
-                    // only run once.
-                    _ => unreachable!(),
+                    // Another concurrent populate beat us; nothing to do.
+                    CachingResult::Cached { .. } => return,
                 };
                 match result {
                     Ok((prop_changes, interface, uncached_properties)) => {
@@ -318,9 +332,7 @@ impl PropertiesCache {
             }
         }
         .instrument(info_span!("{}", task_name));
-        let task = executor.spawn(proxy_caching, &task_name);
-
-        (cache, task)
+        executor.spawn(proxy_caching, task_name)
     }
 
     /// new() runs this in a task it spawns for initialization of properties cache.
@@ -483,6 +495,35 @@ impl PropertiesCache {
             CachingResult::Caching { .. } => unreachable!(),
             CachingResult::Cached { result } => result.clone(),
         }
+    }
+
+    /// Re-attempt cache population after a prior failure.
+    ///
+    /// Resets the caching state to `Caching` and spawns a new initialization task. If the cache
+    /// is not in a failed state, this is a no-op.
+    fn retry(
+        self: &Arc<Self>,
+        proxy: PropertiesProxy<'static>,
+        interface: InterfaceName<'static>,
+        executor: &Executor<'_>,
+        uncached_properties: HashSet<zvariant::Str<'static>>,
+    ) {
+        {
+            let mut caching_result = self.caching_result.write().expect("lock poisoned");
+            match &*caching_result {
+                CachingResult::Cached { result: Err(_) } => {
+                    // Reset to Caching so that `ready()` will wait for the new attempt.
+                    *caching_result = CachingResult::Caching {
+                        ready: Event::new(),
+                    };
+                }
+                _ => return,
+            }
+        }
+
+        let task_name = format!("{interface} proxy caching (retry)");
+        self.spawn_populate(proxy, interface, executor, uncached_properties, &task_name)
+            .detach();
     }
 }
 
@@ -788,14 +829,37 @@ impl<'a> Proxy<'a> {
         T: TryFrom<OwnedValue>,
         T::Error: Into<Error>,
     {
+        let mut should_retry_cache = true;
         if let Some(cache) = self.get_property_cache() {
-            cache.ready().await?;
-        }
-        if let Some(value) = self.cached_property(property_name)? {
-            return Ok(value);
+            // If the cache failed to populate (e.g. the interface wasn't registered yet when the
+            // proxy was created), don't fail permanently — fall through to a direct `Get` call.
+            if cache.ready().await.is_ok() {
+                should_retry_cache = false;
+                if let Some(value) = self.cached_property(property_name)? {
+                    return Ok(value);
+                }
+            }
         }
 
         let value = self.get_proxy_property(property_name).await?;
+
+        // The direct Get succeeded, so the interface is now available. If the cache previously
+        // failed to populate, kick off a retry so subsequent calls can use the cache.
+        if should_retry_cache {
+            if let Some(cache) = self.get_property_cache() {
+                let proxy = self.owned_properties_proxy();
+                let interface = self.inner.interface.to_owned();
+                let uncached_properties: HashSet<zvariant::Str<'static>> = self
+                    .inner
+                    .uncached_properties
+                    .iter()
+                    .map(|s| s.to_owned())
+                    .collect();
+                let executor = self.connection().executor();
+                cache.retry(proxy, interface, executor, uncached_properties);
+            }
+        }
+
         value.try_into().map_err(Into::into)
     }
 

--- a/zbus/tests/issue/issue_proxy_before_server.rs
+++ b/zbus/tests/issue/issue_proxy_before_server.rs
@@ -110,13 +110,26 @@ async fn test_proxy_created_before_server_property() -> Result<()> {
     #[cfg(not(feature = "tokio"))]
     async_io::Timer::after(Duration::from_millis(100)).await;
 
-    // Try to read the property again. The interface IS now registered and a fresh
-    // Get call would work. But the proxy's cache.ready() still returns the
-    // original error, so this always fails — demonstrating the bug.
+    // Try to read the property again. The interface IS now registered, so a
+    // direct Get call should succeed even though the cache was poisoned.
     let second_result = proxy.value().await;
+    assert_eq!(
+        second_result.expect("property read should succeed after interface is registered"),
+        42,
+    );
 
-    // BUG: This assertion documents the broken behavior. Once the bug is fixed this should not panic.
-    let _ = second_result.expect("Should return the value after the interface is published");
+    // Give the cache retry task a moment to repopulate.
+    #[cfg(feature = "tokio")]
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    #[cfg(not(feature = "tokio"))]
+    async_io::Timer::after(Duration::from_millis(100)).await;
+
+    // Subsequent reads should now come from the repopulated cache.
+    let third_result = proxy.value().await;
+    assert_eq!(
+        third_result.expect("property read should use repopulated cache"),
+        42,
+    );
 
     Ok(())
 }

--- a/zbus/tests/issue/issue_proxy_before_server.rs
+++ b/zbus/tests/issue/issue_proxy_before_server.rs
@@ -1,34 +1,34 @@
+use std::time::Duration;
+
+use futures_util::StreamExt;
 use ntest::timeout;
 use test_log::test;
-use zbus::block_on;
+use zbus::{Result, block_on};
 
-use zbus::Result;
-
-/// Test that demonstrates a bug: if a client proxy is created *before* the server
-/// registers the interface, reading a property from that proxy will always fail,
-/// even after the server interface has been registered.
-///
-/// When the proxy is built with caching enabled (default), the background caching
-/// task issues a GetAll Properties call. If the interface isn't registered yet, the
-/// server responds with UnknownObject/UnknownInterface. This error is stored in the
-/// cache's `CachingResult`. Every subsequent call to `get_property` calls
-/// `cache.ready().await?` which returns the stored error, so the property can never
-/// be read from this proxy instance — even after the interface is properly registered.
-#[test]
-#[timeout(15000)]
-fn proxy_created_before_server_property_fails() {
-    block_on(test_proxy_created_before_server_property()).unwrap();
+async fn sleep(d: Duration) {
+    #[cfg(feature = "tokio")]
+    tokio::time::sleep(d).await;
+    #[cfg(not(feature = "tokio"))]
+    async_io::Timer::after(d).await;
 }
 
-async fn test_proxy_created_before_server_property() -> Result<()> {
-    use std::time::Duration;
+/// Interface registered *after* the proxy is created, on a service that does **not** expose an
+/// `ObjectManager`. Neither `NameOwnerChanged` nor `InterfacesAdded` will fire — the cache
+/// recovers via the `kick_retry` fallback that `Proxy::get_property` triggers after a
+/// successful out-of-band `Get`.
+#[test]
+#[timeout(15000)]
+fn proxy_created_before_interface_added() {
+    block_on(test_proxy_created_before_interface_added()).unwrap();
+}
 
+async fn test_proxy_created_before_interface_added() -> Result<()> {
     #[derive(Debug, Default)]
     struct MyService {
         value: u32,
     }
 
-    #[zbus::interface(name = "org.zbus.TestPropertyBeforeServer")]
+    #[zbus::interface(name = "org.zbus.TestPropBeforeIface")]
     impl MyService {
         #[zbus(property)]
         fn value(&self) -> u32 {
@@ -38,38 +38,26 @@ async fn test_proxy_created_before_server_property() -> Result<()> {
 
     #[zbus::proxy(
         gen_blocking = false,
-        interface = "org.zbus.TestPropertyBeforeServer",
-        default_service = "org.zbus.TestPropertyBeforeServer",
-        default_path = "/org/zbus/TestPropertyBeforeServer"
+        interface = "org.zbus.TestPropBeforeIface",
+        default_service = "org.zbus.TestPropBeforeIface",
+        default_path = "/org/zbus/TestPropBeforeIface"
     )]
     trait MyService {
         #[zbus(property)]
         fn value(&self) -> zbus::Result<u32>;
     }
 
-    // Build the service connection and claim the well-known name WITHOUT
-    // registering the test interface. Access object_server() to ensure
-    // the dispatch task is running so it can respond to incoming calls
-    // with proper errors (UnknownObject/UnknownInterface).
+    // Service connection claims the well-known name *without* registering the test interface.
     let service_conn = zbus::connection::Builder::session()
         .unwrap()
-        .name("org.zbus.TestPropertyBeforeServer")
+        .name("org.zbus.TestPropBeforeIface")
         .unwrap()
         .build()
         .await
         .unwrap();
-    // Start the object server dispatch task so it can reply to method calls.
     let _ = service_conn.object_server();
+    sleep(Duration::from_millis(50)).await;
 
-    // Small delay to ensure the object server dispatch task is ready.
-    #[cfg(feature = "tokio")]
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    #[cfg(not(feature = "tokio"))]
-    async_io::Timer::after(Duration::from_millis(50)).await;
-
-    // Create the client proxy BEFORE the server has the interface.
-    // The proxy's caching task will issue a GetAll call which will fail with
-    // UnknownObject since no interface is registered at the requested path.
     let client_conn = zbus::connection::Builder::session()
         .unwrap()
         .method_timeout(Duration::from_millis(500))
@@ -83,53 +71,176 @@ async fn test_proxy_created_before_server_property() -> Result<()> {
         .await
         .unwrap();
 
-    // Attempt to read the property. This triggers cache.ready().await which
-    // waits for the caching task's GetAll to complete. Since there's no interface
-    // registered, the server replies with an error and the cache stores it.
-    let first_result = proxy.value().await;
-    assert!(
-        first_result.is_err(),
-        "Expected first property read to fail (interface not registered yet), \
-         but it succeeded with value: {:?}",
-        first_result.ok()
-    );
+    // Start a property change stream *before* the interface is registered. After recovery the
+    // stream should receive the value from the repopulated cache.
+    let mut stream = proxy.receive_value_changed().await;
 
-    // Now register the interface on the server.
+    // Initial read fails: cache init failed (UnknownObject) and direct Get also fails.
+    assert!(proxy.value().await.is_err());
+
+    // Register the interface — no NameOwnerChanged, no InterfacesAdded.
     service_conn
         .object_server()
-        .at(
-            "/org/zbus/TestPropertyBeforeServer",
-            MyService { value: 42 },
-        )
+        .at("/org/zbus/TestPropBeforeIface", MyService { value: 42 })
+        .await
+        .unwrap();
+    sleep(Duration::from_millis(50)).await;
+
+    // Direct Get now succeeds and kicks the background populate task.
+    assert_eq!(proxy.value().await.unwrap(), 42);
+
+    // The pre-existing property stream sees the repopulation.
+    let changed = stream.next().await.expect("property stream closed");
+    assert_eq!(changed.get().await.unwrap(), 42);
+
+    // Subsequent reads come from the repopulated cache.
+    sleep(Duration::from_millis(50)).await;
+    assert_eq!(proxy.value().await.unwrap(), 42);
+
+    Ok(())
+}
+
+/// Proxy is created before the *service* connects to the bus at all. The cache recovers via the
+/// `NameOwnerChanged` subscription installed by the background populate task — no `get_property`
+/// kick is required.
+#[test]
+#[timeout(15000)]
+fn proxy_created_before_service_connects() {
+    block_on(test_proxy_created_before_service_connects()).unwrap();
+}
+
+async fn test_proxy_created_before_service_connects() -> Result<()> {
+    #[derive(Debug, Default)]
+    struct MyService {
+        value: u32,
+    }
+
+    #[zbus::interface(name = "org.zbus.TestPropBeforeService")]
+    impl MyService {
+        #[zbus(property)]
+        fn value(&self) -> u32 {
+            self.value
+        }
+    }
+
+    #[zbus::proxy(
+        gen_blocking = false,
+        interface = "org.zbus.TestPropBeforeService",
+        default_service = "org.zbus.TestPropBeforeService",
+        default_path = "/org/zbus/TestPropBeforeService"
+    )]
+    trait MyService {
+        #[zbus(property)]
+        fn value(&self) -> zbus::Result<u32>;
+    }
+
+    let client_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .method_timeout(Duration::from_millis(500))
+        .build()
+        .await
+        .unwrap();
+    let proxy = MyServiceProxy::new(&client_conn).await.unwrap();
+
+    // Start a property change stream before the service exists.
+    let mut stream = proxy.receive_value_changed().await;
+
+    // Cache init fails (name has no owner).
+    assert!(proxy.value().await.is_err());
+
+    // Now bring up the service with the interface already registered. NameOwnerChanged will
+    // fire and wake the populate task — no further get_property calls are made.
+    let service_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .name("org.zbus.TestPropBeforeService")
+        .unwrap()
+        .serve_at("/org/zbus/TestPropBeforeService", MyService { value: 7 })
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    let _ = service_conn.object_server();
+
+    let changed = stream.next().await.expect("property stream closed");
+    assert_eq!(changed.get().await.unwrap(), 7);
+
+    Ok(())
+}
+
+/// Service is already on the bus and exposes an `ObjectManager`, but the test interface is
+/// registered *after* the proxy is created. The cache should recover via the `InterfacesAdded`
+/// signal emitted by the `ObjectManager` — no `get_property` kick required.
+#[test]
+#[timeout(15000)]
+fn proxy_recovers_via_object_manager() {
+    block_on(test_proxy_recovers_via_object_manager()).unwrap();
+}
+
+async fn test_proxy_recovers_via_object_manager() -> Result<()> {
+    #[derive(Debug, Default)]
+    struct MyService {
+        value: u32,
+    }
+
+    #[zbus::interface(name = "org.zbus.TestPropObjMgr")]
+    impl MyService {
+        #[zbus(property)]
+        fn value(&self) -> u32 {
+            self.value
+        }
+    }
+
+    #[zbus::proxy(
+        gen_blocking = false,
+        interface = "org.zbus.TestPropObjMgr",
+        default_service = "org.zbus.TestPropObjMgr",
+        default_path = "/org/zbus/TestPropObjMgr/Obj"
+    )]
+    trait MyService {
+        #[zbus(property)]
+        fn value(&self) -> zbus::Result<u32>;
+    }
+
+    // Service comes up with the well-known name and an `ObjectManager` at the parent path, but
+    // *without* the test interface registered yet.
+    let service_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .name("org.zbus.TestPropObjMgr")
+        .unwrap()
+        .serve_at("/org/zbus/TestPropObjMgr", zbus::fdo::ObjectManager)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    let _ = service_conn.object_server();
+    sleep(Duration::from_millis(50)).await;
+
+    let client_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .method_timeout(Duration::from_millis(500))
+        .build()
+        .await
+        .unwrap();
+    let proxy = MyServiceProxy::new(&client_conn).await.unwrap();
+
+    // Stream opened before the interface exists — should fire once recovery happens.
+    let mut stream = proxy.receive_value_changed().await;
+
+    // Cache init fails: the path/interface is not yet registered.
+    assert!(proxy.value().await.is_err());
+
+    // Now register the interface under the ObjectManager. This emits `InterfacesAdded`, which
+    // the populate task is subscribed to (filtered by our path), waking it up to retry `init`.
+    service_conn
+        .object_server()
+        .at("/org/zbus/TestPropObjMgr/Obj", MyService { value: 99 })
         .await
         .unwrap();
 
-    // Give the server a moment to be ready.
-    #[cfg(feature = "tokio")]
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    #[cfg(not(feature = "tokio"))]
-    async_io::Timer::after(Duration::from_millis(100)).await;
-
-    // Try to read the property again. The interface IS now registered, so a
-    // direct Get call should succeed even though the cache was poisoned.
-    let second_result = proxy.value().await;
-    assert_eq!(
-        second_result.expect("property read should succeed after interface is registered"),
-        42,
-    );
-
-    // Give the cache retry task a moment to repopulate.
-    #[cfg(feature = "tokio")]
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    #[cfg(not(feature = "tokio"))]
-    async_io::Timer::after(Duration::from_millis(100)).await;
-
-    // Subsequent reads should now come from the repopulated cache.
-    let third_result = proxy.value().await;
-    assert_eq!(
-        third_result.expect("property read should use repopulated cache"),
-        42,
-    );
+    // No get_property call between the signal firing and observing the stream update — recovery
+    // must happen purely through the `InterfacesAdded` subscription.
+    let changed = stream.next().await.expect("property stream closed");
+    assert_eq!(changed.get().await.unwrap(), 99);
 
     Ok(())
 }

--- a/zbus/tests/issue/issue_proxy_before_server.rs
+++ b/zbus/tests/issue/issue_proxy_before_server.rs
@@ -1,0 +1,122 @@
+use ntest::timeout;
+use test_log::test;
+use zbus::block_on;
+
+use zbus::Result;
+
+/// Test that demonstrates a bug: if a client proxy is created *before* the server
+/// registers the interface, reading a property from that proxy will always fail,
+/// even after the server interface has been registered.
+///
+/// When the proxy is built with caching enabled (default), the background caching
+/// task issues a GetAll Properties call. If the interface isn't registered yet, the
+/// server responds with UnknownObject/UnknownInterface. This error is stored in the
+/// cache's `CachingResult`. Every subsequent call to `get_property` calls
+/// `cache.ready().await?` which returns the stored error, so the property can never
+/// be read from this proxy instance — even after the interface is properly registered.
+#[test]
+#[timeout(15000)]
+fn proxy_created_before_server_property_fails() {
+    block_on(test_proxy_created_before_server_property()).unwrap();
+}
+
+async fn test_proxy_created_before_server_property() -> Result<()> {
+    use std::time::Duration;
+
+    #[derive(Debug, Default)]
+    struct MyService {
+        value: u32,
+    }
+
+    #[zbus::interface(name = "org.zbus.TestPropertyBeforeServer")]
+    impl MyService {
+        #[zbus(property)]
+        fn value(&self) -> u32 {
+            self.value
+        }
+    }
+
+    #[zbus::proxy(
+        gen_blocking = false,
+        interface = "org.zbus.TestPropertyBeforeServer",
+        default_service = "org.zbus.TestPropertyBeforeServer",
+        default_path = "/org/zbus/TestPropertyBeforeServer"
+    )]
+    trait MyService {
+        #[zbus(property)]
+        fn value(&self) -> zbus::Result<u32>;
+    }
+
+    // Build the service connection and claim the well-known name WITHOUT
+    // registering the test interface. Access object_server() to ensure
+    // the dispatch task is running so it can respond to incoming calls
+    // with proper errors (UnknownObject/UnknownInterface).
+    let service_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .name("org.zbus.TestPropertyBeforeServer")
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    // Start the object server dispatch task so it can reply to method calls.
+    let _ = service_conn.object_server();
+
+    // Small delay to ensure the object server dispatch task is ready.
+    #[cfg(feature = "tokio")]
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    #[cfg(not(feature = "tokio"))]
+    async_io::Timer::after(Duration::from_millis(50)).await;
+
+    // Create the client proxy BEFORE the server has the interface.
+    // The proxy's caching task will issue a GetAll call which will fail with
+    // UnknownObject since no interface is registered at the requested path.
+    let client_conn = zbus::connection::Builder::session()
+        .unwrap()
+        .method_timeout(Duration::from_millis(500))
+        .build()
+        .await
+        .unwrap();
+    let proxy = MyServiceProxy::builder(&client_conn)
+        .destination(service_conn.unique_name().unwrap())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    // Attempt to read the property. This triggers cache.ready().await which
+    // waits for the caching task's GetAll to complete. Since there's no interface
+    // registered, the server replies with an error and the cache stores it.
+    let first_result = proxy.value().await;
+    assert!(
+        first_result.is_err(),
+        "Expected first property read to fail (interface not registered yet), \
+         but it succeeded with value: {:?}",
+        first_result.ok()
+    );
+
+    // Now register the interface on the server.
+    service_conn
+        .object_server()
+        .at(
+            "/org/zbus/TestPropertyBeforeServer",
+            MyService { value: 42 },
+        )
+        .await
+        .unwrap();
+
+    // Give the server a moment to be ready.
+    #[cfg(feature = "tokio")]
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    #[cfg(not(feature = "tokio"))]
+    async_io::Timer::after(Duration::from_millis(100)).await;
+
+    // Try to read the property again. The interface IS now registered and a fresh
+    // Get call would work. But the proxy's cache.ready() still returns the
+    // original error, so this always fails — demonstrating the bug.
+    let second_result = proxy.value().await;
+
+    // BUG: This assertion documents the broken behavior. Once the bug is fixed this should not panic.
+    let _ = second_result.expect("Should return the value after the interface is published");
+
+    Ok(())
+}

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -22,3 +22,5 @@ mod issue_356;
 
 #[cfg(all(unix, feature = "p2p"))]
 mod issue_813;
+
+mod issue_proxy_before_server;


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

When a proxy would be created before the interface that is was targeting would be created, while caching is enabled, the cache would be permanently poisoned. You could solve it by recreating the client but I felt like it could be easier. The main issue is that once cache.ready is invalid it will never recover. An idea I had was that it would fall through to doing a real call even if the cache is invalid and if it succeeds would "refresh" the cache.

Property streams will still not work but at least property gets will, we encountered this while developing and it seemed like  small enough change that might help some people in the future. 

Disclaimer this PR was made with assistance of claude.