### PR TITLE
🐛 zv: Add tail padding to fixed-size struct in GVariant encoding

### DIFF
--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -769,6 +769,12 @@ impl<'d, 'de, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> SeqAccess<'de
             // All fields have been deserialized.
             self.de.0.container_depths = self.de.0.container_depths.dec_structure();
 
+            if self.de.0.signature.is_fixed_sized() {
+                debug_assert_eq!(self.offsets_len, 0);
+                let alignment = self.de.0.signature.alignment(Format::GVariant);
+                self.de.0.parse_padding(alignment)?;
+            }
+
             // Skip over the framing offsets (if any)
             self.de.0.pos += self.offsets_len;
         }

--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -638,6 +638,11 @@ impl<'d, 'de, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> MapAccess<'de
         self.de.0.pos += de.0.pos;
         // No need for retaking the container depths as the value can't be incomplete.
 
+        // A fixed-sized dictionary entry should be padded to its alignment.
+        if self.offsets.is_none() {
+            self.de.0.parse_padding(self.element_alignment)?;
+        }
+
         if let Some(key_offset_size) = self.key_offset_size {
             self.de.0.pos += key_offset_size as usize;
         }

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -728,6 +728,11 @@ where
         value.serialize(&mut *self.seq.ser)?;
         self.seq.ser.0.signature = self.key_signature;
 
+        // A fixed-sized dictionary entry should be padded to its alignment.
+        if self.seq.offsets.is_none() {
+            self.seq.ser.0.add_padding(self.seq.element_alignment)?;
+        }
+
         if let Some(key_offset) = key_offset {
             let entry_size = self.seq.ser.0.bytes_written - self.key_start.unwrap_or(0);
             let offset_size = FramingOffsetSize::for_encoded_container(entry_size);

--- a/zvariant/src/gvariant/ser.rs
+++ b/zvariant/src/gvariant/ser.rs
@@ -603,6 +603,13 @@ where
             Some(offsets) => offsets,
             None => return Ok(()),
         };
+
+        if self.ser.0.signature.is_fixed_sized() {
+            debug_assert!(offsets.is_empty());
+            let alignment = self.ser.0.signature.alignment(Format::GVariant);
+            self.ser.0.add_padding(alignment)?;
+        }
+
         let struct_len = self.ser.0.bytes_written - self.start;
         if struct_len == 0 {
             // Empty sequence

--- a/zvariant/tests/dict_value.rs
+++ b/zvariant/tests/dict_value.rs
@@ -114,6 +114,32 @@ fn dict_value() {
     }
     let ctxt = Context::new_dbus(NATIVE_ENDIAN, 0);
 
+    // Dict<u32, u8>
+    let mut map: HashMap<u32, u8> = HashMap::new();
+    map.insert(1, 2);
+    let encoded = to_bytes(ctxt, &map).unwrap();
+    assert_eq!(
+        encoded.bytes(),
+        [
+            0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02
+        ]
+    );
+    let decoded: HashMap<u32, u8> = encoded.deserialize().unwrap().0;
+    assert_eq!(decoded, map);
+
+    // GVariant format now
+    #[cfg(feature = "gvariant")]
+    {
+        let ctxt = Context::new_gvariant(NATIVE_ENDIAN, 0);
+        let encoded = to_bytes(ctxt, &map).unwrap();
+        assert_eq!(
+            encoded.bytes(),
+            [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
+        );
+        let map: HashMap<u32, u8> = encoded.deserialize().unwrap().0;
+        assert_eq!(decoded, map);
+    }
+
     // Now a hand-crafted Dict Value but with a Value as value
     let mut dict = Dict::new(<&str>::SIGNATURE, Value::SIGNATURE);
     dict.add("hello", Value::new("there")).unwrap();

--- a/zvariant/tests/struct_value.rs
+++ b/zvariant/tests/struct_value.rs
@@ -35,6 +35,25 @@ fn struct_value() {
     let decoded: as_value::Deserialize<'_, Foo> = encoded.deserialize().unwrap().0;
     assert_eq!(decoded.0, foo);
 
+    // A struct with underaligned tail.
+    let foo: (u32, u8) = (u32::MAX, 0x40);
+    let encoded = to_bytes(ctxt, &foo).unwrap();
+    assert_eq!(encoded.bytes(), [0xff, 0xff, 0xff, 0xff, 0x40]);
+    let decoded: (u32, u8) = encoded.deserialize().unwrap().0;
+    assert_eq!(decoded, foo);
+
+    #[cfg(feature = "gvariant")]
+    {
+        let ctxt = Context::new_gvariant(LE, 0);
+        let encoded = to_bytes(ctxt, &foo).unwrap();
+        assert_eq!(
+            encoded.bytes(),
+            [0xff, 0xff, 0xff, 0xff, 0x40, 0x00, 0x00, 0x00]
+        );
+        let decoded: (u32, u8) = encoded.deserialize().unwrap().0;
+        assert_eq!(decoded, foo);
+    }
+
     // Unit struct should be treated as a 0-sized tuple (the same as unit type)
     #[derive(Serialize, Deserialize, Type, PartialEq, Debug)]
     struct Unit;


### PR DESCRIPTION
<https://developer.gnome.org/documentation/specifications/gvariant-specification-1.0.html#structures>

> If all of the items contained in a structure are fixed-size then the structure itself is fixed- size. Considerations have to be made to satisfy the constraints that are placed on the value of this fixed size.

> [..] the fixed sized must be a multiple of the alignment of the structure. This is accomplished by adding zero-filled padding bytes to the end of any fixed-width structure until this property becomes true.

```console
$ python
>>> from gi.repository import GLib
>>> GLib.Variant.parse(None, '{uint32 0xffffffff: byte 0xa0}').get_data_as_bytes().get_data()
b'\xff\xff\xff\xff\xa0\x00\x00\x00'
>>> GLib.Variant.parse(None, '(uint32 0xffffffff, byte 0xa0)').get_data_as_bytes().get_data()
b'\xff\xff\xff\xff\xa0\x00\x00\x00'
```
