### PR TITLE
✨ zb: Make the tokio and async-io features additive

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,6 +113,11 @@ jobs:
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --tests -p zbus --no-default-features \
               --features tokio-vsock -- --skip fdpass_systemd
+          # Test tokio and async-io enabled together (additive features): the backend is then
+          # chosen at run time. `vsock` is included as it pulls in `async-io` alongside `tokio`.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose -p zbus --features tokio,p2p,vsock \
+              -- --skip fdpass_systemd
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --doc --no-default-features connection::Connection::executor
           # zvariant only with ostree tests (which implicitly enables `gvariant` feature too).

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -42,12 +42,9 @@ For example to create a bus-less peer-to-peer connection on Unix, you can do:
 ```rust,noplayground
 # #[tokio::main]
 # async fn main() -> zbus::Result<()> {
-# #[cfg(unix)]
+# #[cfg(all(unix, feature = "async-io"))]
 # {
-#[cfg(not(feature = "tokio"))]
 use std::os::unix::net::UnixStream;
-#[cfg(feature = "tokio")]
-use tokio::net::UnixStream;
 use zbus::{connection::Builder, Guid};
 
 let guid = Guid::generate();
@@ -55,15 +52,21 @@ let (p0, p1) = UnixStream::pair().unwrap();
 # #[allow(unused)]
 let (client_conn, server_conn) = futures_util::try_join!(
     // Client
-    Builder::unix_stream(p0).p2p().build(),
+    Builder::async_io_unix_stream(p0).p2p().build(),
     // Server
-    Builder::unix_stream(p1).server(guid)?.p2p().build(),
+    Builder::async_io_unix_stream(p1).server(guid)?.p2p().build(),
 )?;
 # }
 #
 # Ok(())
 # }
 ```
