### PR TITLE
🐛 zv: Don't double-wrap variant-typed fields in as_value

### DIFF
--- a/zvariant/src/as_value/deserialize.rs
+++ b/zvariant/src/as_value/deserialize.rs
@@ -30,6 +30,13 @@ impl<'de, T: Type + serde::Deserialize<'de>> serde::Deserialize<'de> for Deseria
     where
         D: Deserializer<'de>,
     {
+        // `Value`/`OwnedValue` (and any other type whose signature is already `v`) deserialize
+        // themselves from a variant, so the extra unwrapping below would expect a
+        // variant-of-variant. Just delegate to their own `Deserialize` impl in that case.
+        if T::SIGNATURE == &Signature::Variant {
+            return Ok(Deserialize(T::deserialize(deserializer)?, PhantomData));
+        }
+
         const FIELDS: &[&str] = &["signature", "value"];
         Ok(Deserialize(
             deserializer.deserialize_struct(

--- a/zvariant/src/as_value/serialize.rs
+++ b/zvariant/src/as_value/serialize.rs
@@ -1,6 +1,6 @@
 use serde::ser::{SerializeStruct, Serializer};
 
-use crate::Type;
+use crate::{Signature, Type};
 
 /// A wrapper to serialize `T: Type + serde::Serialize` as a value.
 ///
@@ -20,6 +20,13 @@ impl<T: Type + serde::Serialize> serde::Serialize for Serialize<'_, T> {
     where
         S: Serializer,
     {
+        // `Value`/`OwnedValue` (and any other type whose signature is already `v`) serialize
+        // themselves as a variant, so wrapping them here would emit a variant-of-variant. Just
+        // delegate to their own `Serialize` impl in that case.
+        if T::SIGNATURE == &Signature::Variant {
+            return self.0.serialize(serializer);
+        }
+
         // Serializer implementation needs to ensure padding isn't added for Value.
         let mut structure = serializer.serialize_struct("Variant", 2)?;
 

--- a/zvariant/tests/dict_value.rs
+++ b/zvariant/tests/dict_value.rs
@@ -341,39 +341,66 @@ fn nested_dict_value() {
             media,
         }
     );
-}
 
-#[test]
-fn owned_value_field_in_dict() {
+    // A different shape of nesting (https://github.com/z-galaxy/zbus/issues/1819): an outer
+    // `a{sv}` (so the value type is `v`) where one variant value is itself an `a{sv}`. Unlike
+    // `Interfaces` above, the outer value type here is `v`, so each field is wrapped in a
+    // variant on the wire.
     use zvariant::OwnedValue;
 
-    let ctxt = Context::new_dbus(NATIVE_ENDIAN, 0);
-
-    // A `Value`/`OwnedValue`-typed field in an `a{sv}` `*Dict` struct must capture the variant
-    // value verbatim, without an extra variant-of-variant wrapping layer. Regression test for
-    // https://github.com/z-galaxy/zbus/issues/1819.
     #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
     #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
-    struct Info {
+    struct InspectBundleUpdateInfo {
+        compatible: Option<bool>,
+        version: Option<String>,
+    }
+
+    // The reporter's case: the nested `a{sv}` is modelled as a typed `*Dict` struct field.
+    #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
+    #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
+    struct InspectBundleInfo {
         manifest_hash: Option<String>,
-        // The value behind this key is itself an `a{sv}` variant.
+        update: Option<InspectBundleUpdateInfo>,
+    }
+
+    // The same, but capturing the nested variant verbatim as an `OwnedValue` field.
+    #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
+    #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
+    struct InspectBundleInfoRaw {
+        manifest_hash: Option<String>,
         update: Option<OwnedValue>,
     }
 
-    // Build the wire data the way an external producer would: an `a{sv}` whose `update` key holds
-    // a variant containing another `a{sv}`.
-    let mut update: HashMap<&str, Value<'_>> = HashMap::new();
-    update.insert("compatible", Value::new(true));
-    update.insert("version", Value::new("1.0"));
+    let info = InspectBundleInfo {
+        manifest_hash: Some("abc".to_string()),
+        update: Some(InspectBundleUpdateInfo {
+            compatible: Some(true),
+            version: Some("1.0".to_string()),
+        }),
+    };
 
-    let mut outer: HashMap<&str, Value<'_>> = HashMap::new();
-    outer.insert("manifest-hash", Value::new("abc"));
-    outer.insert("update", Value::Dict(Dict::from(update)));
+    // Typed-struct field: round-trips through the derives.
+    let encoded = to_bytes(ctxt, &info).unwrap();
+    let decoded: InspectBundleInfo = encoded.deserialize().unwrap().0;
+    assert_eq!(decoded, info);
 
-    let encoded = to_bytes(ctxt, &outer).unwrap();
-    let decoded: Info = encoded.deserialize().unwrap().0;
-    assert_eq!(decoded.manifest_hash.as_deref(), Some("abc"));
-    let update = decoded.update.as_ref().unwrap();
+    // And it decodes from data produced the way a real D-Bus peer would send it: an `a{sv}`
+    // whose `update` key holds a variant containing another `a{sv}`.
+    let mut update_props: HashMap<&str, Value<'_>> = HashMap::new();
+    update_props.insert("compatible", Value::new(true));
+    update_props.insert("version", Value::new("1.0"));
+    let mut info_props: HashMap<&str, Value<'_>> = HashMap::new();
+    info_props.insert("manifest-hash", Value::new("abc"));
+    info_props.insert("update", Value::Dict(Dict::from(update_props)));
+    let map_encoded = to_bytes(ctxt, &info_props).unwrap();
+    let from_map: InspectBundleInfo = map_encoded.deserialize().unwrap().0;
+    assert_eq!(from_map, info);
+
+    // `OwnedValue` field: must capture the nested `a{sv}` variant verbatim, without an extra
+    // variant-of-variant layer (the bug fixed in #1819).
+    let raw: InspectBundleInfoRaw = map_encoded.deserialize().unwrap().0;
+    assert_eq!(raw.manifest_hash.as_deref(), Some("abc"));
+    let update = raw.update.as_ref().unwrap();
     assert_eq!(update.value_signature(), "a{sv}");
     let update_dict = update.downcast_ref::<&Dict<'_, '_>>().unwrap();
     assert_eq!(
@@ -384,13 +411,13 @@ fn owned_value_field_in_dict() {
         true
     );
 
-    // And the round-trip through the derived `SerializeDict` must not double-wrap the variant.
-    let reencoded = to_bytes(ctxt, &decoded).unwrap();
-    let redecoded: Info = reencoded.deserialize().unwrap().0;
-    assert_eq!(redecoded, decoded);
-    // The re-serialized bytes are still readable as a plain `a{sv}` map.
-    let as_map: HashMap<String, Value<'_>> = reencoded.deserialize().unwrap().0;
-    assert_eq!(as_map["update"].value_signature(), "a{sv}");
+    // Re-serializing the `OwnedValue` field must not double-wrap it: the bytes still read back
+    // both as the same raw struct and as the typed-struct view.
+    let reencoded = to_bytes(ctxt, &raw).unwrap();
+    let raw_again: InspectBundleInfoRaw = reencoded.deserialize().unwrap().0;
+    assert_eq!(raw_again, raw);
+    let typed_again: InspectBundleInfo = reencoded.deserialize().unwrap().0;
+    assert_eq!(typed_again, info);
 }
 
 #[test]

--- a/zvariant/tests/dict_value.rs
+++ b/zvariant/tests/dict_value.rs
@@ -344,6 +344,56 @@ fn nested_dict_value() {
 }
 
 #[test]
+fn owned_value_field_in_dict() {
+    use zvariant::OwnedValue;
+
+    let ctxt = Context::new_dbus(NATIVE_ENDIAN, 0);
+
+    // A `Value`/`OwnedValue`-typed field in an `a{sv}` `*Dict` struct must capture the variant
+    // value verbatim, without an extra variant-of-variant wrapping layer. Regression test for
+    // https://github.com/z-galaxy/zbus/issues/1819.
+    #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
+    #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
+    struct Info {
+        manifest_hash: Option<String>,
+        // The value behind this key is itself an `a{sv}` variant.
+        update: Option<OwnedValue>,
+    }
+
+    // Build the wire data the way an external producer would: an `a{sv}` whose `update` key holds
+    // a variant containing another `a{sv}`.
+    let mut update: HashMap<&str, Value<'_>> = HashMap::new();
+    update.insert("compatible", Value::new(true));
+    update.insert("version", Value::new("1.0"));
+
+    let mut outer: HashMap<&str, Value<'_>> = HashMap::new();
+    outer.insert("manifest-hash", Value::new("abc"));
+    outer.insert("update", Value::Dict(Dict::from(update)));
+
+    let encoded = to_bytes(ctxt, &outer).unwrap();
+    let decoded: Info = encoded.deserialize().unwrap().0;
+    assert_eq!(decoded.manifest_hash.as_deref(), Some("abc"));
+    let update = decoded.update.as_ref().unwrap();
+    assert_eq!(update.value_signature(), "a{sv}");
+    let update_dict = update.downcast_ref::<&Dict<'_, '_>>().unwrap();
+    assert_eq!(
+        update_dict
+            .get::<&str, bool>(&"compatible")
+            .unwrap()
+            .unwrap(),
+        true
+    );
+
+    // And the round-trip through the derived `SerializeDict` must not double-wrap the variant.
+    let reencoded = to_bytes(ctxt, &decoded).unwrap();
+    let redecoded: Info = reencoded.deserialize().unwrap().0;
+    assert_eq!(redecoded, decoded);
+    // The re-serialized bytes are still readable as a plain `a{sv}` map.
+    let as_map: HashMap<String, Value<'_>> = reencoded.deserialize().unwrap().0;
+    assert_eq!(as_map["update"].value_signature(), "a{sv}");
+}
+
+#[test]
 fn nested_dict_object_path_keys() {
     let ctxt = Context::new_dbus(NATIVE_ENDIAN, 0);
 


### PR DESCRIPTION
`as_value::Serialize`/`Deserialize` always wrapped/unwrapped an extra
variant layer around the value. For a concrete type `T` that's correct,
but `Value`/`OwnedValue` (and anything else whose signature is already
`v`) (de)serialize themselves as a variant. The extra layer meant:

- serializing emitted a variant-of-variant on the wire, and
- deserializing expected a variant-of-variant, failing with
  `invalid value: string "a{sv}", expected the value signature`.

This broke using a `Value`/`OwnedValue` field inside an `a{sv}`
`*Dict` struct (a natural way to capture a nested `a{sv}` variant
verbatim). When `T::SIGNATURE` is already `Variant`, delegate to `T`'s
own `Serialize`/`Deserialize` impl instead of adding the wrapper.

Fixes #1819.