### PR TITLE
🐛 zu: Fix GVariant bool alignment

### DIFF
--- a/zvariant/tests/number/bool_value.rs
+++ b/zvariant/tests/number/bool_value.rs
@@ -1,4 +1,6 @@
 use zvariant::LE;
+#[cfg(feature = "gvariant")]
+use zvariant::{serialized::Context, to_bytes};
 
 #[test]
 fn bool_value() {
@@ -10,4 +12,14 @@ fn bool_value() {
         let gvariant = basic_type_test!(LE, GVariant, true, 1, bool, 1, Bool, 3);
         assert_eq!(*gvariant.bytes(), [1]);
     }
+}
+
+#[test]
+#[cfg(feature = "gvariant")]
+fn bool_maybe_array_value() {
+    let ctxt = Context::new_gvariant(LE, 0);
+    let encoded = to_bytes(ctxt, &vec![Some(true); 3]).unwrap();
+    assert_eq!(encoded.bytes(), b"\x01\x01\x01\x01\x02\x03");
+    let decoded: Vec<Option<bool>> = encoded.deserialize().unwrap().0;
+    assert_eq!(decoded, vec![Some(true); 3]);
 }

--- a/zvariant_utils/src/signature/mod.rs
+++ b/zvariant_utils/src/signature/mod.rs
@@ -294,6 +294,7 @@ impl Signature {
         use std::cmp::max;
 
         match self {
+            Signature::Bool => 1,
             Signature::Unit
             | Signature::U8
             | Signature::I16
@@ -301,7 +302,6 @@ impl Signature {
             | Signature::I32
             | Signature::U32
             | Signature::F64
-            | Signature::Bool
             | Signature::I64
             | Signature::U64
             | Signature::Signature => self.alignment_dbus(),


### PR DESCRIPTION
In GVariant, the boolean type has an alignment of 1, not 4.

<https://developer.gnome.org/documentation/specifications/gvariant-specification-1.0.html#booleans>

> A boolean has a fixed size of 1 and an alignment of 1.

This means that the elements of `amb` should be packed tightly like this:

```console
$ python
>>> from gi.repository import GLib
>>> GLib.Variant.parse(None, '[just true, true, true]').get_data_as_bytes().get_data()
b'\x01\x01\x01\x01\x02\x03'
```