+
+`async_io_unix_stream` (and `async_io_tcp_stream`) take a [`std::os::unix::net::UnixStream`]. With `tokio`
+enabled you can instead pass a [`tokio::net::UnixStream`] to `unix_stream`.
+
+[`std::os::unix::net::UnixStream`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html
+[`tokio::net::UnixStream`]: https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html
 
 **Note:** the `p2p` and `server` methods of `connection::Builder` are only available when `p2p`
 cargo feature of `zbus` is enabled.

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -166,6 +166,15 @@ feature:
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 ```
 
+Disabling `async-io` is recommended but not required. When both features are enabled, zbus picks the
+runtime at run time: it uses tokio when a tokio runtime is driving the current thread, and falls back
+to `async-io` otherwise. This keeps the features additive, so an `async-io`-based application keeps
+working even when another crate in the workspace enables zbus's `tokio` feature.
+
+This run-time selection applies to the async API. The blocking API (`zbus::blocking`) drives its
+connections through its own `block_on`, which uses tokio whenever the `tokio` feature is enabled, so
+those connections always run on tokio when that feature is on.
+
 **Note**: On Windows, the `async-io` feature is currently required for UNIX domain socket support,
 see [the corresponding tokio issue on GitHub][tctiog].
 

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -38,7 +38,7 @@ async-io = [
     "blocking",
 ]
 tokio = ["dep:tokio"]
-vsock = ["dep:vsock", "dep:async-io"]
+vsock = ["dep:vsock", "async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 # Enable blocking API (default).
 blocking-api = ["zbus_macros/blocking-api"]

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -128,6 +128,16 @@ zbus = { version = "5", default-features = false, features = ["tokio"] }
 That's it! No threads launched behind your back by zbus (directly or indirectly) now and no need to
 tick any executors etc. 😼
 
+The `tokio` and `async-io` features are additive: when both are enabled (for example, because
+another crate in your dependency tree enables `tokio`), zbus selects the runtime at run time — using
+tokio when a tokio runtime is driving the current thread, and `async-io` otherwise. With only the
+`tokio` feature enabled (i.e. `async-io` disabled), zbus must be used from a thread running a tokio
+runtime, as there is no `async-io` fallback to drive its I/O.
+
+This run-time selection applies to the async API. The blocking API (`zbus::blocking`) drives its
+connections through its own `block_on`, which uses tokio whenever the `tokio` feature is enabled, so
+those connections always run on tokio when that feature is on.
+
 **Note**: On Windows, the `async-io` feature is currently required for UNIX domain socket support,
 see [the corresponding tokio issue on GitHub][tctiog].
 

--- a/zbus/src/abstractions/async_lock.rs
+++ b/zbus/src/abstractions/async_lock.rs
@@ -1,30 +1,30 @@
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 pub(crate) use async_lock::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 pub(crate) use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// An abstraction over async semaphore API.
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 pub(crate) struct Semaphore(async_lock::Semaphore);
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 pub(crate) struct Semaphore(tokio::sync::Semaphore);
 
 impl Semaphore {
     pub const fn new(permits: usize) -> Self {
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         let semaphore = async_lock::Semaphore::new(permits);
-        #[cfg(feature = "tokio")]
+        #[cfg(all(feature = "tokio", not(feature = "async-io")))]
         let semaphore = tokio::sync::Semaphore::const_new(permits);
 
         Self(semaphore)
     }
 
     pub async fn acquire(&self) -> SemaphorePermit<'_> {
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         {
             self.0.acquire().await
         }
-        #[cfg(feature = "tokio")]
+        #[cfg(all(feature = "tokio", not(feature = "async-io")))]
         {
             // SAFETY: Since we never explicitly close the sempaphore, `acquire` can't fail.
             self.0.acquire().await.unwrap()
@@ -32,7 +32,7 @@ impl Semaphore {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 pub(crate) type SemaphorePermit<'a> = async_lock::SemaphoreGuard<'a>;
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 pub(crate) type SemaphorePermit<'a> = tokio::sync::SemaphorePermit<'a>;

--- a/zbus/src/abstractions/executor.rs
+++ b/zbus/src/abstractions/executor.rs
@@ -80,7 +80,7 @@ impl Executor<'_> {
 
     /// Runs a single task.
     ///
-    /// With `tokio` feature enabled, its a noop and never returns.
+    /// With `tokio` feature enabled, it's a noop and never returns.
     pub async fn tick(&self) {
         #[cfg(not(feature = "tokio"))]
         {

--- a/zbus/src/abstractions/executor.rs
+++ b/zbus/src/abstractions/executor.rs
@@ -1,8 +1,12 @@
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_executor::Executor as AsyncExecutor;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_task::Task as AsyncTask;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "tokio")]
+use std::io::Error;
+#[cfg(not(feature = "async-io"))]
+use std::marker::PhantomData;
+#[cfg(feature = "async-io")]
 use std::sync::Arc;
 use std::{
     future::Future,
@@ -11,8 +15,6 @@ use std::{
     task::{Context, Poll},
 };
 #[cfg(feature = "tokio")]
-use std::{future::pending, io::Error, marker::PhantomData};
-#[cfg(feature = "tokio")]
 use tokio::task::JoinHandle;
 
 /// A wrapper around the underlying runtime/executor.
@@ -20,16 +22,12 @@ use tokio::task::JoinHandle;
 /// This is used to run asynchronous tasks internally and allows integration with various runtimes.
 /// See [`crate::Connection::executor`] for an example of integration with external runtimes.
 ///
-/// **Note:** You can (and should) completely ignore this type when building with `tokio` feature
-/// enabled.
-#[cfg(not(feature = "tokio"))]
+/// **Note:** You can (and should) completely ignore this type when the `tokio` backend is in use.
 #[derive(Debug, Clone)]
 pub struct Executor<'a> {
-    executor: Arc<AsyncExecutor<'a>>,
-}
-#[cfg(feature = "tokio")]
-#[derive(Debug, Clone)]
-pub struct Executor<'a> {
+    #[cfg(feature = "async-io")]
+    async_io: Option<Arc<AsyncExecutor<'a>>>,
+    #[cfg(not(feature = "async-io"))]
     phantom: PhantomData<&'a ()>,
 }
 
@@ -41,87 +39,91 @@ impl Executor<'_> {
         future: impl Future<Output = T> + Send + 'static,
         #[allow(unused)] name: &str,
     ) -> Task<T> {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Task(Some(self.executor.spawn(future)))
+        #[cfg(feature = "async-io")]
+        if let Some(executor) = &self.async_io {
+            return Task::from_async_io(executor.spawn(future));
         }
 
         #[cfg(feature = "tokio")]
-        {
-            #[cfg(tokio_unstable)]
-            {
-                Task(Some(
-                    tokio::task::Builder::new()
-                        .name(name)
-                        .spawn(future)
-                        // SAFETY: Looking at the code, this call always returns an `Ok`.
-                        .unwrap(),
-                ))
-            }
-            #[cfg(not(tokio_unstable))]
-            {
-                Task(Some(tokio::task::spawn(future)))
-            }
-        }
+        return Task::from_tokio(tokio_spawn(future, name));
+
+        #[cfg(all(feature = "async-io", not(feature = "tokio")))]
+        unreachable!("async-io executor is always `Some` when tokio is disabled")
     }
 
     /// Return `true` if there are no unfinished tasks.
     ///
-    /// With `tokio` feature enabled, this always returns `true`.
+    /// With the `tokio` backend in use, this always returns `true`.
     pub fn is_empty(&self) -> bool {
-        #[cfg(not(feature = "tokio"))]
-        {
-            self.executor.is_empty()
+        #[cfg(feature = "async-io")]
+        if let Some(executor) = &self.async_io {
+            return executor.is_empty();
         }
 
-        #[cfg(feature = "tokio")]
         true
     }
 
     /// Runs a single task.
     ///
-    /// With `tokio` feature enabled, it's a noop and never returns.
+    /// With the `tokio` backend in use, it's a noop and never returns.
     pub async fn tick(&self) {
-        #[cfg(not(feature = "tokio"))]
-        {
-            self.executor.tick().await
+        #[cfg(feature = "async-io")]
+        if let Some(executor) = &self.async_io {
+            executor.tick().await;
+            // Skip the `tokio` branch below (only present when both backends are compiled in).
+            #[cfg(feature = "tokio")]
+            return;
         }
 
         #[cfg(feature = "tokio")]
-        {
-            pending().await
-        }
+        std::future::pending::<()>().await;
     }
 
     /// Create a new `Executor`.
     pub(crate) fn new() -> Self {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Self {
-                executor: Arc::new(AsyncExecutor::new()),
-            }
+        Self {
+            #[cfg(feature = "async-io")]
+            async_io: (!super::use_tokio()).then(|| Arc::new(AsyncExecutor::new())),
+            #[cfg(not(feature = "async-io"))]
+            phantom: PhantomData,
         }
+    }
 
-        #[cfg(feature = "tokio")]
-        {
-            Self {
-                phantom: PhantomData,
-            }
-        }
+    /// Whether this executor needs an external driver thread (only the `async-io` backend does).
+    #[cfg(feature = "async-io")]
+    pub(crate) fn needs_internal_driver(&self) -> bool {
+        self.async_io.is_some()
     }
 
     /// Runs the executor until the given future completes.
     ///
-    /// With `tokio` feature enabled, it just awaits on the `future`.
+    /// With the `tokio` backend in use, it just awaits on the `future`.
     pub(crate) async fn run<T>(&self, future: impl Future<Output = T>) -> T {
-        #[cfg(not(feature = "tokio"))]
-        {
-            self.executor.run(future).await
+        #[cfg(feature = "async-io")]
+        if let Some(executor) = &self.async_io {
+            return executor.run(future).await;
         }
-        #[cfg(feature = "tokio")]
-        {
-            future.await
-        }
+
+        future.await
+    }
+}
+
+#[cfg(feature = "tokio")]
+fn tokio_spawn<T: Send + 'static>(
+    future: impl Future<Output = T> + Send + 'static,
+    #[allow(unused)] name: &str,
+) -> JoinHandle<T> {
+    #[cfg(tokio_unstable)]
+    {
+        tokio::task::Builder::new()
+            .name(name)
+            .spawn(future)
+            // SAFETY: Looking at the code, this call always returns an `Ok`.
+            .unwrap()
+    }
+    #[cfg(not(tokio_unstable))]
+    {
+        tokio::task::spawn(future)
     }
 }
 
@@ -132,28 +134,46 @@ impl Executor<'_> {
 /// * it will be cancelled, rather than detached. For detaching, use the `detach` method.
 /// * errors from the task cancellation will will be ignored. If you need to know about task errors,
 ///   convert the task to a `FallibleTask` using the `fallible` method.
-#[cfg(not(feature = "tokio"))]
 #[doc(hidden)]
 #[derive(Debug)]
-pub struct Task<T>(Option<AsyncTask<T>>);
-#[cfg(feature = "tokio")]
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct Task<T>(Option<JoinHandle<T>>);
+pub struct Task<T> {
+    #[cfg(feature = "async-io")]
+    async_io: Option<AsyncTask<T>>,
+    #[cfg(feature = "tokio")]
+    tokio: Option<JoinHandle<T>>,
+}
 
 impl<T> Task<T> {
+    #[cfg(feature = "async-io")]
+    fn from_async_io(task: AsyncTask<T>) -> Self {
+        Self {
+            async_io: Some(task),
+            #[cfg(feature = "tokio")]
+            tokio: None,
+        }
+    }
+
+    #[cfg(feature = "tokio")]
+    fn from_tokio(handle: JoinHandle<T>) -> Self {
+        Self {
+            #[cfg(feature = "async-io")]
+            async_io: None,
+            tokio: Some(handle),
+        }
+    }
+
     /// Detaches the task to let it keep running in the background.
     #[allow(unused_mut)]
-    #[allow(unused)]
     pub fn detach(mut self) {
-        #[cfg(not(feature = "tokio"))]
-        {
-            self.0.take().expect("async_task::Task is none").detach()
+        #[cfg(feature = "async-io")]
+        if let Some(task) = self.async_io.take() {
+            task.detach();
         }
 
         #[cfg(feature = "tokio")]
-        {
-            self.0.take().expect("tokio::task::JoinHandle is none");
+        if let Some(handle) = self.tokio.take() {
+            // Dropping a tokio `JoinHandle` detaches it.
+            drop(handle);
         }
     }
 }
@@ -163,43 +183,46 @@ where
     T: Send + 'static,
 {
     /// Launch the given blocking function in a task.
+    ///
+    /// `blocking::unblock` needs no runtime, so async-io's pool is used unless a tokio runtime is
+    /// active.
     #[allow(unused)]
     pub(crate) fn spawn_blocking<F>(f: F, #[allow(unused)] name: &str) -> Self
     where
         F: FnOnce() -> T + Send + 'static,
     {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Self(Some(blocking::unblock(f)))
+        super::select_runtime! {
+            tokio: Self::from_tokio(tokio_spawn_blocking(f, name)),
+            async_io: Self::from_async_io(blocking::unblock(f)),
         }
+    }
+}
 
-        #[cfg(feature = "tokio")]
-        {
-            #[cfg(tokio_unstable)]
-            {
-                Self(Some(
-                    tokio::task::Builder::new()
-                        .name(name)
-                        .spawn_blocking(f)
-                        // SAFETY: Looking at the code, this call always returns an `Ok`.
-                        .unwrap(),
-                ))
-            }
-            #[cfg(not(tokio_unstable))]
-            {
-                Self(Some(tokio::task::spawn_blocking(f)))
-            }
-        }
+#[cfg(feature = "tokio")]
+fn tokio_spawn_blocking<F, T>(f: F, #[allow(unused)] name: &str) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    #[cfg(tokio_unstable)]
+    {
+        tokio::task::Builder::new()
+            .name(name)
+            .spawn_blocking(f)
+            // SAFETY: Looking at the code, this call always returns an `Ok`.
+            .unwrap()
+    }
+    #[cfg(not(tokio_unstable))]
+    {
+        tokio::task::spawn_blocking(f)
     }
 }
 
 impl<T> Drop for Task<T> {
     fn drop(&mut self) {
         #[cfg(feature = "tokio")]
-        {
-            if let Some(join_handle) = self.0.take() {
-                join_handle.abort();
-            }
+        if let Some(join_handle) = self.tokio.take() {
+            join_handle.abort();
         }
     }
 }
@@ -208,24 +231,16 @@ impl<T> Future for Task<T> {
     type Output = Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Pin::new(&mut self.get_mut().0.as_mut().expect("async_task::Task is none"))
-                .poll(cx)
-                .map(|r| Ok(r))
+        let this = self.get_mut();
+
+        #[cfg(feature = "async-io")]
+        if let Some(task) = &mut this.async_io {
+            return Pin::new(task).poll(cx).map(Ok);
         }
 
         #[cfg(feature = "tokio")]
-        {
-            Pin::new(
-                &mut self
-                    .get_mut()
-                    .0
-                    .as_mut()
-                    .expect("tokio::task::JoinHandle is none"),
-            )
-            .poll(cx)
-            .map(|r| match r {
+        if let Some(handle) = &mut this.tokio {
+            return Pin::new(handle).poll(cx).map(|r| match r {
                 Ok(v) => Ok(v),
                 Err(e) => {
                     if e.is_cancelled() {
@@ -234,7 +249,9 @@ impl<T> Future for Task<T> {
                         panic!("tokio::task::JoinHandle error: {e}")
                     }
                 }
-            })
+            });
         }
+
+        unreachable!("Task always has exactly one backend")
     }
 }

--- a/zbus/src/abstractions/mod.rs
+++ b/zbus/src/abstractions/mod.rs
@@ -64,3 +64,16 @@ pub(crate) mod timeout;
 // Not unix-specific itself but only used on unix.
 #[cfg(target_family = "unix")]
 pub(crate) mod process;
+
+#[cfg(all(test, feature = "tokio", feature = "async-io"))]
+mod tests {
+    #[test]
+    fn use_tokio_reflects_active_runtime() {
+        assert!(!super::use_tokio(), "no runtime is active here");
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        assert!(
+            runtime.block_on(async { super::use_tokio() }),
+            "a tokio runtime is active",
+        );
+    }
+}

--- a/zbus/src/abstractions/mod.rs
+++ b/zbus/src/abstractions/mod.rs
@@ -1,7 +1,59 @@
-/// This mod contains a bunch of abstractions.
+//! This mod contains a bunch of abstractions.
+//!
+//! These abstractions allow us to make use of the appropriate API depending on which features are
+//! enabled.
+
+/// Evaluates the `tokio` or `async-io` expression for the active backend.
 ///
-/// These abstractions allow us to make use of the appropriate API depending on which features are
-/// enabled.
+/// With a single backend it resolves to that backend's expression at compile time; with both it
+/// picks at runtime via [`use_tokio`]. The inactive arm is `cfg`-stripped, so each arm only needs
+/// to be valid in the configurations where its backend is compiled in.
+///
+/// The choice is re-evaluated on every call, so this is only safe where it doesn't need to match a
+/// particular connection's backend. A connection latches its backend once at build time (see
+/// [`Executor::new`]); use that instead of this macro for anything tied to the socket's reactor.
+/// The current call sites (timers, the blocking pool) are independent of the socket, so a per-call
+/// decision is fine.
+macro_rules! select_runtime {
+    (tokio: $tokio:expr, async_io: $async_io:expr $(,)?) => {{
+        #[cfg(all(feature = "tokio", feature = "async-io"))]
+        {
+            if $crate::abstractions::use_tokio() {
+                $tokio
+            } else {
+                $async_io
+            }
+        }
+        #[cfg(all(feature = "tokio", not(feature = "async-io")))]
+        {
+            $tokio
+        }
+        #[cfg(all(feature = "async-io", not(feature = "tokio")))]
+        {
+            $async_io
+        }
+    }};
+}
+pub(crate) use select_runtime;
+
+/// Whether zbus should use tokio (rather than `async-io`) for its I/O.
+///
+/// Only consulted when `async-io` is compiled in, since that's the only time there's a choice. With
+/// both backends we use tokio when a tokio runtime is active on the current thread; with only
+/// `async-io` the answer is always `false`. This keeps the features additive: enabling `tokio`
+/// elsewhere in the dependency graph doesn't force every zbus user into a tokio runtime.
+#[cfg(feature = "async-io")]
+pub(crate) fn use_tokio() -> bool {
+    #[cfg(feature = "tokio")]
+    {
+        tokio::runtime::Handle::try_current().is_ok()
+    }
+    #[cfg(not(feature = "tokio"))]
+    {
+        false
+    }
+}
+
 mod executor;
 pub use executor::*;
 mod async_drop;

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -1,17 +1,21 @@
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_process::{Child, unix::CommandExt};
 #[cfg(unix)]
 use std::process::Output;
 use std::{ffi::OsStr, io::Error, process::Stdio};
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 use tokio::process::Child;
 
 use crate::address::transport::Unixexec;
 
 /// A wrapper around the command API of the underlying async runtime.
+///
+/// Unlike the socket transports, `unixexec` isn't run-time selected: `async-process` is used
+/// whenever it's compiled in (its pipes are `Async<_>`, which any runtime can drive), so with both
+/// backends a tokio app connecting over `unixexec:` picks up async-io's reactor.
 pub struct Command(
-    #[cfg(not(feature = "tokio"))] async_process::Command,
-    #[cfg(feature = "tokio")] tokio::process::Command,
+    #[cfg(feature = "async-io")] async_process::Command,
+    #[cfg(all(feature = "tokio", not(feature = "async-io")))] tokio::process::Command,
 );
 
 impl Command {
@@ -20,10 +24,10 @@ impl Command {
     where
         S: AsRef<OsStr>,
     {
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         return Self(async_process::Command::new(program));
 
-        #[cfg(feature = "tokio")]
+        #[cfg(all(feature = "tokio", not(feature = "async-io")))]
         return Self(tokio::process::Command::new(program));
     }
 

--- a/zbus/src/abstractions/timeout.rs
+++ b/zbus/src/abstractions/timeout.rs
@@ -1,9 +1,8 @@
 use crate::{Error, Result};
 use std::{future::Future, io::ErrorKind, time::Duration};
 
-/// Awaits a future with a provided timeout.
 #[cfg(feature = "tokio")]
-pub(crate) async fn timeout<F, T>(fut: F, timeout: Duration) -> Result<T>
+async fn timeout_tokio<F, T>(fut: F, timeout: Duration) -> Result<T>
 where
     F: Future<Output = Result<T>>,
 {
@@ -15,9 +14,8 @@ where
     })?
 }
 
-/// Awaits a future with a provided timeout.
-#[cfg(not(feature = "tokio"))]
-pub(crate) async fn timeout<F, T>(fut: F, timeout: Duration) -> Result<T>
+#[cfg(feature = "async-io")]
+async fn timeout_async_io<F, T>(fut: F, timeout: Duration) -> Result<T>
 where
     F: Future<Output = Result<T>>,
 {
@@ -32,4 +30,15 @@ where
         )))
     })
     .await
+}
+
+/// Awaits a future with a provided timeout.
+pub(crate) async fn timeout<F, T>(fut: F, timeout: Duration) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    crate::abstractions::select_runtime! {
+        tokio: timeout_tokio(fut, timeout).await,
+        async_io: timeout_async_io(fut, timeout).await,
+    }
 }

--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -301,7 +301,7 @@ mod tests {
             Transport::Ibus(crate::address::transport::Ibus::new()).into(),
         );
 
-        #[cfg(all(feature = "vsock", feature = "p2p", not(feature = "tokio")))]
+        #[cfg(all(any(feature = "vsock", feature = "tokio-vsock"), feature = "p2p"))]
         {
             let guid = crate::Guid::generate();
             assert_eq!(
@@ -404,7 +404,7 @@ mod tests {
             "ibus:"
         );
 
-        #[cfg(all(feature = "vsock", feature = "p2p", not(feature = "tokio")))]
+        #[cfg(all(any(feature = "vsock", feature = "tokio-vsock"), feature = "p2p"))]
         {
             let guid = crate::Guid::generate();
             assert_eq!(

--- a/zbus/src/address/transport/mod.rs
+++ b/zbus/src/address/transport/mod.rs
@@ -2,26 +2,16 @@
 //!
 //! This module provides the transport information for D-Bus addresses.
 
-#[cfg(unix)]
-use crate::connection::socket::Command;
 #[cfg(windows)]
 use crate::win32::autolaunch_bus_address;
-use crate::{Address, Error, Result};
-#[cfg(not(feature = "tokio"))]
+use crate::{Address, Error, Result, connection::socket::BoxedSplit};
+#[cfg(feature = "async-io")]
 use async_io::Async;
-#[cfg(not(feature = "tokio"))]
-use std::net::TcpStream;
 #[cfg(unix)]
 use std::os::unix::net::{SocketAddr, UnixStream};
 use std::{collections::HashMap, sync::Arc};
-#[cfg(feature = "tokio")]
-use tokio::net::TcpStream;
-#[cfg(feature = "tokio-vsock")]
-use tokio_vsock::VsockStream;
 #[cfg(windows)]
 use uds_windows::UnixStream;
-#[cfg(all(feature = "vsock", not(feature = "tokio")))]
-use vsock::VsockStream;
 #[cfg(unix)]
 mod unixexec;
 #[cfg(unix)]
@@ -48,19 +38,13 @@ pub use launchd::Launchd;
 mod ibus;
 #[cfg(unix)]
 pub use ibus::Ibus;
-#[cfg(any(
-    all(feature = "vsock", not(feature = "tokio")),
-    feature = "tokio-vsock"
-))]
+#[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
 #[path = "vsock.rs"]
 // Gotta rename to avoid name conflict with the `vsock` crate.
 mod vsock_transport;
 #[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
-#[cfg(any(
-    all(feature = "vsock", not(feature = "tokio")),
-    feature = "tokio-vsock"
-))]
+#[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
 pub use vsock_transport::Vsock;
 
 /// The transport properties of a D-Bus address.
@@ -83,10 +67,7 @@ pub enum Transport {
     /// IBus daemon for its D-Bus address using the `ibus address` command.
     #[cfg(unix)]
     Ibus(Ibus),
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     /// A VSOCK address.
     ///
     /// This variant is only available when either the `vsock` or `tokio-vsock` feature is enabled.
@@ -134,51 +115,57 @@ impl Transport {
                     "unix stream connection",
                 )
                 .await??;
-                #[cfg(not(feature = "tokio"))]
+                #[cfg(unix)]
                 {
-                    Async::new(stream)
-                        .map(Stream::Unix)
-                        .map_err(|e| Error::InputOutput(e.into()))
+                    let split = crate::abstractions::select_runtime! {
+                        tokio: unix_stream_to_tokio(stream),
+                        async_io: unix_stream_to_async_io(stream),
+                    };
+                    split.map(Stream::Unix)
                 }
-
-                #[cfg(feature = "tokio")]
+                // tokio doesn't support unix sockets on Windows, so async-io is the only backend
+                // that can drive one there.
+                #[cfg(all(not(unix), feature = "async-io"))]
                 {
-                    #[cfg(unix)]
-                    {
-                        tokio::net::UnixStream::from_std(stream)
-                            .map(Stream::Unix)
-                            .map_err(|e| Error::InputOutput(e.into()))
-                    }
-
-                    #[cfg(not(unix))]
-                    {
-                        let _ = stream;
-                        Err(Error::Unsupported)
-                    }
+                    unix_stream_to_async_io(stream).map(Stream::Unix)
+                }
+                #[cfg(all(not(unix), not(feature = "async-io")))]
+                {
+                    let _ = stream;
+                    Err(Error::Unsupported)
                 }
             }
             #[cfg(unix)]
-            Transport::Unixexec(unixexec) => unixexec.connect(&address).await.map(Stream::Unixexec),
-            #[cfg(all(feature = "vsock", not(feature = "tokio")))]
+            Transport::Unixexec(unixexec) => unixexec
+                .connect(&address)
+                .await
+                .map(|s| Stream::Unixexec(s.into())),
+            #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
             Transport::Vsock(addr) => {
-                let stream = VsockStream::connect_with_cid_port(addr.cid(), addr.port())
-                    .map_err(|e| Error::Connection(Arc::new(e), address))?;
-                Async::new(stream).map(Stream::Vsock).map_err(Into::into)
+                #[cfg(all(feature = "vsock", feature = "tokio-vsock"))]
+                {
+                    if crate::abstractions::use_tokio() {
+                        vsock_connect_tokio(&addr, &address).await
+                    } else {
+                        vsock_connect_async_io(&addr, &address)
+                    }
+                }
+                #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
+                {
+                    vsock_connect_async_io(&addr, &address)
+                }
+                #[cfg(all(feature = "tokio-vsock", not(feature = "vsock")))]
+                {
+                    vsock_connect_tokio(&addr, &address).await
+                }
             }
 
-            #[cfg(feature = "tokio-vsock")]
-            Transport::Vsock(addr) => {
-                VsockStream::connect(tokio_vsock::VsockAddr::new(addr.cid(), addr.port()))
-                    .await
-                    .map(Stream::Vsock)
-                    .map_err(|e| Error::Connection(Arc::new(e), address))
-            }
+            Transport::Tcp(mut addr) => {
+                let nonce_file = addr.take_nonce_file();
+                #[allow(unused_mut)]
+                let mut stream = addr.connect(&address).await?;
 
-            Transport::Tcp(mut addr) => match addr.take_nonce_file() {
-                Some(nonce_file) => {
-                    #[allow(unused_mut)]
-                    let mut stream = addr.connect(&address).await?;
-
+                if let Some(nonce_file) = nonce_file {
                     #[cfg(unix)]
                     let nonce_file = {
                         use std::os::unix::ffi::OsStrExt;
@@ -190,7 +177,7 @@ impl Transport {
                         Error::Address("nonce file path is invalid UTF-8".to_owned())
                     })?;
 
-                    #[cfg(not(feature = "tokio"))]
+                    #[cfg(feature = "async-io")]
                     {
                         let nonce = std::fs::read(nonce_file)?;
                         let mut nonce = &nonce[..];
@@ -203,16 +190,20 @@ impl Transport {
                         }
                     }
 
-                    #[cfg(feature = "tokio")]
+                    #[cfg(all(feature = "tokio", not(feature = "async-io")))]
                     {
                         let nonce = tokio::fs::read(nonce_file).await?;
                         tokio::io::AsyncWriteExt::write_all(&mut stream, &nonce).await?;
                     }
-
-                    Ok(Stream::Tcp(stream))
                 }
-                None => addr.connect(&address).await.map(Stream::Tcp),
-            },
+
+                #[cfg(feature = "async-io")]
+                let split = tcp_async_to_split(stream)?;
+                #[cfg(all(feature = "tokio", not(feature = "async-io")))]
+                let split = stream.into();
+
+                Ok(Stream::Tcp(split))
+            }
 
             #[cfg(windows)]
             Transport::Autolaunch(Autolaunch { scope }) => match scope {
@@ -247,10 +238,7 @@ impl Transport {
             "unixexec" => Unixexec::from_options(options).map(Self::Unixexec),
             "tcp" => Tcp::from_options(options, false).map(Self::Tcp),
             "nonce-tcp" => Tcp::from_options(options, true).map(Self::Tcp),
-            #[cfg(any(
-                all(feature = "vsock", not(feature = "tokio")),
-                feature = "tokio-vsock"
-            ))]
+            #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
             "vsock" => Vsock::from_options(options).map(Self::Vsock),
             #[cfg(windows)]
             "autolaunch" => Autolaunch::from_options(options).map(Self::Autolaunch),
@@ -266,27 +254,57 @@ impl Transport {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
 #[derive(Debug)]
 pub(crate) enum Stream {
-    Unix(Async<UnixStream>),
+    #[cfg(any(unix, feature = "async-io"))]
+    Unix(BoxedSplit),
     #[cfg(unix)]
-    Unixexec(Command),
-    Tcp(Async<TcpStream>),
-    #[cfg(feature = "vsock")]
-    Vsock(Async<VsockStream>),
+    Unixexec(BoxedSplit),
+    Tcp(BoxedSplit),
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
+    Vsock(BoxedSplit),
 }
 
-#[cfg(feature = "tokio")]
-#[derive(Debug)]
-pub(crate) enum Stream {
-    #[cfg(unix)]
-    Unix(tokio::net::UnixStream),
-    #[cfg(unix)]
-    Unixexec(Command),
-    Tcp(TcpStream),
-    #[cfg(feature = "tokio-vsock")]
-    Vsock(VsockStream),
+#[cfg(feature = "async-io")]
+fn unix_stream_to_async_io(stream: UnixStream) -> Result<BoxedSplit> {
+    Async::new(stream).map(Into::into).map_err(Into::into)
+}
+
+#[cfg(all(unix, feature = "tokio"))]
+fn unix_stream_to_tokio(stream: UnixStream) -> Result<BoxedSplit> {
+    tokio::net::UnixStream::from_std(stream)
+        .map(Into::into)
+        .map_err(Into::into)
+}
+
+// `async-io` always does the connecting; hand the socket over to tokio when it's in use.
+#[cfg(feature = "async-io")]
+fn tcp_async_to_split(stream: Async<std::net::TcpStream>) -> Result<BoxedSplit> {
+    #[cfg(feature = "tokio")]
+    if crate::abstractions::use_tokio() {
+        return tokio::net::TcpStream::from_std(stream.into_inner()?)
+            .map(Into::into)
+            .map_err(Into::into);
+    }
+
+    Ok(stream.into())
+}
+
+#[cfg(feature = "vsock")]
+fn vsock_connect_async_io(addr: &Vsock, address: &Address) -> Result<Stream> {
+    let stream = vsock::VsockStream::connect_with_cid_port(addr.cid(), addr.port())
+        .map_err(|e| Error::Connection(Arc::new(e), address.clone()))?;
+    Async::new(stream)
+        .map(|s| Stream::Vsock(s.into()))
+        .map_err(Into::into)
+}
+
+#[cfg(feature = "tokio-vsock")]
+async fn vsock_connect_tokio(addr: &Vsock, address: &Address) -> Result<Stream> {
+    tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(addr.cid(), addr.port()))
+        .await
+        .map(|s| Stream::Vsock(s.into()))
+        .map_err(|e| Error::Connection(Arc::new(e), address.clone()))
 }
 
 fn decode_hex(c: char) -> Result<u8> {
@@ -376,10 +394,7 @@ impl Display for Transport {
             Self::Unix(unix) => write!(f, "{unix}")?,
             #[cfg(unix)]
             Self::Unixexec(unixexec) => write!(f, "{unixexec}")?,
-            #[cfg(any(
-                all(feature = "vsock", not(feature = "tokio")),
-                feature = "tokio-vsock"
-            ))]
+            #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
             Self::Vsock(vsock) => write!(f, "{}", vsock)?,
             #[cfg(windows)]
             Self::Autolaunch(autolaunch) => write!(f, "{autolaunch}")?,

--- a/zbus/src/address/transport/tcp.rs
+++ b/zbus/src/address/transport/tcp.rs
@@ -1,8 +1,8 @@
 use super::encode_percents;
 use crate::{Address, Error, Result};
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_io::Async;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::{
     collections::HashMap,
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 use tokio::net::TcpStream;
 
 /// A TCP transport in a D-Bus address.
@@ -128,7 +128,7 @@ impl Tcp {
         })
     }
 
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(feature = "async-io")]
     pub(super) async fn connect(self, address: &Address) -> Result<Async<TcpStream>> {
         let address_clone = address.clone();
         let family = self.family();
@@ -171,7 +171,7 @@ impl Tcp {
         Err(last_err)
     }
 
-    #[cfg(feature = "tokio")]
+    #[cfg(all(feature = "tokio", not(feature = "async-io")))]
     pub(super) async fn connect(self, address: &Address) -> Result<TcpStream> {
         TcpStream::connect((self.host(), self.port()))
             .await

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -102,13 +102,23 @@ impl<'a> Builder<'a> {
     ///
     /// This method expects a
     /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
-    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead.
+    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead, but
+    /// that form is deprecated in favor of
+    /// [`async_io_unix_stream`](Self::async_io_unix_stream).
     ///
     /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
     /// is not available when the `tokio` feature is enabled and building for Windows target.
     ///
     /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
+    #[cfg_attr(
+        not(feature = "tokio"),
+        deprecated(
+            since = "5.19.0",
+            note = "Use `async_io_unix_stream` to avoid a build failure if the `tokio` feature gets enabled"
+        )
+    )]
     #[cfg(any(unix, not(feature = "tokio")))]
+    #[allow(deprecated)] // forwards to the async builder's equally-deprecated `unix_stream`
     pub fn unix_stream(stream: UnixStream) -> Self {
         Self(crate::connection::Builder::unix_stream(stream))
     }
@@ -125,7 +135,16 @@ impl<'a> Builder<'a> {
     ///
     /// This method expects a
     /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
-    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead.
+    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead, but that form is
+    /// deprecated in favor of [`async_io_tcp_stream`](Self::async_io_tcp_stream).
+    #[cfg_attr(
+        not(feature = "tokio"),
+        deprecated(
+            since = "5.19.0",
+            note = "Use `async_io_tcp_stream` to avoid a build failure if the `tokio` feature gets enabled"
+        )
+    )]
+    #[allow(deprecated)] // forwards to the async builder's equally-deprecated `tcp_stream`
     pub fn tcp_stream(stream: TcpStream) -> Self {
         Self(crate::connection::Builder::tcp_stream(stream))
     }

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -9,6 +9,14 @@ use tokio::net::UnixStream;
 #[cfg(all(windows, not(feature = "tokio")))]
 use uds_windows::UnixStream;
 
+// Feature-independent stream types for the `async_io_*_stream` builders.
+#[cfg(feature = "async-io")]
+use std::net::TcpStream as AsyncIoTcpStream;
+#[cfg(all(unix, feature = "async-io"))]
+use std::os::unix::net::UnixStream as AsyncIoUnixStream;
+#[cfg(all(windows, feature = "async-io"))]
+use uds_windows::UnixStream as AsyncIoUnixStream;
+
 use zvariant::ObjectPath;
 
 #[cfg(feature = "p2p")]
@@ -81,9 +89,20 @@ impl<'a> Builder<'a> {
 
     /// Create a builder for a connection that will use the given unix stream.
     ///
-    /// If the default `async-io` feature is disabled, this method will expect a
-    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html)
-    /// argument.
+    /// The stream is a [`std::os::unix::net::UnixStream`] (or [`uds_windows::UnixStream`] on
+    /// Windows).
+    ///
+    /// [`uds_windows::UnixStream`]: https://docs.rs/uds_windows/latest/uds_windows/struct.UnixStream.html
+    #[cfg(all(any(unix, windows), feature = "async-io"))]
+    pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
+        Self(crate::connection::Builder::async_io_unix_stream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given unix stream.
+    ///
+    /// This method expects a
+    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
+    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead.
     ///
     /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
     /// is not available when the `tokio` feature is enabled and building for Windows target.
@@ -96,9 +115,17 @@ impl<'a> Builder<'a> {
 
     /// Create a builder for a connection that will use the given TCP stream.
     ///
-    /// If the default `async-io` feature is disabled, this method will expect a
-    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html)
-    /// argument.
+    /// The stream is a [`std::net::TcpStream`].
+    #[cfg(feature = "async-io")]
+    pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
+        Self(crate::connection::Builder::async_io_tcp_stream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given TCP stream.
+    ///
+    /// This method expects a
+    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
+    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead.
     pub fn tcp_stream(stream: TcpStream) -> Self {
         Self(crate::connection::Builder::tcp_stream(stream))
     }

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -342,6 +342,9 @@ mod tests {
         blocking::{MessageIterator, connection::Builder},
     };
 
+    // Exercises the deprecated `unix_stream` (which must keep working); the `async_io_unix_stream`
+    // replacement just forwards to the async builder covered elsewhere.
+    #[allow(deprecated)]
     #[test]
     #[timeout(15000)]
     fn unix_p2p() {

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -1,8 +1,5 @@
 use async_broadcast::Receiver as ActiveReceiver;
-#[cfg(any(
-    not(feature = "tokio"),
-    all(feature = "vsock", not(feature = "tokio-vsock"))
-))]
+#[cfg(feature = "async-io")]
 use async_io::Async;
 use enumflags2::BitFlags;
 use event_listener::Event;
@@ -24,6 +21,15 @@ use tokio_vsock::VsockStream;
 use uds_windows::UnixStream;
 #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
 use vsock::VsockStream;
+
+// Feature-independent stream types for the `async_io_*_stream` builders: these always take the
+// blocking/`async-io` stream, so enabling `tokio` elsewhere can't change what they accept.
+#[cfg(feature = "async-io")]
+use std::net::TcpStream as AsyncIoTcpStream;
+#[cfg(all(unix, feature = "async-io"))]
+use std::os::unix::net::UnixStream as AsyncIoUnixStream;
+#[cfg(all(windows, feature = "async-io"))]
+use uds_windows::UnixStream as AsyncIoUnixStream;
 
 use zvariant::ObjectPath;
 
@@ -47,9 +53,14 @@ const DEFAULT_MAX_QUEUED: usize = 64;
 
 #[derive(Debug)]
 enum Target {
-    #[cfg(any(unix, not(feature = "tokio")))]
-    UnixStream(UnixStream),
-    TcpStream(TcpStream),
+    #[cfg(all(unix, feature = "tokio"))]
+    TokioUnixStream(tokio::net::UnixStream),
+    #[cfg(all(any(unix, windows), feature = "async-io"))]
+    AsyncIoUnixStream(AsyncIoUnixStream),
+    #[cfg(feature = "tokio")]
+    TokioTcpStream(tokio::net::TcpStream),
+    #[cfg(feature = "async-io")]
+    AsyncIoTcpStream(AsyncIoTcpStream),
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     VsockStream(VsockStream),
     Address(Address),
@@ -189,9 +200,20 @@ impl<'a> Builder<'a> {
 
     /// Create a builder for a connection that will use the given unix stream.
     ///
-    /// When the `tokio` feature is enabled this method expects a
-    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html),
-    /// otherwise a [`std::os::unix::net::UnixStream`].
+    /// The stream is a [`std::os::unix::net::UnixStream`] (or [`uds_windows::UnixStream`] on
+    /// Windows).
+    ///
+    /// [`uds_windows::UnixStream`]: https://docs.rs/uds_windows/latest/uds_windows/struct.UnixStream.html
+    #[cfg(all(any(unix, windows), feature = "async-io"))]
+    pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
+        Self::new(Target::AsyncIoUnixStream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given unix stream.
+    ///
+    /// This method expects a
+    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
+    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead.
     ///
     /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
     /// is not available when the `tokio` feature is enabled and building for Windows target.
@@ -199,16 +221,38 @@ impl<'a> Builder<'a> {
     /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
     #[cfg(any(unix, not(feature = "tokio")))]
     pub fn unix_stream(stream: UnixStream) -> Self {
-        Self::new(Target::UnixStream(stream))
+        #[cfg(not(feature = "tokio"))]
+        {
+            Self::new(Target::AsyncIoUnixStream(stream))
+        }
+        #[cfg(feature = "tokio")]
+        {
+            Self::new(Target::TokioUnixStream(stream))
+        }
     }
 
     /// Create a builder for a connection that will use the given TCP stream.
     ///
-    /// When the `tokio` feature is enabled this method expects a
-    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html),
-    /// otherwise a [`std::net::TcpStream`].
+    /// The stream is a [`std::net::TcpStream`].
+    #[cfg(feature = "async-io")]
+    pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
+        Self::new(Target::AsyncIoTcpStream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given TCP stream.
+    ///
+    /// This method expects a
+    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
+    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead.
     pub fn tcp_stream(stream: TcpStream) -> Self {
-        Self::new(Target::TcpStream(stream))
+        #[cfg(not(feature = "tokio"))]
+        {
+            Self::new(Target::AsyncIoTcpStream(stream))
+        }
+        #[cfg(feature = "tokio")]
+        {
+            Self::new(Target::TokioTcpStream(stream))
+        }
     }
 
     /// Create a builder for a connection that will use the given VSOCK stream.
@@ -680,14 +724,14 @@ impl<'a> Builder<'a> {
         // SAFETY: `self.target` is always `Some` from the beginning and this method is only called
         // once.
         let split = match self.target.take().unwrap() {
-            #[cfg(not(feature = "tokio"))]
-            Target::UnixStream(stream) => Async::new(stream)?.into(),
             #[cfg(all(unix, feature = "tokio"))]
-            Target::UnixStream(stream) => stream.into(),
-            #[cfg(not(feature = "tokio"))]
-            Target::TcpStream(stream) => Async::new(stream)?.into(),
+            Target::TokioUnixStream(stream) => stream.into(),
+            #[cfg(all(any(unix, windows), feature = "async-io"))]
+            Target::AsyncIoUnixStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio")]
-            Target::TcpStream(stream) => stream.into(),
+            Target::TokioTcpStream(stream) => stream.into(),
+            #[cfg(feature = "async-io")]
+            Target::AsyncIoTcpStream(stream) => Async::new(stream)?.into(),
             #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
             Target::VsockStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio-vsock")]

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -213,12 +213,21 @@ impl<'a> Builder<'a> {
     ///
     /// This method expects a
     /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
-    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead.
+    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead, but
+    /// that form is deprecated in favor of
+    /// [`async_io_unix_stream`](Self::async_io_unix_stream).
     ///
     /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
     /// is not available when the `tokio` feature is enabled and building for Windows target.
     ///
     /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
+    #[cfg_attr(
+        not(feature = "tokio"),
+        deprecated(
+            since = "5.19.0",
+            note = "Use `async_io_unix_stream` to avoid a build failure if the `tokio` feature gets enabled"
+        )
+    )]
     #[cfg(any(unix, not(feature = "tokio")))]
     pub fn unix_stream(stream: UnixStream) -> Self {
         #[cfg(not(feature = "tokio"))]
@@ -243,7 +252,15 @@ impl<'a> Builder<'a> {
     ///
     /// This method expects a
     /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
-    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead.
+    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead, but that form is
+    /// deprecated in favor of [`async_io_tcp_stream`](Self::async_io_tcp_stream).
+    #[cfg_attr(
+        not(feature = "tokio"),
+        deprecated(
+            since = "5.19.0",
+            note = "Use `async_io_tcp_stream` to avoid a build failure if the `tokio` feature gets enabled"
+        )
+    )]
     pub fn tcp_stream(stream: TcpStream) -> Self {
         #[cfg(not(feature = "tokio"))]
         {

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -1,5 +1,8 @@
 use async_broadcast::Receiver as ActiveReceiver;
-#[cfg(not(feature = "tokio"))]
+#[cfg(any(
+    not(feature = "tokio"),
+    all(feature = "vsock", not(feature = "tokio-vsock"))
+))]
 use async_io::Async;
 use enumflags2::BitFlags;
 use event_listener::Event;
@@ -19,7 +22,7 @@ use tokio::net::UnixStream;
 use tokio_vsock::VsockStream;
 #[cfg(all(windows, not(feature = "tokio")))]
 use uds_windows::UnixStream;
-#[cfg(all(feature = "vsock", not(feature = "tokio")))]
+#[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
 use vsock::VsockStream;
 
 use zvariant::ObjectPath;
@@ -47,10 +50,7 @@ enum Target {
     #[cfg(any(unix, not(feature = "tokio")))]
     UnixStream(UnixStream),
     TcpStream(TcpStream),
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     VsockStream(VsockStream),
     Address(Address),
     Socket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
@@ -189,9 +189,9 @@ impl<'a> Builder<'a> {
 
     /// Create a builder for a connection that will use the given unix stream.
     ///
-    /// If the default `async-io` feature is disabled, this method will expect a
-    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html)
-    /// argument.
+    /// When the `tokio` feature is enabled this method expects a
+    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html),
+    /// otherwise a [`std::os::unix::net::UnixStream`].
     ///
     /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
     /// is not available when the `tokio` feature is enabled and building for Windows target.
@@ -204,9 +204,9 @@ impl<'a> Builder<'a> {
 
     /// Create a builder for a connection that will use the given TCP stream.
     ///
-    /// If the default `async-io` feature is disabled, this method will expect a
-    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html)
-    /// argument.
+    /// When the `tokio` feature is enabled this method expects a
+    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html),
+    /// otherwise a [`std::net::TcpStream`].
     pub fn tcp_stream(stream: TcpStream) -> Self {
         Self::new(Target::TcpStream(stream))
     }
@@ -216,10 +216,7 @@ impl<'a> Builder<'a> {
     /// This method is only available when either `vsock` or `tokio-vsock` feature is enabled. The
     /// type of `stream` is `vsock::VsockStream` with `vsock` feature and `tokio_vsock::VsockStream`
     /// with `tokio-vsock` feature.
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     pub fn vsock_stream(stream: VsockStream) -> Self {
         Self::new(Target::VsockStream(stream))
     }
@@ -512,13 +509,13 @@ impl<'a> Builder<'a> {
         activate_msg_stream: bool,
     ) -> Result<(Connection, Option<ActiveReceiver<Result<Message>>>)> {
         let executor = Executor::new();
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         let internal_executor = self.internal_executor;
         // Box the future as it's large and can cause stack overflow.
         let conn =
             Box::pin(executor.run(self.build_(executor.clone(), activate_msg_stream))).await?;
 
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         start_internal_executor(&executor, internal_executor)?;
 
         Ok(conn)
@@ -691,23 +688,20 @@ impl<'a> Builder<'a> {
             Target::TcpStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio")]
             Target::TcpStream(stream) => stream.into(),
-            #[cfg(all(feature = "vsock", not(feature = "tokio")))]
+            #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
             Target::VsockStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio-vsock")]
             Target::VsockStream(stream) => stream.into(),
             Target::Address(address) => {
                 guid = address.guid().map(|g| g.to_owned().into());
                 match address.connect().await? {
-                    #[cfg(any(unix, not(feature = "tokio")))]
-                    address::transport::Stream::Unix(stream) => stream.into(),
+                    #[cfg(any(unix, feature = "async-io"))]
+                    address::transport::Stream::Unix(split) => split,
                     #[cfg(unix)]
-                    address::transport::Stream::Unixexec(stream) => stream.into(),
-                    address::transport::Stream::Tcp(stream) => stream.into(),
-                    #[cfg(any(
-                        all(feature = "vsock", not(feature = "tokio")),
-                        feature = "tokio-vsock"
-                    ))]
-                    address::transport::Stream::Vsock(stream) => stream.into(),
+                    address::transport::Stream::Unixexec(split) => split,
+                    address::transport::Stream::Tcp(split) => split,
+                    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
+                    address::transport::Stream::Vsock(split) => split,
                 }
             }
             Target::Socket(stream) => stream,
@@ -726,9 +720,10 @@ impl<'a> Builder<'a> {
 ///
 /// Returns a dummy task that keep the executor ticking thread from exiting due to absence of any
 /// tasks until socket reader task kicks in.
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 fn start_internal_executor(executor: &Executor<'static>, internal_executor: bool) -> Result<()> {
-    if internal_executor {
+    // tokio drives its own tasks; only the `async-io` backend needs this driver thread.
+    if internal_executor && executor.needs_internal_driver() {
         let executor = executor.clone();
         std::thread::Builder::new()
             .name("zbus::Connection executor".into())

--- a/zbus/src/connection/handshake/mod.rs
+++ b/zbus/src/connection/handshake/mod.rs
@@ -117,13 +117,13 @@ fn sasl_auth_id() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use futures_util::future::join;
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(feature = "async-io")]
     use futures_util::io::{AsyncWrite, AsyncWriteExt};
     use ntest::timeout;
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(feature = "async-io")]
     use std::os::unix::net::UnixStream;
     use test_log::test;
-    #[cfg(feature = "tokio")]
+    #[cfg(not(feature = "async-io"))]
     use tokio::{
         io::{AsyncWrite, AsyncWriteExt},
         net::UnixStream,
@@ -138,7 +138,7 @@ mod tests {
         let (p0, p1) = crate::utils::block_on(async { UnixStream::pair().unwrap() });
 
         // initialize both handshakes
-        #[cfg(not(feature = "tokio"))]
+        #[cfg(feature = "async-io")]
         let (p0, p1) = {
             p0.set_nonblocking(true).unwrap();
             p1.set_nonblocking(true).unwrap();

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1735,27 +1735,21 @@ mod p2p_tests {
         )
     }
 
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     #[test]
     #[timeout(15000)]
     fn vsock_connect() {
         let _ = crate::utils::block_on(test_vsock_connect()).unwrap();
     }
 
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     async fn test_vsock_connect() -> Result<(Connection, Connection)> {
         #[cfg(feature = "tokio-vsock")]
         use futures_util::StreamExt;
 
         let guid = Guid::generate();
 
-        #[cfg(all(feature = "vsock", not(feature = "tokio")))]
+        #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
         let listener = vsock::VsockListener::bind_with_cid_port(vsock::VMADDR_CID_LOCAL, u32::MAX)?;
         #[cfg(feature = "tokio-vsock")]
         let listener = tokio_vsock::VsockListener::bind(tokio_vsock::VsockAddr::new(1, u32::MAX))?;
@@ -1764,7 +1758,7 @@ mod p2p_tests {
         let addr = format!("vsock:cid={},port={},guid={guid}", addr.cid(), addr.port());
 
         let server = async {
-            #[cfg(all(feature = "vsock", not(feature = "tokio")))]
+            #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
             let server =
                 crate::Task::spawn_blocking(move || listener.incoming().next(), "").await?;
             #[cfg(feature = "tokio-vsock")]
@@ -1784,20 +1778,14 @@ mod p2p_tests {
         futures_util::try_join!(server, client)
     }
 
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     #[test]
     #[timeout(15000)]
     fn vsock_p2p() {
         crate::utils::block_on(test_vsock_p2p()).unwrap();
     }
 
-    #[cfg(any(
-        all(feature = "vsock", not(feature = "tokio")),
-        feature = "tokio-vsock"
-    ))]
+    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     async fn test_vsock_p2p() -> Result<()> {
         let (server1, client1) = vsock_p2p_pipe().await?;
         let (server2, client2) = vsock_p2p_pipe().await?;
@@ -1805,7 +1793,7 @@ mod p2p_tests {
         test_p2p(server1, client1, server2, client2).await
     }
 
-    #[cfg(all(feature = "vsock", not(feature = "tokio")))]
+    #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
     async fn vsock_p2p_pipe() -> Result<(Connection, Connection)> {
         let guid = Guid::generate();
 

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1735,6 +1735,41 @@ mod p2p_tests {
         )
     }
 
+    // With both backends compiled in, exercise the async-io one end to end. `utils::block_on`
+    // establishes a tokio runtime (so the other tests hit the tokio arm), so drive this with
+    // `async_io::block_on` and hand the builder async-io streams: the connection must then latch
+    // the async-io backend and spin up its internal driver thread.
+    #[cfg(all(unix, feature = "tokio", feature = "async-io"))]
+    #[test]
+    #[timeout(15000)]
+    fn unix_p2p_async_io_backend() {
+        async_io::block_on(async {
+            let (server1, client1) = async_io_unix_p2p_pipe().await.unwrap();
+            assert!(server1.executor().needs_internal_driver());
+            assert!(client1.executor().needs_internal_driver());
+            let (server2, client2) = async_io_unix_p2p_pipe().await.unwrap();
+
+            test_p2p(server1, client1, server2, client2).await.unwrap();
+        });
+    }
+
+    #[cfg(all(unix, feature = "tokio", feature = "async-io"))]
+    async fn async_io_unix_p2p_pipe() -> Result<(Connection, Connection)> {
+        use std::os::unix::net::UnixStream;
+
+        let guid = Guid::generate();
+        let (p0, p1) = UnixStream::pair().unwrap();
+
+        futures_util::try_join!(
+            Builder::async_io_unix_stream(p1).p2p().build(),
+            Builder::async_io_unix_stream(p0)
+                .server(guid)
+                .unwrap()
+                .p2p()
+                .build(),
+        )
+    }
+
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     #[test]
     #[timeout(15000)]

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1672,12 +1672,12 @@ mod p2p_tests {
             let p0 = listener.incoming().next().unwrap().unwrap();
 
             (
-                Builder::tcp_stream(p0)
+                Builder::async_io_tcp_stream(p0)
                     .server(guid)
                     .unwrap()
                     .p2p()
                     .auth_mechanism(AuthMechanism::Anonymous),
-                Builder::tcp_stream(p1).p2p(),
+                Builder::async_io_tcp_stream(p1).p2p(),
             )
         };
 
@@ -1729,10 +1729,15 @@ mod p2p_tests {
 
         let (p0, p1) = UnixStream::pair().unwrap();
 
-        futures_util::try_join!(
-            Builder::unix_stream(p1).p2p().build(),
-            Builder::unix_stream(p0).server(guid).unwrap().p2p().build(),
-        )
+        #[cfg(not(feature = "tokio"))]
+        let (b1, b0) = (
+            Builder::async_io_unix_stream(p1),
+            Builder::async_io_unix_stream(p0),
+        );
+        #[cfg(feature = "tokio")]
+        let (b1, b0) = (Builder::unix_stream(p1), Builder::unix_stream(p0));
+
+        futures_util::try_join!(b1.p2p().build(), b0.server(guid).unwrap().p2p().build(),)
     }
 
     // With both backends compiled in, exercise the async-io one end to end. `utils::block_on`

--- a/zbus/src/connection/socket/command.rs
+++ b/zbus/src/connection/socket/command.rs
@@ -1,9 +1,9 @@
 use std::{io, os::fd::BorrowedFd};
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_process::{Child, ChildStdin, ChildStdout};
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 use tokio::{
     io::{AsyncReadExt, ReadBuf},
     process::{Child, ChildStdin, ChildStdout},
@@ -56,7 +56,7 @@ impl TryFrom<&mut Child> for Command {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 #[async_trait::async_trait]
 impl ReadHalf for ChildStdout {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
@@ -73,7 +73,7 @@ impl ReadHalf for ChildStdout {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 #[async_trait::async_trait]
 impl ReadHalf for ChildStdout {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
@@ -88,7 +88,7 @@ impl ReadHalf for ChildStdout {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 #[async_trait::async_trait]
 impl WriteHalf for ChildStdin {
     async fn sendmsg(
@@ -112,7 +112,7 @@ impl WriteHalf for ChildStdin {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", not(feature = "async-io")))]
 #[async_trait::async_trait]
 impl WriteHalf for ChildStdin {
     async fn sendmsg(

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -14,9 +14,9 @@ mod tcp;
 mod unix;
 mod vsock;
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_io::Async;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use std::sync::Arc;
 use std::{io, mem};
 use tracing::trace;
@@ -411,7 +411,7 @@ impl WriteHalf for Box<dyn WriteHalf> {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 impl<T> Socket for Async<T>
 where
     T: std::fmt::Debug + Send + Sync,

--- a/zbus/src/connection/socket/tcp.rs
+++ b/zbus/src/connection/socket/tcp.rs
@@ -1,16 +1,16 @@
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_io::Async;
 use std::io;
 #[cfg(unix)]
 use std::os::fd::BorrowedFd;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use std::{net::TcpStream, sync::Arc};
 
 use super::{ReadHalf, RecvmsgResult, WriteHalf};
 #[cfg(feature = "tokio")]
 use super::{Socket, Split};
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 #[async_trait::async_trait]
 impl ReadHalf for Arc<Async<TcpStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> RecvmsgResult {
@@ -53,7 +53,7 @@ impl ReadHalf for Arc<Async<TcpStream>> {
     }
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 #[async_trait::async_trait]
 impl WriteHalf for Arc<Async<TcpStream>> {
     async fn sendmsg(

--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -1,12 +1,12 @@
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use async_io::Async;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::FromRawFd;
 #[cfg(unix)]
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
-#[cfg(all(unix, not(feature = "tokio")))]
+#[cfg(all(unix, feature = "async-io"))]
 use std::os::unix::net::UnixStream;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use std::sync::Arc;
 #[cfg(unix)]
 use std::{
@@ -15,7 +15,7 @@ use std::{
     os::fd::OwnedFd,
     task::Poll,
 };
-#[cfg(all(windows, not(feature = "tokio")))]
+#[cfg(all(windows, feature = "async-io"))]
 use uds_windows::UnixStream;
 
 #[cfg(unix)]
@@ -27,7 +27,7 @@ use rustix::net::{
 #[cfg(unix)]
 use crate::utils::FDS_MAX;
 
-#[cfg(all(unix, not(feature = "tokio")))]
+#[cfg(all(unix, feature = "async-io"))]
 #[async_trait::async_trait]
 impl super::ReadHalf for Arc<Async<UnixStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> super::RecvmsgResult {
@@ -59,7 +59,7 @@ impl super::ReadHalf for Arc<Async<UnixStream>> {
     }
 }
 
-#[cfg(all(unix, not(feature = "tokio")))]
+#[cfg(all(unix, feature = "async-io"))]
 #[async_trait::async_trait]
 impl super::WriteHalf for Arc<Async<UnixStream>> {
     async fn sendmsg(
@@ -213,7 +213,7 @@ impl super::WriteHalf for tokio::net::unix::OwnedWriteHalf {
     }
 }
 
-#[cfg(all(windows, not(feature = "tokio")))]
+#[cfg(all(windows, feature = "async-io"))]
 #[async_trait::async_trait]
 impl super::ReadHalf for Arc<Async<UnixStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> super::RecvmsgResult {
@@ -248,7 +248,7 @@ impl super::ReadHalf for Arc<Async<UnixStream>> {
     }
 }
 
-#[cfg(all(windows, not(feature = "tokio")))]
+#[cfg(all(windows, feature = "async-io"))]
 #[async_trait::async_trait]
 impl super::WriteHalf for Arc<Async<UnixStream>> {
     async fn sendmsg(

--- a/zbus/src/connection/socket/vsock.rs
+++ b/zbus/src/connection/socket/vsock.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "tokio-vsock")]
 use super::{Socket, Split};
 
-#[cfg(all(feature = "vsock", not(feature = "tokio")))]
+#[cfg(feature = "vsock")]
 #[async_trait::async_trait]
 impl super::ReadHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
     async fn recvmsg(&mut self, buf: &mut [u8]) -> super::RecvmsgResult {
@@ -22,7 +22,7 @@ impl super::ReadHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
     }
 }
 
-#[cfg(all(feature = "vsock", not(feature = "tokio")))]
+#[cfg(feature = "vsock")]
 #[async_trait::async_trait]
 impl super::WriteHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
     async fn sendmsg(

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1504,10 +1504,10 @@ mod tests {
             let server_fut = async move {
                 use std::time::Duration;
 
-                #[cfg(not(feature = "tokio"))]
+                #[cfg(feature = "async-io")]
                 use async_io::Timer;
 
-                #[cfg(feature = "tokio")]
+                #[cfg(all(feature = "tokio", not(feature = "async-io")))]
                 use tokio::time::sleep;
 
                 let iface_ref = conn
@@ -1524,10 +1524,10 @@ mod tests {
                             .unwrap();
                     }
 
-                    #[cfg(not(feature = "tokio"))]
+                    #[cfg(feature = "async-io")]
                     Timer::after(Duration::from_millis(5)).await;
 
-                    #[cfg(feature = "tokio")]
+                    #[cfg(all(feature = "tokio", not(feature = "async-io")))]
                     sleep(Duration::from_millis(5)).await;
                 }
             };

--- a/zbus/src/win32.rs
+++ b/zbus/src/win32.rs
@@ -32,7 +32,7 @@ use windows_sys::Win32::{
 };
 
 use crate::Address;
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 use uds_windows::UnixStream;
 
 struct Mutex(OwnedHandle);
@@ -224,14 +224,14 @@ pub fn socket_addr_get_pid(addr: &SocketAddr) -> Result<u32, Error> {
 }
 
 /// Get the process ID of the connected peer.
-#[cfg(any(test, not(feature = "tokio")))]
+#[cfg(any(test, feature = "async-io"))]
 pub fn tcp_stream_get_peer_pid(stream: &std::net::TcpStream) -> Result<u32, Error> {
     let peer_addr = stream.peer_addr()?;
 
     socket_addr_get_pid(&peer_addr)
 }
 
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 fn last_err() -> std::io::Error {
     use windows_sys::Win32::Networking::WinSock::WSAGetLastError;
 
@@ -240,7 +240,7 @@ fn last_err() -> std::io::Error {
 }
 
 /// Get the process ID of the connected peer.
-#[cfg(not(feature = "tokio"))]
+#[cfg(feature = "async-io")]
 pub fn unix_stream_get_peer_pid(stream: &UnixStream) -> Result<u32, Error> {
     use std::os::windows::io::AsRawSocket;
     use windows_sys::Win32::Networking::WinSock::{IOC_OUT, IOC_VENDOR, SOCKET_ERROR, WSAIoctl};

--- a/zbus/tests/builder_message_stream.rs
+++ b/zbus/tests/builder_message_stream.rs
@@ -16,6 +16,7 @@ use zbus::{Connection, Guid, block_on, connection::Builder};
 
 /// Simulates the busd race: a bus client pipelines Hello during SASL auth, before the server
 /// has started polling. `build_message_stream` must still deliver it.
+#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[test]
 #[timeout(15000)]
 fn build_message_stream_does_not_drop_pipelined_hello() {

--- a/zbus/tests/connection_closed.rs
+++ b/zbus/tests/connection_closed.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, feature = "p2p"))]
+#![cfg(all(unix, feature = "p2p", feature = "async-io"))]
 
 use std::os::unix::net::UnixStream;
 
@@ -13,8 +13,11 @@ fn closed_resolves_when_peer_disconnects() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
-        let client_builder = Builder::unix_stream(s1).p2p();
+        let server_builder = Builder::async_io_unix_stream(s0)
+            .server(guid)
+            .unwrap()
+            .p2p();
+        let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
         let server = server.unwrap();
@@ -38,8 +41,11 @@ fn closed_resolves_on_explicit_close() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
-        let client_builder = Builder::unix_stream(s1).p2p();
+        let server_builder = Builder::async_io_unix_stream(s0)
+            .server(guid)
+            .unwrap()
+            .p2p();
+        let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
         let server = server.unwrap();
@@ -62,8 +68,11 @@ fn closed_resolves_immediately_if_already_closed() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
-        let client_builder = Builder::unix_stream(s1).p2p();
+        let server_builder = Builder::async_io_unix_stream(s0)
+            .server(guid)
+            .unwrap()
+            .p2p();
+        let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
         let server = server.unwrap();

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -34,6 +34,7 @@ fn iface_and_proxy_unix_p2p() {
     block_on(iface_and_proxy_(true));
 }
 
+#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[instrument]
 async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
     let event = event_listener::Event::new();

--- a/zbus/tests/issue/issue_1003.rs
+++ b/zbus/tests/issue/issue_1003.rs
@@ -10,6 +10,7 @@ use zbus::{AuthMechanism, Guid, block_on, connection::Builder};
 
 const UID: u32 = 0;
 
+#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[test]
 #[timeout(15000)]
 #[instrument]

--- a/zbus/tests/issue/issue_279.rs
+++ b/zbus/tests/issue/issue_279.rs
@@ -1,6 +1,7 @@
 use test_log::test;
 use tracing::instrument;
 
+#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 #[instrument]
 async fn issue_279() {

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -5,6 +5,7 @@ use zbus::block_on;
 
 use zbus::Result;
 
+#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[instrument]
 #[test]
 #[timeout(15000)]


### PR DESCRIPTION
Cargo unifies features across the whole build, so the `tokio` feature can be turned on by another, independent crate in the workspace even when the application itself uses zbus with async-io. That used to compile the async-io backend out and force every zbus user in the process into a tokio runtime, so the async-io application would panic with "there is no reactor running".

Gate the async-io backend on `feature = "async-io"` rather than `not(feature = "tokio")` so both can be compiled together. When both are enabled, pick the backend at run time: use tokio when a tokio runtime is active on the current thread, and async-io otherwise.

