### PR TITLE
♻️ zx: Drop quick-xml in favour of a bespoke XML parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.1"
+version = "5.2.0"
 dependencies = [
  "codspeed-criterion-compat",
  "doc-comment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,16 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2289,6 @@ version = "5.2.0"
 dependencies = [
  "codspeed-criterion-compat",
  "doc-comment",
- "quick-xml",
  "serde",
  "winnow 1.0.3",
  "zbus_names",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,7 @@ dependencies = [
  "doc-comment",
  "quick-xml",
  "serde",
+ "winnow 1.0.3",
  "zbus_names",
  "zvariant",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,6 +2297,7 @@ dependencies = [
 name = "zbus_xml"
 version = "5.1.1"
 dependencies = [
+ "codspeed-criterion-compat",
  "doc-comment",
  "quick-xml",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ futures-lite = { version = "2.6.0", default-features = false, features = [
     "std",
 ] }
 
-quick-xml = { version = "0.41", features = ["serialize", "overlapped-lists"] }
 event-listener = "5.3.0"
 xdg-home = "1.1.0"
 tracing = "0.1.40"

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -17,7 +17,6 @@ serde.workspace = true
 zvariant = { path = "../zvariant", version = "5.12.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.2" }
 winnow.workspace = true
-quick-xml.workspace = true
 
 [dev-dependencies]
 doc-comment.workspace = true

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zbus_xml"
-version = "5.1.1"
+version = "5.2.0"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 serde.workspace = true
 zvariant = { path = "../zvariant", version = "5.12.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.2" }
+winnow.workspace = true
 quick-xml.workspace = true
 
 [dev-dependencies]

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -20,6 +20,14 @@ quick-xml.workspace = true
 
 [dev-dependencies]
 doc-comment.workspace = true
+criterion.workspace = true
+
+[lib]
+bench = false
+
+[[bench]]
+name = "benchmarks"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus_xml/benches/benchmarks.rs
+++ b/zbus_xml/benches/benchmarks.rs
@@ -1,0 +1,27 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use zbus_xml::Node;
+
+fn benchmarks(c: &mut Criterion) {
+    // The largest of the real-world introspection documents in the test data.
+    let xml = include_str!("../tests/data/real_world/systemd1_manager.xml");
+
+    c.bench_function("parse_systemd_manager", |b| {
+        b.iter(|| Node::try_from(black_box(xml)).unwrap())
+    });
+
+    let node = Node::try_from(xml).unwrap();
+    c.bench_function("write_systemd_manager", |b| {
+        b.iter(|| {
+            let mut writer = Vec::with_capacity(xml.len());
+            node.to_writer(black_box(&mut writer)).unwrap();
+
+            writer
+        })
+    });
+}
+
+criterion_group!(benches, benchmarks);
+criterion_main!(benches);

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -2,12 +2,13 @@ use quick_xml::{de::DeError, se::SeError};
 use std::{convert::Infallible, error, fmt};
 use zvariant::Error as VariantError;
 
-/// The error type for `zbus_names`.
+/// The error type for `zbus_xml`.
 ///
 /// The various errors that can be reported by this crate.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// A zvariant error, e.g. an invalid signature.
     Variant(VariantError),
     /// An XML error from quick_xml
     QuickXml(DeError),

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -1,5 +1,6 @@
 use quick_xml::{de::DeError, se::SeError};
 use std::{convert::Infallible, error, fmt};
+use zbus_names::Error as NamesError;
 use zvariant::Error as VariantError;
 
 /// The error type for `zbus_xml`.
@@ -10,6 +11,10 @@ use zvariant::Error as VariantError;
 pub enum Error {
     /// A zvariant error, e.g. an invalid signature.
     Variant(VariantError),
+    /// A D-Bus name error.
+    Name(NamesError),
+    /// An XML parsing error.
+    Xml(XmlError),
     /// An XML error from quick_xml
     QuickXml(DeError),
     /// An XML serialization error from quick_xml
@@ -20,6 +25,8 @@ impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Variant(s), Self::Variant(o)) => s == o,
+            (Self::Name(s), Self::Name(o)) => s == o,
+            (Self::Xml(s), Self::Xml(o)) => s == o,
             (Self::QuickXml(_), Self::QuickXml(_)) => false,
             (Self::QuickXmlSer(_), Self::QuickXmlSer(_)) => false,
             (_, _) => false,
@@ -31,6 +38,8 @@ impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Error::Variant(e) => Some(e),
+            Error::Name(e) => Some(e),
+            Error::Xml(e) => Some(e),
             Error::QuickXml(e) => Some(e),
             Error::QuickXmlSer(e) => Some(e),
         }
@@ -41,6 +50,8 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Variant(e) => write!(f, "{e}"),
+            Error::Name(e) => write!(f, "{e}"),
+            Error::Xml(e) => write!(f, "XML error: {e}"),
             Error::QuickXml(e) => write!(f, "XML error: {e}"),
             Error::QuickXmlSer(e) => write!(f, "XML serialization error: {e}"),
         }
@@ -50,6 +61,18 @@ impl fmt::Display for Error {
 impl From<VariantError> for Error {
     fn from(val: VariantError) -> Self {
         Error::Variant(val)
+    }
+}
+
+impl From<NamesError> for Error {
+    fn from(val: NamesError) -> Self {
+        Error::Name(val)
+    }
+}
+
+impl From<XmlError> for Error {
+    fn from(val: XmlError) -> Self {
+        Error::Xml(val)
     }
 }
 
@@ -70,6 +93,40 @@ impl From<Infallible> for Error {
         match i {}
     }
 }
+
+/// An error encountered while parsing an XML document.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct XmlError {
+    message: String,
+    position: usize,
+}
+
+impl XmlError {
+    pub(crate) fn new(message: impl Into<String>, position: usize) -> Self {
+        Self {
+            message: message.into(),
+            position,
+        }
+    }
+
+    /// A message describing the error.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// The byte offset in the document at which the error was encountered.
+    pub fn position(&self) -> usize {
+        self.position
+    }
+}
+
+impl fmt::Display for XmlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (at byte offset {})", self.message, self.position)
+    }
+}
+
+impl error::Error for XmlError {}
 
 /// Alias for a `Result` with the error type `zbus_xml::Error`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -1,5 +1,4 @@
-use quick_xml::{de::DeError, se::SeError};
-use std::{convert::Infallible, error, fmt, io, sync::Arc};
+use std::{borrow::Cow, convert::Infallible, error, fmt, io, num::NonZeroUsize, sync::Arc};
 use zbus_names::Error as NamesError;
 use zvariant::Error as VariantError;
 
@@ -18,8 +17,20 @@ pub enum Error {
     /// An I/O error.
     Io(Arc<io::Error>),
     /// An XML error from quick_xml
+    #[deprecated(
+        since = "5.2.0",
+        note = "This variant is no longer returned from any of our API. \
+                Match on `Error::Xml` instead."
+    )]
+    #[allow(deprecated)]
     QuickXml(DeError),
     /// An XML serialization error from quick_xml
+    #[deprecated(
+        since = "5.2.0",
+        note = "This variant is no longer returned from any of our API. \
+                Match on `Error::Xml` or `Error::Io` instead."
+    )]
+    #[allow(deprecated)]
     QuickXmlSer(SeError),
 }
 
@@ -29,8 +40,6 @@ impl PartialEq for Error {
             (Self::Variant(s), Self::Variant(o)) => s == o,
             (Self::Name(s), Self::Name(o)) => s == o,
             (Self::Xml(s), Self::Xml(o)) => s == o,
-            (Self::QuickXml(_), Self::QuickXml(_)) => false,
-            (Self::QuickXmlSer(_), Self::QuickXmlSer(_)) => false,
             (_, _) => false,
         }
     }
@@ -43,7 +52,9 @@ impl error::Error for Error {
             Error::Name(e) => Some(e),
             Error::Xml(e) => Some(e),
             Error::Io(e) => Some(e),
+            #[allow(deprecated)]
             Error::QuickXml(e) => Some(e),
+            #[allow(deprecated)]
             Error::QuickXmlSer(e) => Some(e),
         }
     }
@@ -56,7 +67,9 @@ impl fmt::Display for Error {
             Error::Name(e) => write!(f, "{e}"),
             Error::Xml(e) => write!(f, "XML error: {e}"),
             Error::Io(e) => write!(f, "I/O error: {e}"),
+            #[allow(deprecated)]
             Error::QuickXml(e) => write!(f, "XML error: {e}"),
+            #[allow(deprecated)]
             Error::QuickXmlSer(e) => write!(f, "XML serialization error: {e}"),
         }
     }
@@ -83,18 +96,6 @@ impl From<XmlError> for Error {
 impl From<io::Error> for Error {
     fn from(val: io::Error) -> Self {
         Error::Io(Arc::new(val))
-    }
-}
-
-impl From<DeError> for Error {
-    fn from(val: DeError) -> Self {
-        Error::QuickXml(val)
-    }
-}
-
-impl From<SeError> for Error {
-    fn from(val: SeError) -> Self {
-        Error::QuickXmlSer(val)
     }
 }
 
@@ -137,6 +138,107 @@ impl fmt::Display for XmlError {
 }
 
 impl error::Error for XmlError {}
+
+/// A copy of `quick_xml::de::DeError`, kept for backwards compatibility.
+///
+/// This crate no longer uses quick-xml, so this error is never returned. It only exists so that
+/// code matching on [`Error::QuickXml`] keeps compiling. The `InvalidXml` variant carries the
+/// error message as a string instead of the quick-xml error type it used to wrap, so `source()`
+/// returns `None` for it.
+#[doc(hidden)]
+#[deprecated(
+    since = "5.2.0",
+    note = "This error is no longer returned from any of our API. \
+            Match on `Error::Xml` instead."
+)]
+#[derive(Clone, Debug)]
+pub enum DeError {
+    /// Serde custom error.
+    Custom(String),
+    /// XML parsing error.
+    InvalidXml(String),
+    /// `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`.
+    KeyNotRead,
+    /// Deserializer encountered a start tag with an unexpected name.
+    UnexpectedStart(Vec<u8>),
+    /// The reader produced an EOF event when it wasn't expecting one.
+    UnexpectedEof,
+    /// Too many events were skipped while deserializing a sequence.
+    TooManyEvents(NonZeroUsize),
+}
+
+#[allow(deprecated)]
+impl fmt::Display for DeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom(s) => f.write_str(s),
+            Self::InvalidXml(e) => f.write_str(e),
+            Self::KeyNotRead => f.write_str(
+                "invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called \
+                 before `MapAccess::next_key[_seed]`",
+            ),
+            Self::UnexpectedStart(e) => {
+                write!(
+                    f,
+                    "unexpected `Event::Start({})`",
+                    String::from_utf8_lossy(e)
+                )
+            }
+            Self::UnexpectedEof => f.write_str("unexpected `Event::Eof`"),
+            Self::TooManyEvents(s) => write!(f, "deserializer buffered {s} events, limit exceeded"),
+        }
+    }
+}
+
+#[allow(deprecated)]
+impl error::Error for DeError {}
+
+/// A copy of `quick_xml::se::SeError`, kept for backwards compatibility.
+///
+/// This crate no longer uses quick-xml, so this error is never returned. It only exists so that
+/// code matching on [`Error::QuickXmlSer`] keeps compiling.
+#[doc(hidden)]
+#[deprecated(
+    since = "5.2.0",
+    note = "This error is no longer returned from any of our API. \
+            Match on `Error::Xml` or `Error::Io` instead."
+)]
+#[derive(Clone, Debug)]
+pub enum SeError {
+    /// Serde custom error.
+    Custom(String),
+    /// XML document cannot be written to the underlying source.
+    Io(Arc<io::Error>),
+    /// Some value could not be formatted.
+    Fmt(std::fmt::Error),
+    /// Serialized type cannot be represented in XML.
+    Unsupported(Cow<'static, str>),
+    /// Some value could not be turned to UTF-8.
+    NonEncodable(std::str::Utf8Error),
+}
+
+#[allow(deprecated)]
+impl fmt::Display for SeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom(s) => f.write_str(s),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Fmt(e) => write!(f, "formatting error: {e}"),
+            Self::Unsupported(s) => write!(f, "unsupported value: {s}"),
+            Self::NonEncodable(e) => write!(f, "malformed UTF-8: {e}"),
+        }
+    }
+}
+
+#[allow(deprecated)]
+impl error::Error for SeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
 
 /// Alias for a `Result` with the error type `zbus_xml::Error`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -1,5 +1,5 @@
 use quick_xml::{de::DeError, se::SeError};
-use std::{convert::Infallible, error, fmt};
+use std::{convert::Infallible, error, fmt, io, sync::Arc};
 use zbus_names::Error as NamesError;
 use zvariant::Error as VariantError;
 
@@ -15,6 +15,8 @@ pub enum Error {
     Name(NamesError),
     /// An XML parsing error.
     Xml(XmlError),
+    /// An I/O error.
+    Io(Arc<io::Error>),
     /// An XML error from quick_xml
     QuickXml(DeError),
     /// An XML serialization error from quick_xml
@@ -40,6 +42,7 @@ impl error::Error for Error {
             Error::Variant(e) => Some(e),
             Error::Name(e) => Some(e),
             Error::Xml(e) => Some(e),
+            Error::Io(e) => Some(e),
             Error::QuickXml(e) => Some(e),
             Error::QuickXmlSer(e) => Some(e),
         }
@@ -52,6 +55,7 @@ impl fmt::Display for Error {
             Error::Variant(e) => write!(f, "{e}"),
             Error::Name(e) => write!(f, "{e}"),
             Error::Xml(e) => write!(f, "XML error: {e}"),
+            Error::Io(e) => write!(f, "I/O error: {e}"),
             Error::QuickXml(e) => write!(f, "XML error: {e}"),
             Error::QuickXmlSer(e) => write!(f, "XML serialization error: {e}"),
         }
@@ -73,6 +77,12 @@ impl From<NamesError> for Error {
 impl From<XmlError> for Error {
     fn from(val: XmlError) -> Self {
         Error::Xml(val)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(val: io::Error) -> Self {
+        Error::Io(Arc::new(val))
     }
 }
 

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -12,7 +12,9 @@
 )))]
 
 mod error;
-pub use error::{Error, Result};
+pub use error::{Error, Result, XmlError};
+
+mod xml;
 
 use quick_xml::{de::Deserializer, se::to_writer};
 use serde::{Deserialize, Serialize};

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -12,6 +12,8 @@
 )))]
 
 mod error;
+#[allow(deprecated)]
+pub use error::{DeError, SeError};
 pub use error::{Error, Result, XmlError};
 
 mod xml;

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -15,11 +15,11 @@ mod error;
 pub use error::{Error, Result, XmlError};
 
 mod xml;
+use xml::escape;
 
-use quick_xml::{de::Deserializer, se::to_writer};
 use serde::{Deserialize, Serialize};
 use std::{
-    io::{BufReader, Read, Write},
+    io::{BufWriter, Read, Write},
     ops::Deref,
 };
 
@@ -44,6 +44,15 @@ impl Annotation {
     pub fn value(&self) -> &str {
         &self.value
     }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(
+            w,
+            "<annotation name=\"{}\" value=\"{}\"/>",
+            escape(&self.name),
+            escape(&self.value)
+        )
+    }
 }
 
 /// A direction of an argument
@@ -53,6 +62,15 @@ pub enum ArgDirection {
     In,
     #[serde(rename = "out")]
     Out,
+}
+
+impl ArgDirection {
+    fn xml_value(&self) -> &'static str {
+        match self {
+            ArgDirection::In => "in",
+            ArgDirection::Out => "out",
+        }
+    }
 }
 
 /// An argument
@@ -88,6 +106,25 @@ impl Arg {
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(w, "<arg")?;
+        if let Some(name) = &self.name {
+            write!(w, " name=\"{}\"", escape(name))?;
+        }
+        write!(w, " type=\"{}\"", escape(&self.ty.to_string()))?;
+        if let Some(direction) = self.direction {
+            write!(w, " direction=\"{}\"", direction.xml_value())?;
+        }
+        if self.annotations.is_empty() {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for annotation in &self.annotations {
+            annotation.write_xml(w)?;
+        }
+        write!(w, "</arg>")
+    }
 }
 
 /// A method
@@ -115,6 +152,21 @@ impl Method<'_> {
     /// Return the method annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(w, "<method name=\"{}\"", escape(self.name.as_str()))?;
+        if self.args.is_empty() && self.annotations.is_empty() {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for arg in &self.args {
+            arg.write_xml(w)?;
+        }
+        for annotation in &self.annotations {
+            annotation.write_xml(w)?;
+        }
+        write!(w, "</method>")
     }
 }
 
@@ -145,6 +197,21 @@ impl Signal<'_> {
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(w, "<signal name=\"{}\"", escape(self.name.as_str()))?;
+        if self.args.is_empty() && self.annotations.is_empty() {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for arg in &self.args {
+            arg.write_xml(w)?;
+        }
+        for annotation in &self.annotations {
+            annotation.write_xml(w)?;
+        }
+        write!(w, "</signal>")
+    }
 }
 
 /// The possible property access types
@@ -165,6 +232,14 @@ impl PropertyAccess {
 
     pub fn write(&self) -> bool {
         matches!(self, PropertyAccess::Write | PropertyAccess::ReadWrite)
+    }
+
+    fn xml_value(&self) -> &'static str {
+        match self {
+            PropertyAccess::Read => "read",
+            PropertyAccess::Write => "write",
+            PropertyAccess::ReadWrite => "readwrite",
+        }
     }
 }
 
@@ -202,6 +277,24 @@ impl Property<'_> {
     /// Return the associated annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(
+            w,
+            "<property name=\"{}\" type=\"{}\" access=\"{}\"",
+            escape(self.name.as_str()),
+            escape(&self.ty.to_string()),
+            self.access.xml_value()
+        )?;
+        if self.annotations.is_empty() {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for annotation in &self.annotations {
+            annotation.write_xml(w)?;
+        }
+        write!(w, "</property>")
     }
 }
 
@@ -246,6 +339,31 @@ impl<'a> Interface<'a> {
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(w, "<interface name=\"{}\"", escape(self.name.as_str()))?;
+        if self.methods.is_empty()
+            && self.properties.is_empty()
+            && self.signals.is_empty()
+            && self.annotations.is_empty()
+        {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for method in &self.methods {
+            method.write_xml(w)?;
+        }
+        for property in &self.properties {
+            property.write_xml(w)?;
+        }
+        for signal in &self.signals {
+            signal.write_xml(w)?;
+        }
+        for annotation in &self.annotations {
+            annotation.write_xml(w)?;
+        }
+        write!(w, "</interface>")
+    }
 }
 
 /// An introspection tree node (typically the root of the XML document).
@@ -262,27 +380,21 @@ pub struct Node<'a> {
 
 impl<'a> Node<'a> {
     /// Parse the introspection XML document from reader.
-    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'a>> {
-        let mut deserializer = Deserializer::from_reader(BufReader::new(reader));
-        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
-        Ok(Node::deserialize(&mut deserializer)?)
+    ///
+    /// Note that `reader` is consumed until end-of-stream before parsing, so this must not be
+    /// used with a reader that stays open past the end of the document (e.g. a socket).
+    pub fn from_reader<R: Read>(mut reader: R) -> Result<Node<'a>> {
+        let mut input = String::new();
+        reader.read_to_string(&mut input)?;
+
+        xml::parse(&input)
     }
 
     /// Write the XML document to writer.
     pub fn to_writer<W: Write>(&self, writer: W) -> Result<()> {
-        // Need this wrapper until this is resolved: https://github.com/tafia/quick-xml/issues/499
-        struct Writer<T>(T);
-
-        impl<T> std::fmt::Write for Writer<T>
-        where
-            T: Write,
-        {
-            fn write_str(&mut self, s: &str) -> std::fmt::Result {
-                self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
-            }
-        }
-
-        to_writer(Writer(writer), &self)?;
+        let mut writer = BufWriter::new(writer);
+        self.write_xml(&mut writer)?;
+        writer.flush()?;
 
         Ok(())
     }
@@ -301,6 +413,24 @@ impl<'a> Node<'a> {
     pub fn interfaces(&self) -> &[Interface<'a>] {
         &self.interfaces
     }
+
+    fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write!(w, "<node")?;
+        if let Some(name) = &self.name {
+            write!(w, " name=\"{}\"", escape(name))?;
+        }
+        if self.interfaces.is_empty() && self.nodes.is_empty() {
+            return write!(w, "/>");
+        }
+        write!(w, ">")?;
+        for interface in &self.interfaces {
+            interface.write_xml(w)?;
+        }
+        for node in &self.nodes {
+            node.write_xml(w)?;
+        }
+        write!(w, "</node>")
+    }
 }
 
 impl<'a> TryFrom<&'a str> for Node<'a> {
@@ -308,16 +438,14 @@ impl<'a> TryFrom<&'a str> for Node<'a> {
 
     /// Parse the introspection XML document from `s`.
     fn try_from(s: &'a str) -> Result<Node<'a>> {
-        let mut deserializer = Deserializer::from_str(s);
-        deserializer.event_buffer_size(Some(4096_usize.try_into().unwrap()));
-        Ok(Node::deserialize(&mut deserializer)?)
+        xml::parse(s)
     }
 }
 
 /// A thin wrapper around `zvariant::parsed::Signature`.
 ///
-/// This is to allow `Signature` to be deserialized from an owned string, which is what quick-xml2
-/// deserializer does.
+/// This is to allow `Signature` to be deserialized from an owned string, which is what XML
+/// deserializers typically produce.
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct Signature(zvariant::Signature);
 

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -1,0 +1,811 @@
+//! A parser for D-Bus introspection XML, and a matching attribute-value escaping helper.
+//!
+//! Introspection XML only uses elements and attributes, so rather than reaching for a
+//! general-purpose XML library this is a small [`winnow`] parser that recognises exactly the
+//! D-Bus introspection grammar — `<node>`, `<interface>`, `<method>`, `<signal>`, `<property>`,
+//! `<arg>` and `<annotation>` — and builds the [`Node`] tree directly, one combinator per
+//! element deciding which attributes are required, which are optional, and which child elements
+//! are expected. Everything else a real document may carry (the XML declaration, a doctype,
+//! comments, processing instructions, CDATA and foreign elements such as Telepathy's
+//! `<tp:docstring>`) is recognised only well enough to skip over it.
+
+use std::{borrow::Cow, collections::HashSet};
+
+use winnow::{
+    LocatingSlice, ModalResult, Parser,
+    combinator::{alt, cut_err, delimited, eof, opt, preceded, repeat},
+    error::{ErrMode, ParserError},
+    stream::Location,
+    token::{any, take_till, take_until, take_while},
+};
+use zbus_names::{InterfaceName, MemberName, PropertyName};
+
+use crate::{
+    Annotation, Arg, ArgDirection, Interface, Method, Node, Property, PropertyAccess, Signal,
+    Signature,
+    error::{Error, Result, XmlError},
+};
+
+/// The maximum element nesting depth accepted when parsing.
+///
+/// Far deeper than any real introspection tree (four levels, plus one per nested `<node>`). The
+/// parser iterates rather than recurses over the two axes where a document can nest arbitrarily
+/// deep — nested `<node>`s and skipped-over foreign elements — so this cap only bounds the memory
+/// spent tracking the open elements, not the call stack.
+const MAX_DEPTH: usize = 1024;
+
+/// Parse a D-Bus introspection document into its [`Node`] tree.
+pub(crate) fn parse<'a>(document: &str) -> Result<Node<'a>> {
+    let mut input = LocatingSlice::new(document);
+    match document_node(&mut input) {
+        // The tree owns its data, so it outlives `document` and satisfies any caller lifetime.
+        Ok(node) => Ok(node),
+        Err(ErrMode::Backtrack(error) | ErrMode::Cut(error)) => Err(error.into_error()),
+        Err(ErrMode::Incomplete(_)) => Err(Error::Xml(XmlError::new(
+            "unexpected end of document",
+            document.len(),
+        ))),
+    }
+}
+
+/// The document's root element, preceded by an optional prolog (declaration, doctype, comments).
+///
+/// The root element's name is not checked, for compatibility with servers that don't name it
+/// `node` and with how previous (quick-xml-based) versions of this crate behaved.
+fn document_node<'i>(input: &mut Input<'i>) -> PResult<Node<'static>> {
+    ignorable(input)?;
+    if opt(eof).parse_next(input)?.is_some() {
+        return Err(error("missing root element", input));
+    }
+    let (tag, attrs, self_closing) = start_element(input)?;
+
+    node(input, tag, attrs, self_closing)
+}
+
+/// The input stream: byte offsets come from [`LocatingSlice`], for error reporting.
+type Input<'i> = LocatingSlice<&'i str>;
+
+/// A parser result, using [`ParseError`] as winnow's error type.
+type PResult<O> = ModalResult<O, ParseError>;
+
+/// A parse failure: either a positioned structural/XML error, or a rejected value (an invalid
+/// name or signature) that carries the matching [`Error`] variant.
+#[derive(Debug)]
+enum ParseError {
+    Xml {
+        message: Cow<'static, str>,
+        offset: usize,
+    },
+    Domain(Error),
+}
+
+impl ParseError {
+    /// A fatal XML error at `offset`.
+    fn xml(message: impl Into<Cow<'static, str>>, offset: usize) -> ErrMode<Self> {
+        ErrMode::Cut(ParseError::Xml {
+            message: message.into(),
+            offset,
+        })
+    }
+
+    /// A fatal error from rejecting a value (an invalid name or signature).
+    fn domain(error: Error) -> ErrMode<Self> {
+        ErrMode::Cut(ParseError::Domain(error))
+    }
+
+    fn into_error(self) -> Error {
+        match self {
+            ParseError::Xml { message, offset } => Error::Xml(XmlError::new(message, offset)),
+            ParseError::Domain(error) => error,
+        }
+    }
+}
+
+impl<'i> ParserError<Input<'i>> for ParseError {
+    type Inner = Self;
+
+    fn from_input(input: &Input<'i>) -> Self {
+        ParseError::Xml {
+            message: Cow::Borrowed("malformed markup"),
+            offset: input.current_token_start(),
+        }
+    }
+
+    fn into_inner(self) -> std::result::Result<Self::Inner, Self> {
+        Ok(self)
+    }
+}
+
+/// A fatal XML error at the input's current position.
+fn error(message: impl Into<Cow<'static, str>>, input: &Input<'_>) -> ErrMode<ParseError> {
+    ParseError::xml(message, input.current_token_start())
+}
+
+/// A `<node>` and its subtree.
+///
+/// Nested `<node>`s — the one axis on which an introspection tree itself can nest arbitrarily
+/// deep — are walked iteratively on an explicit stack, so that a deeply nested document grows
+/// this `Vec` rather than the call stack. Interfaces (and their fixed, shallow subtrees) recurse
+/// normally.
+fn node<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Node<'static>> {
+    let root = empty_node(&attrs);
+    if self_closing {
+        return Ok(root);
+    }
+
+    let mut open: Vec<(&'i str, Node<'static>)> = vec![(tag, root)];
+    loop {
+        ignorable(input)?;
+        let tag = open.last().expect("the root is popped only by returning").0;
+        if opt(eof).parse_next(input)?.is_some() {
+            return Err(error(format!("missing `</{tag}>`"), input));
+        }
+        if let Some(close) = opt(closing_tag).parse_next(input)? {
+            if close != tag {
+                return Err(error(
+                    format!("unexpected `</{close}>` while parsing `<{tag}>`"),
+                    input,
+                ));
+            }
+            let (_, finished) = open.pop().expect("a close tag was just matched");
+            match open.last_mut() {
+                Some((_, parent)) => parent.nodes.push(finished),
+                None => return Ok(finished),
+            }
+            continue;
+        }
+
+        let (child, child_attrs, child_self_closing) = start_element(input)?;
+        match child {
+            "interface" => {
+                let interface = interface(input, child, child_attrs, child_self_closing)?;
+                open.last_mut()
+                    .expect("non-empty")
+                    .1
+                    .interfaces
+                    .push(interface);
+            }
+            "node" if child_self_closing => {
+                open.last_mut()
+                    .expect("non-empty")
+                    .1
+                    .nodes
+                    .push(empty_node(&child_attrs));
+            }
+            "node" => {
+                if open.len() >= MAX_DEPTH {
+                    return Err(error("maximum element nesting depth exceeded", input));
+                }
+                open.push((child, empty_node(&child_attrs)));
+            }
+            _ => skip_element(input, child, child_self_closing)?,
+        }
+    }
+}
+
+/// A `<node>` with only its `name`, ready to be filled in.
+fn empty_node(attrs: &Attrs<'_>) -> Node<'static> {
+    Node {
+        name: attrs.optional("name").map(str::to_owned),
+        interfaces: Vec::new(),
+        nodes: Vec::new(),
+    }
+}
+
+/// An `<interface>` and its members.
+fn interface<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Interface<'static>> {
+    let name = attrs.name(|n| InterfaceName::try_from(n).map_err(Error::Name))?;
+    let mut methods = Vec::new();
+    let mut properties = Vec::new();
+    let mut signals = Vec::new();
+    let mut annotations = Vec::new();
+    children(
+        input,
+        tag,
+        self_closing,
+        |input, child, attrs, sc| match child {
+            "method" => {
+                methods.push(method(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            "property" => {
+                properties.push(property(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            "signal" => {
+                signals.push(signal(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            "annotation" => {
+                annotations.push(annotation(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    )?;
+
+    Ok(Interface {
+        name,
+        methods,
+        properties,
+        signals,
+        annotations,
+    })
+}
+
+/// A `<method>` with its arguments and annotations.
+fn method<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Method<'static>> {
+    let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Name))?;
+    let mut args = Vec::new();
+    let mut annotations = Vec::new();
+    children(
+        input,
+        tag,
+        self_closing,
+        |input, child, attrs, sc| match child {
+            "arg" => {
+                args.push(arg(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            "annotation" => {
+                annotations.push(annotation(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    )?;
+
+    Ok(Method {
+        name,
+        args,
+        annotations,
+    })
+}
+
+/// A `<signal>` with its arguments and annotations.
+fn signal<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Signal<'static>> {
+    let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Name))?;
+    let mut args = Vec::new();
+    let mut annotations = Vec::new();
+    children(
+        input,
+        tag,
+        self_closing,
+        |input, child, attrs, sc| match child {
+            "arg" => {
+                args.push(arg(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            "annotation" => {
+                annotations.push(annotation(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    )?;
+
+    Ok(Signal {
+        name,
+        args,
+        annotations,
+    })
+}
+
+/// A `<property>`: a `name`, a `type` signature, an `access` mode and any annotations.
+fn property<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Property<'static>> {
+    let name = attrs.name(|n| PropertyName::try_from(n).map_err(Error::Name))?;
+    let ty = attrs.signature()?;
+    let access = match attrs.required("access")? {
+        "read" => PropertyAccess::Read,
+        "write" => PropertyAccess::Write,
+        "readwrite" => PropertyAccess::ReadWrite,
+        other => return Err(error(format!("invalid property access `{other}`"), input)),
+    };
+    let mut annotations = Vec::new();
+    children(
+        input,
+        tag,
+        self_closing,
+        |input, child, attrs, sc| match child {
+            "annotation" => {
+                annotations.push(annotation(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    )?;
+
+    Ok(Property {
+        name,
+        ty,
+        access,
+        annotations,
+    })
+}
+
+/// An `<arg>`: an optional `name`, a `type` signature, an optional `direction` and annotations.
+fn arg<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Arg> {
+    let name = attrs.optional("name").map(str::to_owned);
+    let ty = attrs.signature()?;
+    let direction = match attrs.optional("direction") {
+        Some("in") => Some(ArgDirection::In),
+        Some("out") => Some(ArgDirection::Out),
+        Some(other) => {
+            return Err(error(
+                format!("invalid argument direction `{other}`"),
+                input,
+            ));
+        }
+        None => None,
+    };
+    let mut annotations = Vec::new();
+    children(
+        input,
+        tag,
+        self_closing,
+        |input, child, attrs, sc| match child {
+            "annotation" => {
+                annotations.push(annotation(input, child, attrs, sc)?);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    )?;
+
+    Ok(Arg {
+        name,
+        ty,
+        direction,
+        annotations,
+    })
+}
+
+/// An `<annotation>`: a `name`/`value` pair. Its content, if any, is ignored.
+fn annotation<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Annotation> {
+    let name = attrs.required("name")?.to_owned();
+    let value = attrs.required("value")?.to_owned();
+    children(input, tag, self_closing, |_, _, _, _| Ok(false))?;
+
+    Ok(Annotation { name, value })
+}
+
+/// Dispatch each child element of the just-opened `<tag>` to `handle`, skipping over content it
+/// does not claim, until the matching `</tag>`.
+///
+/// `handle` returns whether it consumed the element's body; elements it declines (returns
+/// `Ok(false)` for) are skipped along with their subtree.
+fn children<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    self_closing: bool,
+    mut handle: impl FnMut(&mut Input<'i>, &'i str, Attrs<'i>, bool) -> PResult<bool>,
+) -> PResult<()> {
+    if self_closing {
+        return Ok(());
+    }
+    loop {
+        ignorable(input)?;
+        if opt(eof).parse_next(input)?.is_some() {
+            return Err(error(format!("missing `</{tag}>`"), input));
+        }
+        if let Some(close) = opt(closing_tag).parse_next(input)? {
+            if close != tag {
+                return Err(error(
+                    format!("unexpected `</{close}>` while parsing `<{tag}>`"),
+                    input,
+                ));
+            }
+            return Ok(());
+        }
+        let (child, attrs, self_closing) = start_element(input)?;
+        if !handle(input, child, attrs, self_closing)? {
+            skip_element(input, child, self_closing)?;
+        }
+    }
+}
+
+/// Skip an element whose start tag has been read, along with its whole subtree.
+///
+/// Iterative (tracking the open elements on a `Vec`) so that a deeply nested foreign element
+/// cannot exhaust the call stack.
+fn skip_element<'i>(input: &mut Input<'i>, tag: &'i str, self_closing: bool) -> PResult<()> {
+    if self_closing {
+        return Ok(());
+    }
+    let mut open = vec![tag];
+    while let Some(&expected) = open.last() {
+        ignorable(input)?;
+        if opt(eof).parse_next(input)?.is_some() {
+            return Err(error(format!("missing `</{expected}>`"), input));
+        }
+        if let Some(close) = opt(closing_tag).parse_next(input)? {
+            if close != expected {
+                return Err(error(
+                    format!("unexpected `</{close}>` while parsing `<{expected}>`"),
+                    input,
+                ));
+            }
+            open.pop();
+            continue;
+        }
+        let (child, _, self_closing) = start_element(input)?;
+        if !self_closing {
+            if open.len() >= MAX_DEPTH {
+                return Err(error("maximum element nesting depth exceeded", input));
+            }
+            open.push(child);
+        }
+    }
+
+    Ok(())
+}
+
+/// Consume any content that carries no introspection data: whitespace and text, comments, CDATA
+/// sections, processing instructions and markup declarations. Stops at the next element boundary.
+fn ignorable<'i>(input: &mut Input<'i>) -> PResult<()> {
+    repeat(
+        0..,
+        alt((
+            comment,
+            cdata,
+            processing_instruction,
+            markup_declaration,
+            text,
+        )),
+    )
+    .parse_next(input)
+}
+
+/// An XML comment: `<!-- … -->`.
+fn comment<'i>(input: &mut Input<'i>) -> PResult<()> {
+    ("<!--", cut_err((take_until(0.., "-->"), "-->")))
+        .void()
+        .parse_next(input)
+}
+
+/// A CDATA section: `<![CDATA[ … ]]>`.
+fn cdata<'i>(input: &mut Input<'i>) -> PResult<()> {
+    ("<![CDATA[", cut_err((take_until(0.., "]]>"), "]]>")))
+        .void()
+        .parse_next(input)
+}
+
+/// A processing instruction, e. g. the `<?xml … ?>` declaration.
+fn processing_instruction<'i>(input: &mut Input<'i>) -> PResult<()> {
+    ("<?", cut_err((take_until(0.., "?>"), "?>")))
+        .void()
+        .parse_next(input)
+}
+
+/// A markup declaration such as `<!DOCTYPE …>`.
+///
+/// Tried after [`comment`] and [`cdata`], which also open with `<!`.
+fn markup_declaration<'i>(input: &mut Input<'i>) -> PResult<()> {
+    preceded("<!", cut_err(markup_body)).parse_next(input)
+}
+
+/// The body of a markup declaration, up to and including the terminating `>`.
+///
+/// A `>` inside a quoted literal or an internal subset (`[ … ]`, which may itself contain `>`s)
+/// does not terminate the declaration.
+fn markup_body<'i>(input: &mut Input<'i>) -> PResult<()> {
+    let mut bracket_depth = 0usize;
+    loop {
+        match any.parse_next(input)? {
+            quote @ ('"' | '\'') => {
+                (take_until(0.., quote), any).void().parse_next(input)?;
+            }
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '>' if bracket_depth == 0 => return Ok(()),
+            _ => (),
+        }
+    }
+}
+
+/// A run of character data between tags (carries no introspection data, so ignored).
+fn text<'i>(input: &mut Input<'i>) -> PResult<()> {
+    take_till(1.., '<').void().parse_next(input)
+}
+
+/// A closing tag such as `</node>`, yielding the element name.
+fn closing_tag<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
+    delimited("</", xml_name, (whitespace, '>')).parse_next(input)
+}
+
+/// A start tag such as `<arg name="foo" type="s">`, or the self-closing `<arg … />`, yielding
+/// the element name, its [`Attrs`] and whether it is self-closing.
+fn start_element<'i>(input: &mut Input<'i>) -> PResult<(&'i str, Attrs<'i>, bool)> {
+    let (name, span) = preceded('<', xml_name.with_span()).parse_next(input)?;
+    let pairs = attributes(input)?;
+    let self_closing =
+        preceded(whitespace, alt(("/>".value(true), ">".value(false)))).parse_next(input)?;
+
+    Ok((
+        name,
+        Attrs {
+            element: name,
+            offset: span.start,
+            pairs,
+        },
+        self_closing,
+    ))
+}
+
+/// The attributes of an element: names paired with their unescaped values, in document order.
+struct Attrs<'i> {
+    /// The element name, for error messages.
+    element: &'i str,
+    /// The byte offset of the element name, for missing-attribute errors.
+    offset: usize,
+    pairs: Vec<(&'i str, Cow<'i, str>)>,
+}
+
+impl<'i> Attrs<'i> {
+    /// The value of `key`, if present.
+    fn optional(&self, key: &str) -> Option<&str> {
+        self.pairs
+            .iter()
+            .find(|(name, _)| *name == key)
+            .map(|(_, value)| value.as_ref())
+    }
+
+    /// The value of `key`, or a "missing attribute" error anchored at the element.
+    fn required(&self, key: &str) -> PResult<&str> {
+        self.optional(key).ok_or_else(|| {
+            ParseError::xml(
+                format!("missing attribute `{key}` on `<{}>`", self.element),
+                self.offset,
+            )
+        })
+    }
+
+    /// The required `name` attribute, validated by `parse` (e. g. into an [`InterfaceName`]).
+    fn name<T>(&self, parse: impl FnOnce(String) -> std::result::Result<T, Error>) -> PResult<T> {
+        parse(self.required("name")?.to_owned()).map_err(ParseError::domain)
+    }
+
+    /// The required `type` attribute, parsed as a signature.
+    fn signature(&self) -> PResult<Signature> {
+        zvariant::Signature::try_from(self.required("type")?.as_bytes())
+            .map(Signature)
+            .map_err(|e| ParseError::domain(zvariant::Error::from(e).into()))
+    }
+}
+
+/// The attributes of an element, unescaped and with duplicates rejected.
+fn attributes<'i>(input: &mut Input<'i>) -> PResult<Vec<(&'i str, Cow<'i, str>)>> {
+    let raw: Vec<Attribute<'i>> = repeat(0.., attribute).parse_next(input)?;
+    let mut pairs: Vec<(&'i str, Cow<'i, str>)> = Vec::with_capacity(raw.len());
+    // Real elements carry only a few attributes, for which a linear duplicate scan is cheapest;
+    // but that scan is O(n²), so once a (only ever hostile) tag grows past a threshold, track the
+    // names in a set to keep the work linear.
+    let mut seen: Option<HashSet<&'i str>> = None;
+    for attr in raw {
+        let duplicate = match seen {
+            Some(ref mut seen) => !seen.insert(attr.name),
+            None => {
+                let duplicate = pairs.iter().any(|(name, _)| *name == attr.name);
+                if !duplicate && pairs.len() >= 32 {
+                    let mut set: HashSet<&'i str> = pairs.iter().map(|(name, _)| *name).collect();
+                    set.insert(attr.name);
+                    seen = Some(set);
+                }
+                duplicate
+            }
+        };
+        if duplicate {
+            return Err(ParseError::xml(
+                format!("duplicate attribute `{}`", attr.name),
+                attr.name_offset,
+            ));
+        }
+        let value = unescape(attr.value)
+            .map_err(|(message, at)| ParseError::xml(message, attr.value_offset + at))?;
+        pairs.push((attr.name, value));
+    }
+
+    Ok(pairs)
+}
+
+/// A single attribute with the byte offsets needed to anchor errors precisely.
+struct Attribute<'i> {
+    name: &'i str,
+    name_offset: usize,
+    /// The raw (still escaped) value.
+    value: &'i str,
+    value_offset: usize,
+}
+
+/// A single attribute, e. g. `name="foo"`, along with the whitespace XML requires before it.
+///
+/// The mandatory leading whitespace is what rejects run-together attributes like
+/// `name="a"type="s"`.
+fn attribute<'i>(input: &mut Input<'i>) -> PResult<Attribute<'i>> {
+    let (name, name_span) = preceded(whitespace1, xml_name.with_span()).parse_next(input)?;
+    (whitespace, '=', whitespace).parse_next(input)?;
+    let (value, value_offset) = quoted_value(input)?;
+
+    Ok(Attribute {
+        name,
+        name_offset: name_span.start,
+        value,
+        value_offset,
+    })
+}
+
+/// An element or attribute name: everything up to a delimiter.
+///
+/// Names are only tokenized here, not validated against the XML grammar: the parser only ever
+/// compares them against the fixed set of introspection names.
+fn xml_name<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
+    take_while(1.., |c: char| {
+        !c.is_ascii_whitespace() && !matches!(c, '=' | '/' | '>' | '<')
+    })
+    .parse_next(input)
+}
+
+/// A quoted attribute value, returning its raw (still escaped) contents and their byte offset.
+fn quoted_value<'i>(input: &mut Input<'i>) -> PResult<(&'i str, usize)> {
+    alt((
+        delimited('"', take_until(0.., '"').with_span(), '"'),
+        delimited('\'', take_until(0.., '\'').with_span(), '\''),
+    ))
+    .map(|(value, span)| (value, span.start))
+    .parse_next(input)
+}
+
+/// Optional run of XML whitespace.
+fn whitespace<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
+    take_while(0.., |c: char| c.is_ascii_whitespace()).parse_next(input)
+}
+
+/// At least one XML whitespace character.
+fn whitespace1<'i>(input: &mut Input<'i>) -> PResult<&'i str> {
+    take_while(1.., |c: char| c.is_ascii_whitespace()).parse_next(input)
+}
+
+/// Resolve entity and character references in an attribute value and normalize whitespace.
+///
+/// Per the XML attribute-value normalization rules, literal whitespace characters are replaced
+/// with spaces, while whitespace escaped through character references (e.g. `&#10;`) is kept. A
+/// literal `\r\n` collapses to a single space, as line-ending normalization (which folds it to a
+/// lone `\n`) precedes attribute-value normalization. On failure, the error carries the byte
+/// offset of the offending reference within `value`.
+fn unescape(value: &str) -> std::result::Result<Cow<'_, str>, (String, usize)> {
+    if !value.contains(['&', '\t', '\n', '\r']) {
+        return Ok(Cow::Borrowed(value));
+    }
+
+    let mut unescaped = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(i) = rest.find(['&', '\t', '\n', '\r']) {
+        unescaped.push_str(&rest[..i]);
+        let reference = value.len() - rest.len() + i;
+        if rest.as_bytes()[i] != b'&' {
+            unescaped.push(' ');
+            // A `\r\n` pair is a single line ending, so it normalizes to one space, not two.
+            let width = if rest.as_bytes()[i] == b'\r' && rest.as_bytes().get(i + 1) == Some(&b'\n')
+            {
+                2
+            } else {
+                1
+            };
+            rest = &rest[i + width..];
+            continue;
+        }
+        rest = &rest[i + 1..];
+        let end = rest
+            .find(';')
+            .ok_or(("unterminated entity reference".to_string(), reference))?;
+        let entity = &rest[..end];
+        match entity {
+            "amp" => unescaped.push('&'),
+            "lt" => unescaped.push('<'),
+            "gt" => unescaped.push('>'),
+            "quot" => unescaped.push('"'),
+            "apos" => unescaped.push('\''),
+            _ => unescaped.push(char_reference(entity).map_err(|e| (e, reference))?),
+        }
+        rest = &rest[end + 1..];
+    }
+    unescaped.push_str(rest);
+
+    Ok(Cow::Owned(unescaped))
+}
+
+/// Resolve a numeric character reference (the part of `&#...;` between `&` and `;`).
+fn char_reference(entity: &str) -> std::result::Result<char, String> {
+    let invalid = || format!("invalid character reference `&{entity};`");
+
+    let code = if let Some(hex) = entity
+        .strip_prefix("#x")
+        .or_else(|| entity.strip_prefix("#X"))
+    {
+        if hex.is_empty() || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(invalid());
+        }
+        u32::from_str_radix(hex, 16).ok()
+    } else if let Some(dec) = entity.strip_prefix('#') {
+        if dec.is_empty() || !dec.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(invalid());
+        }
+        dec.parse().ok()
+    } else {
+        return Err(format!("unknown entity `&{entity};`"));
+    };
+
+    code.and_then(char::from_u32)
+        .filter(|c| is_xml_char(*c))
+        .ok_or_else(invalid)
+}
+
+/// Whether `c` is a valid XML 1.0 character (the `Char` production).
+fn is_xml_char(c: char) -> bool {
+    matches!(
+        c,
+        '\u{9}' | '\u{A}' | '\u{D}' | '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}'
+    )
+}
+
+/// Escape a string for use as an attribute value.
+///
+/// Whitespace other than the space character is escaped as character references so that it
+/// survives the attribute-value normalization done by parsers.
+pub(crate) fn escape(value: &str) -> Cow<'_, str> {
+    if !value.contains(['&', '<', '>', '"', '\'', '\t', '\n', '\r']) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut escaped = String::with_capacity(value.len() + 8);
+    for c in value.chars() {
+        match c {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            '\t' => escaped.push_str("&#9;"),
+            '\n' => escaped.push_str("&#10;"),
+            '\r' => escaped.push_str("&#13;"),
+            c => escaped.push(c),
+        }
+    }
+
+    Cow::Owned(escaped)
+}

--- a/zbus_xml/tests/data/real_world/README.md
+++ b/zbus_xml/tests/data/real_world/README.md
@@ -1,0 +1,32 @@
+# Real-world introspection documents
+
+Introspection XML captured verbatim from live D-Bus services (running on Ubuntu 24.04), by
+launching each service on a real bus and calling `org.freedesktop.DBus.Introspectable.Introspect`
+on it:
+
+```sh
+busctl call <dest> <path> org.freedesktop.DBus.Introspectable Introspect --json=short \
+    | jq -r '.data[0]'
+```
+
+The documents are intentionally untouched — whatever the service sent is what is in the file — so
+that the parser is exercised with the exact bytes it will encounter in the wild, across the XML
+flavors produced by sd-bus, libdbus and GDBus.
+
+| File | Service (version) | Object path |
+|------|-------------------|-------------|
+| `dbus_daemon.xml` | `dbus-daemon` (1.14.10) | `/org/freedesktop/DBus` |
+| `systemd1_manager.xml` | `systemd --user` (255.4) | `/org/freedesktop/systemd1` |
+| `systemd1_scope_unit.xml` | `systemd --user` (255.4) | `/org/freedesktop/systemd1/unit/init_2escope` |
+| `systemd1_unit_list.xml` | `systemd --user` (255.4) | `/org/freedesktop/systemd1/unit` |
+| `hostname1.xml` | `systemd-hostnamed` (255.4) | `/org/freedesktop/hostname1` |
+| `timedate1.xml` | `systemd-timedated` (255.4) | `/org/freedesktop/timedate1` |
+| `locale1.xml` | `systemd-localed` (255.4) | `/org/freedesktop/locale1` |
+| `login1.xml` | `systemd-logind` (255.4) | `/org/freedesktop/login1` |
+| `network1.xml` | `systemd-networkd` (255.4) | `/org/freedesktop/network1` |
+| `polkit1_authority.xml` | `polkitd` (124) | `/org/freedesktop/PolicyKit1/Authority` |
+| `packagekit.xml` | `packagekitd` (1.2.8) | `/org/freedesktop/PackageKit` |
+| `dconf_writer.xml` | `dconf-service` (0.40.0, GDBus 2.80.0) | `/ca/desrt/dconf/Writer/user` |
+
+Note: `systemd1_manager.xml` and `login1.xml` contain `h` (file descriptor) signatures, which
+zvariant only supports on Unix — parsing these documents fails on other platforms.

--- a/zbus_xml/tests/data/real_world/dbus_daemon.xml
+++ b/zbus_xml/tests/data/real_world/dbus_daemon.xml
@@ -1,0 +1,150 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus">
+    <method name="Hello">
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="RequestName">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="u"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="ReleaseName">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="StartServiceByName">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="u"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="UpdateActivationEnvironment">
+      <arg direction="in" type="a{ss}"/>
+    </method>
+    <method name="NameHasOwner">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="b"/>
+    </method>
+    <method name="ListNames">
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="ListActivatableNames">
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="AddMatch">
+      <arg direction="in" type="s"/>
+    </method>
+    <method name="RemoveMatch">
+      <arg direction="in" type="s"/>
+    </method>
+    <method name="GetNameOwner">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="ListQueuedOwners">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="GetConnectionUnixUser">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="GetConnectionUnixProcessID">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="GetAdtAuditSessionData">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="ay"/>
+    </method>
+    <method name="GetConnectionSELinuxSecurityContext">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="ay"/>
+    </method>
+    <method name="GetConnectionAppArmorSecurityContext">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="ReloadConfig">
+    </method>
+    <method name="GetId">
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="GetConnectionCredentials">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <property name="Features" type="as" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+    </property>
+    <property name="Interfaces" type="as" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+    </property>
+    <signal name="NameOwnerChanged">
+      <arg type="s"/>
+      <arg type="s"/>
+      <arg type="s"/>
+    </signal>
+    <signal name="NameLost">
+      <arg type="s"/>
+    </signal>
+    <signal name="NameAcquired">
+      <arg type="s"/>
+    </signal>
+    <signal name="ActivatableServicesChanged">
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <method name="Set">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="v"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg type="s" name="interface_name"/>
+      <arg type="a{sv}" name="changed_properties"/>
+      <arg type="as" name="invalidated_properties"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Monitoring">
+    <method name="BecomeMonitor">
+      <arg direction="in" type="as"/>
+      <arg direction="in" type="u"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Debug.Stats">
+    <method name="GetStats">
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <method name="GetConnectionStats">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <method name="GetAllMatchRules">
+      <arg direction="out" type="a{sas}"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="GetMachineId">
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="Ping">
+    </method>
+  </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/dconf_writer.xml
+++ b/zbus_xml/tests/data/real_world/dconf_writer.xml
@@ -1,0 +1,50 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.80.0 -->
+<node>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="out"/>
+    </method>
+    <method name="GetAll">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="a{sv}" name="properties" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="in"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg type="s" name="interface_name"/>
+      <arg type="a{sv}" name="changed_properties"/>
+      <arg type="as" name="invalidated_properties"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" name="xml_data" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg type="s" name="machine_uuid" direction="out"/>
+    </method>
+  </interface>
+  <interface name="ca.desrt.dconf.Writer">
+    <method name="Init"/>
+    <method name="Change">
+      <arg type="ay" name="blob" direction="in"/>
+      <arg type="s" name="tag" direction="out"/>
+    </method>
+    <signal name="Notify">
+      <arg type="s" name="prefix"/>
+      <arg type="as" name="changes"/>
+      <arg type="s" name="tag"/>
+    </signal>
+  </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/hostname1.xml
+++ b/zbus_xml/tests/data/real_world/hostname1.xml
@@ -1,0 +1,138 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.hostname1">
+  <property name="Hostname" type="s" access="read">
+  </property>
+  <property name="StaticHostname" type="s" access="read">
+  </property>
+  <property name="PrettyHostname" type="s" access="read">
+  </property>
+  <property name="DefaultHostname" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HostnameSource" type="s" access="read">
+  </property>
+  <property name="IconName" type="s" access="read">
+  </property>
+  <property name="Chassis" type="s" access="read">
+  </property>
+  <property name="Deployment" type="s" access="read">
+  </property>
+  <property name="Location" type="s" access="read">
+  </property>
+  <property name="KernelName" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KernelRelease" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KernelVersion" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OperatingSystemPrettyName" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OperatingSystemCPEName" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OperatingSystemSupportEnd" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HomeURL" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HardwareVendor" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HardwareModel" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FirmwareVersion" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FirmwareVendor" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FirmwareDate" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="MachineID" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="BootID" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <method name="SetHostname">
+   <arg type="s" name="hostname" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetStaticHostname">
+   <arg type="s" name="hostname" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetPrettyHostname">
+   <arg type="s" name="hostname" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetIconName">
+   <arg type="s" name="icon" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetChassis">
+   <arg type="s" name="chassis" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetDeployment">
+   <arg type="s" name="deployment" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetLocation">
+   <arg type="s" name="location" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="GetProductUUID">
+   <arg type="b" name="interactive" direction="in"/>
+   <arg type="ay" name="uuid" direction="out"/>
+  </method>
+  <method name="GetHardwareSerial">
+   <arg type="s" name="serial" direction="out"/>
+  </method>
+  <method name="Describe">
+   <arg type="s" name="json" direction="out"/>
+  </method>
+ </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/locale1.xml
+++ b/zbus_xml/tests/data/real_world/locale1.xml
@@ -1,0 +1,71 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.locale1">
+  <property name="Locale" type="as" access="read">
+  </property>
+  <property name="X11Layout" type="s" access="read">
+  </property>
+  <property name="X11Model" type="s" access="read">
+  </property>
+  <property name="X11Variant" type="s" access="read">
+  </property>
+  <property name="X11Options" type="s" access="read">
+  </property>
+  <property name="VConsoleKeymap" type="s" access="read">
+  </property>
+  <property name="VConsoleKeymapToggle" type="s" access="read">
+  </property>
+  <method name="SetLocale">
+   <arg type="as" name="locale" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetVConsoleKeyboard">
+   <arg type="s" name="keymap" direction="in"/>
+   <arg type="s" name="keymap_toggle" direction="in"/>
+   <arg type="b" name="convert" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetX11Keyboard">
+   <arg type="s" name="layout" direction="in"/>
+   <arg type="s" name="model" direction="in"/>
+   <arg type="s" name="variant" direction="in"/>
+   <arg type="s" name="options" direction="in"/>
+   <arg type="b" name="convert" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+ </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/login1.xml
+++ b/zbus_xml/tests/data/real_world/login1.xml
@@ -1,0 +1,450 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.login1.Manager">
+  <property name="EnableWallMessages" type="b" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
+  <property name="WallMessage" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
+  <property name="NAutoVTs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillOnlyUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillExcludeUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillUserProcesses" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RebootParameter" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToFirmwareSetup" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderMenu" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderEntry" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BootLoaderEntries" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="BlockInhibited" type="s" access="read">
+  </property>
+  <property name="DelayInhibited" type="s" access="read">
+  </property>
+  <property name="InhibitDelayMaxUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UserStopDelayUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleRebootKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleRebootKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchExternalPower" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchDocked" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HoldoffTimeoutUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleActionUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PreparingForShutdown" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="PreparingForSleep" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ScheduledShutdown" type="(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Docked" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="LidClosed" type="b" access="read">
+  </property>
+  <property name="OnExternalPower" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RemoveIPC" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectorySize" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectoryInodesMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InhibitorsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentInhibitors" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SessionsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentSessions" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StopIdleSessionUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <method name="GetSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetSessionByPID">
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetUser">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetUserByPID">
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetSeat">
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="ListSessions">
+   <arg type="a(susso)" name="sessions" direction="out"/>
+  </method>
+  <method name="ListUsers">
+   <arg type="a(uso)" name="users" direction="out"/>
+  </method>
+  <method name="ListSeats">
+   <arg type="a(so)" name="seats" direction="out"/>
+  </method>
+  <method name="ListInhibitors">
+   <arg type="a(ssssuu)" name="inhibitors" direction="out"/>
+  </method>
+  <method name="CreateSession">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="s" name="service" direction="in"/>
+   <arg type="s" name="type" direction="in"/>
+   <arg type="s" name="class" direction="in"/>
+   <arg type="s" name="desktop" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="u" name="vtnr" direction="in"/>
+   <arg type="s" name="tty" direction="in"/>
+   <arg type="s" name="display" direction="in"/>
+   <arg type="b" name="remote" direction="in"/>
+   <arg type="s" name="remote_user" direction="in"/>
+   <arg type="s" name="remote_host" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+   <arg type="s" name="session_id" direction="out"/>
+   <arg type="o" name="object_path" direction="out"/>
+   <arg type="s" name="runtime_path" direction="out"/>
+   <arg type="h" name="fifo_fd" direction="out"/>
+   <arg type="u" name="uid" direction="out"/>
+   <arg type="s" name="seat_id" direction="out"/>
+   <arg type="u" name="vtnr" direction="out"/>
+   <arg type="b" name="existing" direction="out"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="CreateSessionWithPIDFD">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="h" name="pidfd" direction="in"/>
+   <arg type="s" name="service" direction="in"/>
+   <arg type="s" name="type" direction="in"/>
+   <arg type="s" name="class" direction="in"/>
+   <arg type="s" name="desktop" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="u" name="vtnr" direction="in"/>
+   <arg type="s" name="tty" direction="in"/>
+   <arg type="s" name="display" direction="in"/>
+   <arg type="b" name="remote" direction="in"/>
+   <arg type="s" name="remote_user" direction="in"/>
+   <arg type="s" name="remote_host" direction="in"/>
+   <arg type="t" name="flags" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+   <arg type="s" name="session_id" direction="out"/>
+   <arg type="o" name="object_path" direction="out"/>
+   <arg type="s" name="runtime_path" direction="out"/>
+   <arg type="h" name="fifo_fd" direction="out"/>
+   <arg type="u" name="uid" direction="out"/>
+   <arg type="s" name="seat_id" direction="out"/>
+   <arg type="u" name="vtnr" direction="out"/>
+   <arg type="b" name="existing" direction="out"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ReleaseSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="ActivateSessionOnSeat">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+  </method>
+  <method name="LockSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="UnlockSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="LockSessions">
+  </method>
+  <method name="UnlockSessions">
+  </method>
+  <method name="KillSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
+  </method>
+  <method name="KillUser">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
+  </method>
+  <method name="TerminateSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="TerminateUser">
+   <arg type="u" name="uid" direction="in"/>
+  </method>
+  <method name="TerminateSeat">
+   <arg type="s" name="seat_id" direction="in"/>
+  </method>
+  <method name="SetUserLinger">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="AttachDevice">
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="s" name="sysfs_path" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="FlushDevices">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="PowerOff">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="PowerOffWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Reboot">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="RebootWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Halt">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HaltWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Suspend">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Hibernate">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="HybridSleep">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HybridSleepWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernate">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="CanPowerOff">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanReboot">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHalt">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanSuspend">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHibernate">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHybridSleep">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanSuspendThenHibernate">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="ScheduleShutdown">
+   <arg type="s" name="type" direction="in"/>
+   <arg type="t" name="usec" direction="in"/>
+  </method>
+  <method name="CancelScheduledShutdown">
+   <arg type="b" name="cancelled" direction="out"/>
+  </method>
+  <method name="Inhibit">
+   <arg type="s" name="what" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="s" name="why" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="h" name="pipe_fd" direction="out"/>
+  </method>
+  <method name="CanRebootParameter">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootParameter">
+   <arg type="s" name="parameter" direction="in"/>
+  </method>
+  <method name="CanRebootToFirmwareSetup">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToFirmwareSetup">
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderMenu">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderMenu">
+   <arg type="t" name="timeout" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderEntry">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderEntry">
+   <arg type="s" name="boot_loader_entry" direction="in"/>
+  </method>
+  <method name="SetWallMessage">
+   <arg type="s" name="wall_message" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <signal name="SessionNew">
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SessionRemoved">
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="UserNew">
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="UserRemoved">
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SeatNew">
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SeatRemoved">
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="PrepareForShutdown">
+   <arg type="b" name="start"/>
+  </signal>
+  <signal name="PrepareForShutdownWithMetadata">
+   <arg type="b" name="start"/>
+   <arg type="a{sv}" name="metadata"/>
+  </signal>
+  <signal name="PrepareForSleep">
+   <arg type="b" name="start"/>
+  </signal>
+ </interface>
+ <node name="user"/>
+ <node name="session"/>
+ <node name="seat"/>
+</node>
+

--- a/zbus_xml/tests/data/real_world/network1.xml
+++ b/zbus_xml/tests/data/real_world/network1.xml
@@ -1,0 +1,133 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.network1.Manager">
+  <property name="OperationalState" type="s" access="read">
+  </property>
+  <property name="CarrierState" type="s" access="read">
+  </property>
+  <property name="AddressState" type="s" access="read">
+  </property>
+  <property name="IPv4AddressState" type="s" access="read">
+  </property>
+  <property name="IPv6AddressState" type="s" access="read">
+  </property>
+  <property name="OnlineState" type="s" access="read">
+  </property>
+  <property name="NamespaceId" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <method name="ListLinks">
+   <arg type="a(iso)" name="links" direction="out"/>
+  </method>
+  <method name="GetLinkByName">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="i" name="ifindex" direction="out"/>
+   <arg type="o" name="path" direction="out"/>
+  </method>
+  <method name="GetLinkByIndex">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="name" direction="out"/>
+   <arg type="o" name="path" direction="out"/>
+  </method>
+  <method name="SetLinkNTP">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="as" name="servers" direction="in"/>
+  </method>
+  <method name="SetLinkDNS">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="a(iay)" name="addresses" direction="in"/>
+  </method>
+  <method name="SetLinkDNSEx">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="a(iayqs)" name="addresses" direction="in"/>
+  </method>
+  <method name="SetLinkDomains">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="a(sb)" name="domains" direction="in"/>
+  </method>
+  <method name="SetLinkDefaultRoute">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <method name="SetLinkLLMNR">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+  </method>
+  <method name="SetLinkMulticastDNS">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+  </method>
+  <method name="SetLinkDNSOverTLS">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+  </method>
+  <method name="SetLinkDNSSEC">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+  </method>
+  <method name="SetLinkDNSSECNegativeTrustAnchors">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="as" name="names" direction="in"/>
+  </method>
+  <method name="RevertLinkNTP">
+   <arg type="i" name="ifindex" direction="in"/>
+  </method>
+  <method name="RevertLinkDNS">
+   <arg type="i" name="ifindex" direction="in"/>
+  </method>
+  <method name="RenewLink">
+   <arg type="i" name="ifindex" direction="in"/>
+  </method>
+  <method name="ForceRenewLink">
+   <arg type="i" name="ifindex" direction="in"/>
+  </method>
+  <method name="ReconfigureLink">
+   <arg type="i" name="ifindex" direction="in"/>
+  </method>
+  <method name="Reload">
+  </method>
+  <method name="DescribeLink">
+   <arg type="i" name="ifindex" direction="in"/>
+   <arg type="s" name="json" direction="out"/>
+  </method>
+  <method name="Describe">
+   <arg type="s" name="json" direction="out"/>
+  </method>
+ </interface>
+ <node name="network"/>
+ <node name="link"/>
+</node>
+

--- a/zbus_xml/tests/data/real_world/packagekit.xml
+++ b/zbus_xml/tests/data/real_world/packagekit.xml
@@ -1,0 +1,168 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.80.0 -->
+<node>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="out"/>
+    </method>
+    <method name="GetAll">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="a{sv}" name="properties" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="in"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg type="s" name="interface_name"/>
+      <arg type="a{sv}" name="changed_properties"/>
+      <arg type="as" name="invalidated_properties"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" name="xml_data" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg type="s" name="machine_uuid" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.PackageKit">
+    <method name="CanAuthorize">
+      <annotation name="org.freedesktop.DBus.GLib.Async" value="">
+      </annotation>
+      <arg type="s" name="action_id" direction="in">
+      </arg>
+      <arg type="u" name="result" direction="out">
+      </arg>
+    </method>
+    <method name="CreateTransaction">
+      <annotation name="org.freedesktop.DBus.GLib.Async" value="">
+      </annotation>
+      <arg type="o" name="object_path" direction="out">
+      </arg>
+    </method>
+    <method name="GetTimeSinceAction">
+      <arg type="u" name="role" direction="in">
+      </arg>
+      <arg type="u" name="seconds" direction="out">
+      </arg>
+    </method>
+    <method name="GetTransactionList">
+      <arg type="ao" name="transactions" direction="out">
+      </arg>
+    </method>
+    <method name="StateHasChanged">
+      <arg type="s" name="reason" direction="in">
+      </arg>
+    </method>
+    <method name="SuggestDaemonQuit">
+    </method>
+    <method name="GetPackageHistory">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariant">
+      </annotation>
+      <arg type="as" name="names" direction="in">
+      </arg>
+      <arg type="u" name="count" direction="in">
+      </arg>
+      <arg type="a{saa{sv}}" name="history" direction="out">
+      </arg>
+    </method>
+    <method name="GetDaemonState">
+      <arg type="s" name="state" direction="out">
+      </arg>
+    </method>
+    <method name="SetProxy">
+      <annotation name="org.freedesktop.DBus.GLib.Async" value="">
+      </annotation>
+      <arg type="s" name="proxy_http" direction="in">
+      </arg>
+      <arg type="s" name="proxy_https" direction="in">
+      </arg>
+      <arg type="s" name="proxy_ftp" direction="in">
+      </arg>
+      <arg type="s" name="proxy_socks" direction="in">
+      </arg>
+      <arg type="s" name="no_proxy" direction="in">
+      </arg>
+      <arg type="s" name="pac" direction="in">
+      </arg>
+    </method>
+    <signal name="TransactionListChanged">
+      <arg type="as" name="transactions">
+      </arg>
+    </signal>
+    <signal name="RestartSchedule">
+    </signal>
+    <signal name="RepoListChanged">
+    </signal>
+    <signal name="UpdatesChanged">
+    </signal>
+    <property type="u" name="VersionMajor" access="read">
+    </property>
+    <property type="u" name="VersionMinor" access="read">
+    </property>
+    <property type="u" name="VersionMicro" access="read">
+    </property>
+    <property type="s" name="BackendName" access="read">
+    </property>
+    <property type="s" name="BackendDescription" access="read">
+    </property>
+    <property type="s" name="BackendAuthor" access="read">
+    </property>
+    <property type="t" name="Roles" access="read">
+    </property>
+    <property type="t" name="Groups" access="read">
+    </property>
+    <property type="t" name="Filters" access="read">
+    </property>
+    <property type="as" name="MimeTypes" access="read">
+    </property>
+    <property type="b" name="Locked" access="read">
+    </property>
+    <property type="u" name="NetworkState" access="read">
+    </property>
+    <property type="s" name="DistroId" access="read">
+    </property>
+  </interface>
+  <interface name="org.freedesktop.PackageKit.Offline">
+    <method name="ClearResults">
+    </method>
+    <method name="Trigger">
+      <arg type="s" name="action" direction="in">
+      </arg>
+    </method>
+    <method name="TriggerUpgrade">
+      <arg type="s" name="action" direction="in">
+      </arg>
+    </method>
+    <method name="Cancel">
+    </method>
+    <method name="GetPrepared">
+      <arg type="as" name="package_ids" direction="out">
+      </arg>
+    </method>
+    <property type="b" name="UpdatePrepared" access="read">
+    </property>
+    <property type="b" name="UpdateTriggered" access="read">
+    </property>
+    <property type="b" name="UpgradePrepared" access="read">
+    </property>
+    <property type="b" name="UpgradeTriggered" access="read">
+    </property>
+    <property type="a{sv}" name="PreparedUpgrade" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap">
+      </annotation>
+    </property>
+    <property type="s" name="TriggerAction" access="read">
+    </property>
+  </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/polkit1_authority.xml
+++ b/zbus_xml/tests/data/real_world/polkit1_authority.xml
@@ -1,0 +1,124 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.80.0 -->
+<node>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="out"/>
+    </method>
+    <method name="GetAll">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="a{sv}" name="properties" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg type="s" name="interface_name" direction="in"/>
+      <arg type="s" name="property_name" direction="in"/>
+      <arg type="v" name="value" direction="in"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg type="s" name="interface_name"/>
+      <arg type="a{sv}" name="changed_properties"/>
+      <arg type="as" name="invalidated_properties"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" name="xml_data" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg type="s" name="machine_uuid" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.PolicyKit1.Authority">
+    <method name="EnumerateActions">
+      <arg type="s" name="locale" direction="in">
+      </arg>
+      <arg type="a(ssssssuuua{ss})" name="action_descriptions" direction="out">
+      </arg>
+    </method>
+    <method name="CheckAuthorization">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+      <arg type="s" name="action_id" direction="in">
+      </arg>
+      <arg type="a{ss}" name="details" direction="in">
+      </arg>
+      <arg type="u" name="flags" direction="in">
+      </arg>
+      <arg type="s" name="cancellation_id" direction="in">
+      </arg>
+      <arg type="(bba{ss})" name="result" direction="out">
+      </arg>
+    </method>
+    <method name="CancelCheckAuthorization">
+      <arg type="s" name="cancellation_id" direction="in">
+      </arg>
+    </method>
+    <method name="RegisterAuthenticationAgent">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+      <arg type="s" name="locale" direction="in">
+      </arg>
+      <arg type="s" name="object_path" direction="in">
+      </arg>
+    </method>
+    <method name="RegisterAuthenticationAgentWithOptions">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+      <arg type="s" name="locale" direction="in">
+      </arg>
+      <arg type="s" name="object_path" direction="in">
+      </arg>
+      <arg type="a{sv}" name="options" direction="in">
+      </arg>
+    </method>
+    <method name="UnregisterAuthenticationAgent">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+      <arg type="s" name="object_path" direction="in">
+      </arg>
+    </method>
+    <method name="AuthenticationAgentResponse">
+      <arg type="s" name="cookie" direction="in">
+      </arg>
+      <arg type="(sa{sv})" name="identity" direction="in">
+      </arg>
+    </method>
+    <method name="AuthenticationAgentResponse2">
+      <arg type="u" name="uid" direction="in">
+      </arg>
+      <arg type="s" name="cookie" direction="in">
+      </arg>
+      <arg type="(sa{sv})" name="identity" direction="in">
+      </arg>
+    </method>
+    <method name="EnumerateTemporaryAuthorizations">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+      <arg type="a(ss(sa{sv})tt)" name="temporary_authorizations" direction="out">
+      </arg>
+    </method>
+    <method name="RevokeTemporaryAuthorizations">
+      <arg type="(sa{sv})" name="subject" direction="in">
+      </arg>
+    </method>
+    <method name="RevokeTemporaryAuthorizationById">
+      <arg type="s" name="id" direction="in">
+      </arg>
+    </method>
+    <signal name="Changed">
+    </signal>
+    <property type="s" name="BackendName" access="read">
+    </property>
+    <property type="s" name="BackendVersion" access="read">
+    </property>
+    <property type="u" name="BackendFeatures" access="read">
+    </property>
+  </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/systemd1_manager.xml
+++ b/zbus_xml/tests/data/real_world/systemd1_manager.xml
@@ -1,0 +1,817 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.systemd1.Manager">
+  <property name="Version" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Features" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Virtualization" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ConfidentialVirtualization" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Architecture" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Tainted" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FirmwareTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FirmwareTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="LoaderTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="LoaderTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KernelTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KernelTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UserspaceTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UserspaceTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SecurityStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SecurityStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SecurityFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SecurityFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GeneratorsStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GeneratorsStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GeneratorsFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GeneratorsFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitsLoadTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDSecurityStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDSecurityStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDSecurityFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDSecurityFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDGeneratorsStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDGeneratorsStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDGeneratorsFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDGeneratorsFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDUnitsLoadStartTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDUnitsLoadStartTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDUnitsLoadFinishTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InitRDUnitsLoadFinishTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="LogLevel" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="LogTarget" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NNames" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NFailedUnits" type="u" access="read">
+  </property>
+  <property name="NJobs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NInstalledJobs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NFailedJobs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Progress" type="d" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Environment" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ConfirmSpawn" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ShowStatus" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="UnitPath" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultStandardOutput" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultStandardError" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="WatchdogDevice" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="WatchdogLastPingTimestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="WatchdogLastPingTimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RuntimeWatchdogUSec" type="t" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RuntimeWatchdogPreUSec" type="t" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RuntimeWatchdogPreGovernor" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootWatchdogUSec" type="t" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="KExecWatchdogUSec" type="t" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ServiceWatchdogs" type="b" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ControlGroup" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SystemState" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ExitCode" type="y" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultTimerAccuracyUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultTimeoutStartUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultTimeoutStopUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultTimeoutAbortUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultDeviceTimeoutUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultRestartUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultStartLimitIntervalUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultStartLimitBurst" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultCPUAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultBlockIOAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultIOAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultIPAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultMemoryAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultTasksAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitCPU" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitCPUSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitFSIZE" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitFSIZESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitDATA" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitDATASoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitSTACK" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitSTACKSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitCORE" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitCORESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRSS" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRSSSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNOFILE" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNOFILESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitAS" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitASSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNPROC" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNPROCSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitMEMLOCK" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitMEMLOCKSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitLOCKS" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitLOCKSSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitSIGPENDING" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitSIGPENDINGSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitMSGQUEUE" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitMSGQUEUESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNICE" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitNICESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRTPRIO" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRTPRIOSoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRTTIME" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultLimitRTTIMESoft" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultTasksMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultMemoryPressureThresholdUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultMemoryPressureWatch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="TimerSlackNSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultOOMPolicy" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultOOMScoreAdjust" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CtrlAltDelBurstAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <method name="GetUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+  </method>
+  <method name="GetUnitByPID">
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+  </method>
+  <method name="GetUnitByInvocationID">
+   <arg type="ay" name="invocation_id" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+  </method>
+  <method name="GetUnitByControlGroup">
+   <arg type="s" name="cgroup" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+  </method>
+  <method name="GetUnitByPIDFD">
+   <arg type="h" name="pidfd" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+   <arg type="s" name="unit_id" direction="out"/>
+   <arg type="ay" name="invocation_id" direction="out"/>
+  </method>
+  <method name="LoadUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="o" name="unit" direction="out"/>
+  </method>
+  <method name="StartUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="StartUnitWithFlags">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="t" name="flags" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="StartUnitReplace">
+   <arg type="s" name="old_unit" direction="in"/>
+   <arg type="s" name="new_unit" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="StopUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="ReloadUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="RestartUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="TryRestartUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="ReloadOrRestartUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="ReloadOrTryRestartUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="EnqueueUnitJob">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="job_type" direction="in"/>
+   <arg type="s" name="job_mode" direction="in"/>
+   <arg type="u" name="job_id" direction="out"/>
+   <arg type="o" name="job_path" direction="out"/>
+   <arg type="s" name="unit_id" direction="out"/>
+   <arg type="o" name="unit_path" direction="out"/>
+   <arg type="s" name="job_type" direction="out"/>
+   <arg type="a(uosos)" name="affected_jobs" direction="out"/>
+  </method>
+  <method name="KillUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="whom" direction="in"/>
+   <arg type="i" name="signal" direction="in"/>
+  </method>
+  <method name="QueueSignalUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="whom" direction="in"/>
+   <arg type="i" name="signal" direction="in"/>
+   <arg type="i" name="value" direction="in"/>
+  </method>
+  <method name="CleanUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="as" name="mask" direction="in"/>
+  </method>
+  <method name="FreezeUnit">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="ThawUnit">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="ResetFailedUnit">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="SetUnitProperties">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+  </method>
+  <method name="BindMountUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="source" direction="in"/>
+   <arg type="s" name="destination" direction="in"/>
+   <arg type="b" name="read_only" direction="in"/>
+   <arg type="b" name="mkdir" direction="in"/>
+  </method>
+  <method name="MountImageUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="source" direction="in"/>
+   <arg type="s" name="destination" direction="in"/>
+   <arg type="b" name="read_only" direction="in"/>
+   <arg type="b" name="mkdir" direction="in"/>
+   <arg type="a(ss)" name="options" direction="in"/>
+  </method>
+  <method name="RefUnit">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="UnrefUnit">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="StartTransientUnit">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+   <arg type="a(sa(sv))" name="aux" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="GetUnitProcesses">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="a(sus)" name="processes" direction="out"/>
+  </method>
+  <method name="AttachProcessesToUnit">
+   <arg type="s" name="unit_name" direction="in"/>
+   <arg type="s" name="subcgroup" direction="in"/>
+   <arg type="au" name="pids" direction="in"/>
+  </method>
+  <method name="AbandonScope">
+   <arg type="s" name="name" direction="in"/>
+  </method>
+  <method name="GetJob">
+   <arg type="u" name="id" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="GetJobAfter">
+   <arg type="u" name="id" direction="in"/>
+   <arg type="a(usssoo)" name="jobs" direction="out"/>
+  </method>
+  <method name="GetJobBefore">
+   <arg type="u" name="id" direction="in"/>
+   <arg type="a(usssoo)" name="jobs" direction="out"/>
+  </method>
+  <method name="CancelJob">
+   <arg type="u" name="id" direction="in"/>
+  </method>
+  <method name="ClearJobs">
+  </method>
+  <method name="ResetFailed">
+  </method>
+  <method name="SetShowStatus">
+   <arg type="s" name="mode" direction="in"/>
+  </method>
+  <method name="ListUnits">
+   <arg type="a(ssssssouso)" name="units" direction="out"/>
+  </method>
+  <method name="ListUnitsFiltered">
+   <arg type="as" name="states" direction="in"/>
+   <arg type="a(ssssssouso)" name="units" direction="out"/>
+  </method>
+  <method name="ListUnitsByPatterns">
+   <arg type="as" name="states" direction="in"/>
+   <arg type="as" name="patterns" direction="in"/>
+   <arg type="a(ssssssouso)" name="units" direction="out"/>
+  </method>
+  <method name="ListUnitsByNames">
+   <arg type="as" name="names" direction="in"/>
+   <arg type="a(ssssssouso)" name="units" direction="out"/>
+  </method>
+  <method name="ListJobs">
+   <arg type="a(usssoo)" name="jobs" direction="out"/>
+  </method>
+  <method name="Subscribe">
+  </method>
+  <method name="Unsubscribe">
+  </method>
+  <method name="Dump">
+   <arg type="s" name="output" direction="out"/>
+  </method>
+  <method name="DumpUnitsMatchingPatterns">
+   <arg type="as" name="patterns" direction="in"/>
+   <arg type="s" name="output" direction="out"/>
+  </method>
+  <method name="DumpByFileDescriptor">
+   <arg type="h" name="fd" direction="out"/>
+  </method>
+  <method name="DumpUnitsMatchingPatternsByFileDescriptor">
+   <arg type="as" name="patterns" direction="in"/>
+   <arg type="h" name="fd" direction="out"/>
+  </method>
+  <method name="Reload">
+  </method>
+  <method name="Reexecute">
+   <annotation name="org.freedesktop.DBus.Method.NoReply" value="true"/>
+  </method>
+  <method name="Exit">
+  </method>
+  <method name="Reboot">
+  </method>
+  <method name="SoftReboot">
+   <arg type="s" name="new_root" direction="in"/>
+  </method>
+  <method name="PowerOff">
+  </method>
+  <method name="Halt">
+  </method>
+  <method name="KExec">
+  </method>
+  <method name="SwitchRoot">
+   <arg type="s" name="new_root" direction="in"/>
+   <arg type="s" name="init" direction="in"/>
+  </method>
+  <method name="SetEnvironment">
+   <arg type="as" name="assignments" direction="in"/>
+  </method>
+  <method name="UnsetEnvironment">
+   <arg type="as" name="names" direction="in"/>
+  </method>
+  <method name="UnsetAndSetEnvironment">
+   <arg type="as" name="names" direction="in"/>
+   <arg type="as" name="assignments" direction="in"/>
+  </method>
+  <method name="EnqueueMarkedJobs">
+   <arg type="ao" name="jobs" direction="out"/>
+  </method>
+  <method name="ListUnitFiles">
+   <arg type="a(ss)" name="unit_files" direction="out"/>
+  </method>
+  <method name="ListUnitFilesByPatterns">
+   <arg type="as" name="states" direction="in"/>
+   <arg type="as" name="patterns" direction="in"/>
+   <arg type="a(ss)" name="unit_files" direction="out"/>
+  </method>
+  <method name="GetUnitFileState">
+   <arg type="s" name="file" direction="in"/>
+   <arg type="s" name="state" direction="out"/>
+  </method>
+  <method name="EnableUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="DisableUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="EnableUnitFilesWithFlags">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="t" name="flags" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="DisableUnitFilesWithFlags">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="t" name="flags" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="DisableUnitFilesWithFlagsAndInstallInfo">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="t" name="flags" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="ReenableUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="LinkUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="PresetUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="PresetUnitFilesWithMode">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="b" name="carries_install_info" direction="out"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="MaskUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="UnmaskUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="RevertUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="SetDefaultTarget">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="GetDefaultTarget">
+   <arg type="s" name="name" direction="out"/>
+  </method>
+  <method name="PresetAllUnitFiles">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="AddDependencyUnitFiles">
+   <arg type="as" name="files" direction="in"/>
+   <arg type="s" name="target" direction="in"/>
+   <arg type="s" name="type" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="b" name="force" direction="in"/>
+   <arg type="a(sss)" name="changes" direction="out"/>
+  </method>
+  <method name="GetUnitFileLinks">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="as" name="links" direction="out"/>
+  </method>
+  <method name="SetExitCode">
+   <arg type="y" name="number" direction="in"/>
+  </method>
+  <method name="LookupDynamicUserByName">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="u" name="uid" direction="out"/>
+  </method>
+  <method name="LookupDynamicUserByUID">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="s" name="name" direction="out"/>
+  </method>
+  <method name="GetDynamicUsers">
+   <arg type="a(us)" name="users" direction="out"/>
+  </method>
+  <method name="DumpUnitFileDescriptorStore">
+   <arg type="s" name="name" direction="in"/>
+   <arg type="a(suuutuusu)" name="entries" direction="out"/>
+  </method>
+  <signal name="UnitNew">
+   <arg type="s" name="id"/>
+   <arg type="o" name="unit"/>
+  </signal>
+  <signal name="UnitRemoved">
+   <arg type="s" name="id"/>
+   <arg type="o" name="unit"/>
+  </signal>
+  <signal name="JobNew">
+   <arg type="u" name="id"/>
+   <arg type="o" name="job"/>
+   <arg type="s" name="unit"/>
+  </signal>
+  <signal name="JobRemoved">
+   <arg type="u" name="id"/>
+   <arg type="o" name="job"/>
+   <arg type="s" name="unit"/>
+   <arg type="s" name="result"/>
+  </signal>
+  <signal name="StartupFinished">
+   <arg type="t" name="firmware"/>
+   <arg type="t" name="loader"/>
+   <arg type="t" name="kernel"/>
+   <arg type="t" name="initrd"/>
+   <arg type="t" name="userspace"/>
+   <arg type="t" name="total"/>
+  </signal>
+  <signal name="UnitFilesChanged">
+  </signal>
+  <signal name="Reloading">
+   <arg type="b" name="active"/>
+  </signal>
+ </interface>
+ <node name="unit"/>
+ <node name="job"/>
+</node>
+

--- a/zbus_xml/tests/data/real_world/systemd1_scope_unit.xml
+++ b/zbus_xml/tests/data/real_world/systemd1_scope_unit.xml
@@ -1,0 +1,692 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.systemd1.Scope">
+  <property name="Controller" type="s" access="read">
+  </property>
+  <property name="TimeoutStopUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Result" type="s" access="read">
+  </property>
+  <property name="RuntimeMaxUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeRandomizedExtraUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OOMPolicy" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <signal name="RequestStop">
+  </signal>
+  <method name="Abandon">
+  </method>
+  <property name="Slice" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ControlGroup" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ControlGroupId" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryCurrent" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryPeak" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemorySwapCurrent" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemorySwapPeak" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryZSwapCurrent" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryAvailable" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUUsageNSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="EffectiveCPUs" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="EffectiveMemoryNodes" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="TasksCurrent" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPIngressBytes" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPIngressPackets" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPEgressBytes" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPEgressPackets" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOReadBytes" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOReadOperations" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOWriteBytes" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOWriteOperations" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="GetProcesses">
+   <arg type="a(sus)" name="processes" direction="out"/>
+  </method>
+  <method name="AttachProcesses">
+   <arg type="s" name="subcgroup" direction="in"/>
+   <arg type="au" name="pids" direction="in"/>
+  </method>
+  <property name="Delegate" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DelegateControllers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DelegateSubgroup" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupCPUWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUShares" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupCPUShares" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUQuotaPerSecUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CPUQuotaPeriodUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="AllowedCPUs" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupAllowedCPUs" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="AllowedMemoryNodes" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupAllowedMemoryNodes" type="ay" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupIOWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IODeviceWeight" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOReadBandwidthMax" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOWriteBandwidthMax" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOReadIOPSMax" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IOWriteIOPSMax" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IODeviceLatencyTargetUSec" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BlockIOAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BlockIOWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupBlockIOWeight" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BlockIODeviceWeight" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BlockIOReadBandwidth" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BlockIOWriteBandwidth" type="a(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultMemoryLow" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultStartupMemoryLow" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DefaultMemoryMin" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryMin" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryLow" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupMemoryLow" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryHigh" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupMemoryHigh" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupMemoryMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemorySwapMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupMemorySwapMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryZSwapMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StartupMemoryZSwapMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryLimit" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DevicePolicy" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DeviceAllow" type="a(ss)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="TasksAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="TasksMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPAccounting" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPAddressAllow" type="a(iayu)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPAddressDeny" type="a(iayu)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPIngressFilterPath" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IPEgressFilterPath" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="DisableControllers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ManagedOOMSwap" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ManagedOOMMemoryPressure" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ManagedOOMMemoryPressureLimit" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ManagedOOMPreference" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BPFProgram" type="a(ss)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SocketBindAllow" type="a(iiqq)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SocketBindDeny" type="a(iiqq)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RestrictNetworkInterfaces" type="(bas)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryPressureWatch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="MemoryPressureThresholdUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NFTSet" type="a(iiss)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="CoredumpReceive" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="KillMode" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillSignal" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RestartKillSignal" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FinalKillSignal" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SendSIGKILL" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SendSIGHUP" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="WatchdogSignal" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+ </interface>
+ <interface name="org.freedesktop.systemd1.Unit">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Names" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Following" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Requires" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Requisite" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Wants" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="BindsTo" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PartOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Upholds" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RequiredBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RequisiteOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="WantedBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="BoundBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UpheldBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ConsistsOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Conflicts" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ConflictedBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Before" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="After" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnSuccess" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnSuccessOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnFailure" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnFailureOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Triggers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TriggeredBy" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PropagatesReloadTo" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ReloadPropagatedFrom" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PropagatesStopTo" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="StopPropagatedFrom" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="JoinsNamespaceOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SliceOf" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RequiresMountsFor" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Documentation" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Description" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="AccessSELinuxContext" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="LoadState" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ActiveState" type="s" access="read">
+  </property>
+  <property name="FreezerState" type="s" access="read">
+  </property>
+  <property name="SubState" type="s" access="read">
+  </property>
+  <property name="FragmentPath" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SourcePath" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DropInPaths" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UnitFileState" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="UnitFilePreset" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="StateChangeTimestamp" type="t" access="read">
+  </property>
+  <property name="StateChangeTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="InactiveExitTimestamp" type="t" access="read">
+  </property>
+  <property name="InactiveExitTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="ActiveEnterTimestamp" type="t" access="read">
+  </property>
+  <property name="ActiveEnterTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="ActiveExitTimestamp" type="t" access="read">
+  </property>
+  <property name="ActiveExitTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="InactiveEnterTimestamp" type="t" access="read">
+  </property>
+  <property name="InactiveEnterTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="CanStart" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanStop" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanReload" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanIsolate" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanClean" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanFreeze" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Job" type="(uo)" access="read">
+  </property>
+  <property name="StopWhenUnneeded" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RefuseManualStart" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RefuseManualStop" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="AllowIsolate" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="DefaultDependencies" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SurviveFinalKillSignal" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnSuccessJobMode" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="OnFailureJobMode" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IgnoreOnIsolate" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NeedDaemonReload" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Markers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="JobTimeoutUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="JobRunningTimeoutUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="JobTimeoutAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="JobTimeoutRebootArgument" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ConditionResult" type="b" access="read">
+  </property>
+  <property name="AssertResult" type="b" access="read">
+  </property>
+  <property name="ConditionTimestamp" type="t" access="read">
+  </property>
+  <property name="ConditionTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="AssertTimestamp" type="t" access="read">
+  </property>
+  <property name="AssertTimestampMonotonic" type="t" access="read">
+  </property>
+  <property name="Conditions" type="a(sbbsi)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
+  </property>
+  <property name="Asserts" type="a(sbbsi)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates"/>
+  </property>
+  <property name="LoadError" type="(ss)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Transient" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Perpetual" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="StartLimitIntervalUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="StartLimitBurst" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="StartLimitAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FailureAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="FailureActionExitStatus" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SuccessAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="SuccessActionExitStatus" type="i" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RebootArgument" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InvocationID" type="ay" access="read">
+  </property>
+  <property name="CollectMode" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Refs" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ActivationDetails" type="a(ss)" access="read">
+  </property>
+  <method name="Start">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="Stop">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="Reload">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="Restart">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="TryRestart">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="ReloadOrRestart">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="ReloadOrTryRestart">
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="o" name="job" direction="out"/>
+  </method>
+  <method name="EnqueueJob">
+   <arg type="s" name="job_type" direction="in"/>
+   <arg type="s" name="job_mode" direction="in"/>
+   <arg type="u" name="job_id" direction="out"/>
+   <arg type="o" name="job_path" direction="out"/>
+   <arg type="s" name="unit_id" direction="out"/>
+   <arg type="o" name="unit_path" direction="out"/>
+   <arg type="s" name="job_type" direction="out"/>
+   <arg type="a(uosos)" name="affected_jobs" direction="out"/>
+  </method>
+  <method name="Kill">
+   <arg type="s" name="whom" direction="in"/>
+   <arg type="i" name="signal" direction="in"/>
+  </method>
+  <method name="QueueSignal">
+   <arg type="s" name="whom" direction="in"/>
+   <arg type="i" name="signal" direction="in"/>
+   <arg type="i" name="value" direction="in"/>
+  </method>
+  <method name="ResetFailed">
+  </method>
+  <method name="SetProperties">
+   <arg type="b" name="runtime" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+  </method>
+  <method name="Ref">
+  </method>
+  <method name="Unref">
+  </method>
+  <method name="Clean">
+   <arg type="as" name="mask" direction="in"/>
+  </method>
+  <method name="Freeze">
+  </method>
+  <method name="Thaw">
+  </method>
+ </interface>
+</node>
+

--- a/zbus_xml/tests/data/real_world/systemd1_unit_list.xml
+++ b/zbus_xml/tests/data/real_world/systemd1_unit_list.xml
@@ -1,0 +1,76 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <node name="gpg_2dagent_2eservice"/>
+ <node name="opt_2denv_5cx2drunner_2emount"/>
+ <node name="keyboxd_2eservice"/>
+ <node name="gpg_2dagent_2dextra_2esocket"/>
+ <node name="blockdev_40dev_2dvde_2etarget"/>
+ <node name="pk_2ddebconf_2dhelper_2eservice"/>
+ <node name="launchpadlib_2dcache_2dclean_2eservice"/>
+ <node name="gpg_2dagent_2dbrowser_2esocket"/>
+ <node name="dbus_2esocket"/>
+ <node name="dev_2dvda_2edevice"/>
+ <node name="default_2etarget"/>
+ <node name="blockdev_40dev_2dvdd_2etarget"/>
+ <node name="shutdown_2etarget"/>
+ <node name="init_2escope"/>
+ <node name="launchpadlib_2dcache_2dclean_2etimer"/>
+ <node name="pk_2ddebconf_2dhelper_2esocket"/>
+ <node name="_2d_2emount"/>
+ <node name="dev_2dvdb_2edevice"/>
+ <node name="_2d_2eslice"/>
+ <node name="dev_2dvdc_2edevice"/>
+ <node name="paths_2etarget"/>
+ <node name="mnt_2dskills_2dexamples_2emount"/>
+ <node name="dev_2dvdd_2edevice"/>
+ <node name="timers_2etarget"/>
+ <node name="dbus_2eservice"/>
+ <node name="blockdev_40dev_2dvdc_2etarget"/>
+ <node name="basic_2etarget"/>
+ <node name="opt_2dclaude_5cx2dcode_2emount"/>
+ <node name="app_2eslice"/>
+ <node name="gpg_2dagent_2dssh_2esocket"/>
+ <node name="blockdev_40dev_2dvdb_2etarget"/>
+ <node name="dirmngr_2esocket"/>
+ <node name="dirmngr_2eservice"/>
+ <node name="session_2eslice"/>
+ <node name="mnt_2dskills_2dpublic_2emount"/>
+ <node name="sockets_2etarget"/>
+ <node name="keyboxd_2esocket"/>
+ <node name="gpg_2dagent_2esocket"/>
+ <node name="dev_2dvde_2edevice"/>
+</node>
+

--- a/zbus_xml/tests/data/real_world/timedate1.xml
+++ b/zbus_xml/tests/data/real_world/timedate1.xml
@@ -1,0 +1,78 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.timedate1">
+  <property name="Timezone" type="s" access="read">
+  </property>
+  <property name="LocalRTC" type="b" access="read">
+  </property>
+  <property name="CanNTP" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="NTP" type="b" access="read">
+  </property>
+  <property name="NTPSynchronized" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="TimeUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RTCTimeUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="SetTime">
+   <arg type="x" name="usec_utc" direction="in"/>
+   <arg type="b" name="relative" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetTimezone">
+   <arg type="s" name="timezone" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetLocalRTC">
+   <arg type="b" name="local_rtc" direction="in"/>
+   <arg type="b" name="fix_system" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SetNTP">
+   <arg type="b" name="use_ntp" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="ListTimezones">
+   <arg type="as" name="timezones" direction="out"/>
+  </method>
+ </interface>
+</node>
+

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -1,4 +1,3 @@
-use quick_xml::de::DeError;
 use std::error::Error;
 
 use zbus_xml::{ArgDirection, Node};
@@ -26,6 +25,12 @@ fn serde() -> Result<(), Box<dyn Error>> {
 
     let mut writer = Vec::with_capacity(128);
     node.to_writer(&mut writer).unwrap();
+
+    // Round-trip: the written document parses back to an equal tree.
+    let written = String::from_utf8(writer)?;
+    let reparsed = Node::try_from(written.as_str())?;
+    assert_eq!(node, reparsed);
+
     Ok(())
 }
 
@@ -34,7 +39,7 @@ fn invalid_arg_type() {
     let input = include_str!("data/invalid_arg_type.xml");
     assert!(matches!(
         Node::try_from(input),
-        Err(zbus_xml::Error::QuickXml(DeError::Custom(_)))
+        Err(zbus_xml::Error::Variant(_))
     ));
 }
 
@@ -61,6 +66,220 @@ fn multi_complete_arg_type() -> Result<(), Box<dyn Error>> {
     assert_eq!(fields.len(), 2);
     assert_eq!(fields.get(0), Some(&Signature::U64));
     assert_eq!(fields.get(1), Some(&Signature::U64));
+
+    Ok(())
+}
+
+#[test]
+fn escaped_attributes() -> Result<(), Box<dyn Error>> {
+    let input = r#"
+        <node>
+            <interface name="org.test.testinterface">
+                <annotation name="org.test.Escapes" value="&lt;b&gt; &amp; &quot;q&quot; &apos;a&apos; &#65;&#x42;"/>
+            </interface>
+        </node>
+    "#;
+
+    let node = Node::try_from(input)?;
+    let annotation = &node.interfaces()[0].annotations()[0];
+    assert_eq!(annotation.value(), r#"<b> & "q" 'a' AB"#);
+
+    // Escaping survives a write/parse round-trip.
+    let mut writer = Vec::new();
+    node.to_writer(&mut writer)?;
+    let written = String::from_utf8(writer)?;
+    let reparsed = Node::try_from(written.as_str())?;
+    assert_eq!(node, reparsed);
+
+    Ok(())
+}
+
+#[test]
+fn attribute_whitespace_normalization() -> Result<(), Box<dyn Error>> {
+    // Literal whitespace in attribute values is normalized to spaces, while whitespace escaped
+    // through character references is kept.
+    let input = "<node>\n  <interface name=\"org.test.testinterface\">\n    \
+                 <annotation name=\"org.test.Ws\" value=\"a\nb\tc\r&#10;&#9;&#13;d\"/>\n  \
+                 </interface>\n</node>";
+
+    let node = Node::try_from(input)?;
+    let annotation = &node.interfaces()[0].annotations()[0];
+    assert_eq!(annotation.value(), "a b c \n\t\rd");
+
+    // The writer escapes whitespace so it survives normalization by any parser.
+    let mut writer = Vec::new();
+    node.to_writer(&mut writer)?;
+    let written = String::from_utf8(writer)?;
+    assert!(written.contains("a b c &#10;&#9;&#13;d"));
+    let reparsed = Node::try_from(written.as_str())?;
+    assert_eq!(node, reparsed);
+
+    Ok(())
+}
+
+#[test]
+fn crlf_normalizes_to_single_space() -> Result<(), Box<dyn Error>> {
+    // A literal CRLF is a single line ending, so attribute-value normalization collapses it to
+    // one space (not two); a lone CR or LF likewise yields one space each.
+    let input = "<node name=\"a\r\nb\rc\nd\"/>";
+    let node = Node::try_from(input)?;
+    assert_eq!(node.name(), Some("a b c d"));
+
+    Ok(())
+}
+
+#[test]
+fn many_attributes() -> Result<(), Box<dyn Error>> {
+    // Elements with many attributes parse fine — duplicate detection falls back from a linear
+    // scan to a set past a threshold — and duplicates are still caught beyond that threshold.
+    let attrs: String = (0..100).map(|i| format!(" a{i}=\"{i}\"")).collect();
+    assert!(Node::try_from(format!("<node{attrs}/>").as_str()).is_ok());
+    assert!(matches!(
+        Node::try_from(format!("<node{attrs} a50=\"dup\"/>").as_str()),
+        Err(zbus_xml::Error::Xml(_))
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn doctype_with_quoted_literals() -> Result<(), Box<dyn Error>> {
+    // `>` and brackets inside DOCTYPE quoted literals must not terminate the declaration.
+    let input = r#"
+        <!DOCTYPE node SYSTEM "weird>literal[with]brackets">
+        <node>
+            <interface name="org.test.testinterface"/>
+        </node>
+    "#;
+
+    let node = Node::try_from(input)?;
+    assert_eq!(node.interfaces().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn ignores_unknown_elements_and_text() -> Result<(), Box<dyn Error>> {
+    // Documents in the wild carry foreign elements (with text content, CDATA and comments) that
+    // must be skipped, e.g. Telepathy's `tp:docstring`.
+    let input = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:docstring>Some documentation.</tp:docstring>
+            <interface name="org.test.testinterface">
+                <!-- a comment -->
+                <method name="testmethod">
+                    <tp:docstring>More <tp:em>documentation</tp:em>.</tp:docstring>
+                    <arg name="testarg" direction="out" type="s">
+                        <tp:docstring><![CDATA[Even </more> documentation.]]></tp:docstring>
+                    </arg>
+                </method>
+            </interface>
+        </node>
+    "#;
+
+    let node = Node::try_from(input)?;
+    assert_eq!(node.interfaces().len(), 1);
+    let method = &node.interfaces()[0].methods()[0];
+    assert_eq!(method.args().len(), 1);
+    assert_eq!(method.args()[0].name(), Some("testarg"));
+
+    Ok(())
+}
+
+#[test]
+fn malformed_documents() {
+    for input in [
+        // Empty document.
+        "",
+        // Unclosed root element.
+        "<node>",
+        // Mismatched closing tag.
+        "<node><interface name=\"org.test.testinterface\"></node>",
+        // Unterminated comment.
+        "<node><!-- comment </node>",
+        // Missing attribute value quotes.
+        "<node name=foo/>",
+        // Unknown entity.
+        "<node name=\"&unknown;\"/>",
+        // Character references to characters invalid in XML.
+        "<node name=\"&#0;\"/>",
+        "<node name=\"&#x1F;\"/>",
+        // Signed character references.
+        "<node name=\"&#+65;\"/>",
+        "<node name=\"&#x+41;\"/>",
+        // Duplicate attribute.
+        "<node name=\"a\" name=\"b\"/>",
+        // Missing whitespace between attributes.
+        "<node name=\"a\"name=\"b\"/>",
+    ] {
+        assert!(matches!(
+            Node::try_from(input),
+            Err(zbus_xml::Error::Xml(_))
+        ));
+    }
+
+    // Missing required attribute.
+    let input = "<node><interface name=\"org.test.testinterface\">\
+                 <property name=\"foo\" type=\"s\"/></interface></node>";
+    assert!(matches!(
+        Node::try_from(input),
+        Err(zbus_xml::Error::Xml(_))
+    ));
+
+    // Invalid interface name.
+    let input = "<node><interface name=\"not a valid name\"/></node>";
+    assert!(matches!(
+        Node::try_from(input),
+        Err(zbus_xml::Error::Name(_))
+    ));
+}
+
+#[test]
+fn error_position() {
+    // Errors in attribute values point at the offending reference, not past the value.
+    let input = r#"<node name="abc&unknown;def"/>"#;
+    let Err(zbus_xml::Error::Xml(e)) = Node::try_from(input) else {
+        panic!("expected an XML error");
+    };
+    assert_eq!(e.position(), input.find('&').unwrap());
+}
+
+#[test]
+fn deeply_nested_documents() -> Result<(), Box<dyn Error>> {
+    // The parser iterates over the axes where a document can nest arbitrarily deep, so any
+    // depth up to the cap parses even on a small stack. (Recursing instead overflows even
+    // multi-MiB stacks well before the cap in debug builds, whose stack frames are large.)
+    let deep_nodes = format!("{}{}", "<node>".repeat(1024), "</node>".repeat(1024));
+    let deep_foreign = format!(
+        "<node><interface name=\"org.test.testinterface\">{}{}</interface></node>",
+        "<x>".repeat(1022),
+        "</x>".repeat(1022),
+    );
+
+    std::thread::Builder::new()
+        .stack_size(512 * 1024)
+        .spawn(move || {
+            let node = Node::try_from(deep_nodes.as_str()).unwrap();
+            let mut depth = 1;
+            let mut node = &node;
+            while let [child] = node.nodes() {
+                node = child;
+                depth += 1;
+            }
+            assert_eq!(depth, 1024);
+
+            Node::try_from(deep_foreign.as_str()).unwrap();
+        })?
+        .join()
+        .expect("parsing deeply nested documents must not overflow the stack");
+
+    // One level past the cap is rejected cleanly.
+    let too_deep = format!("{}{}", "<node>".repeat(1025), "</node>".repeat(1025));
+    assert!(matches!(
+        Node::try_from(too_deep.as_str()),
+        Err(zbus_xml::Error::Xml(_))
+    ));
 
     Ok(())
 }

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use zbus_xml::{ArgDirection, Node};
+use zbus_xml::{Arg, ArgDirection, Interface, Node, PropertyAccess};
 use zvariant::Signature;
 
 #[test]
@@ -187,6 +187,394 @@ fn ignores_unknown_elements_and_text() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// The expected shape of an argument: its `name`, signature and `direction`.
+type ArgSpec = (Option<&'static str>, &'static str, Option<ArgDirection>);
+
+const IN: Option<ArgDirection> = Some(ArgDirection::In);
+const OUT: Option<ArgDirection> = Some(ArgDirection::Out);
+/// A signal argument has no direction.
+const NONE: Option<ArgDirection> = None;
+
+/// Look up an interface by name, panicking with a helpful message if it is absent.
+fn interface<'n, 'a>(node: &'n Node<'a>, name: &str) -> &'n Interface<'a> {
+    node.interfaces()
+        .iter()
+        .find(|iface| iface.name() == name)
+        .unwrap_or_else(|| panic!("interface `{name}` not found"))
+}
+
+/// Assert that `args` matches `expected` exactly — count, and every name, signature and
+/// direction.
+fn assert_args(context: &str, args: &[Arg], expected: &[ArgSpec]) {
+    assert_eq!(
+        args.len(),
+        expected.len(),
+        "{context}: expected {} arg(s), got {}",
+        expected.len(),
+        args.len(),
+    );
+    for (i, (arg, &(name, ty, direction))) in args.iter().zip(expected).enumerate() {
+        assert_eq!(arg.name(), name, "{context}: arg {i} name");
+        assert!(
+            arg.ty() == ty,
+            "{context}: arg {i} type: expected `{ty}`, got `{}`",
+            arg.ty().to_string(),
+        );
+        assert_eq!(arg.direction(), direction, "{context}: arg {i} direction");
+    }
+}
+
+/// Assert that `iface`'s methods are exactly `expected` (name and full argument list each), in
+/// no particular order.
+fn assert_methods(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
+    assert_eq!(
+        iface.methods().len(),
+        expected.len(),
+        "{}: method count",
+        iface.name(),
+    );
+    for (name, args) in expected {
+        let method = iface
+            .methods()
+            .iter()
+            .find(|m| m.name() == *name)
+            .unwrap_or_else(|| panic!("method `{}.{name}` not found", iface.name()));
+        assert_args(&format!("{}.{name}", iface.name()), method.args(), args);
+    }
+}
+
+/// Assert that `iface`'s signals are exactly `expected` (name and full argument list each).
+fn assert_signals(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
+    assert_eq!(
+        iface.signals().len(),
+        expected.len(),
+        "{}: signal count",
+        iface.name(),
+    );
+    for (name, args) in expected {
+        let signal = iface
+            .signals()
+            .iter()
+            .find(|s| s.name() == *name)
+            .unwrap_or_else(|| panic!("signal `{}.{name}` not found", iface.name()));
+        assert_args(&format!("{}.{name}", iface.name()), signal.args(), args);
+    }
+}
+
+/// Assert that `iface`'s properties are exactly `expected` (name, signature and access each).
+fn assert_properties(iface: &Interface<'_>, expected: &[(&str, &str, PropertyAccess)]) {
+    assert_eq!(
+        iface.properties().len(),
+        expected.len(),
+        "{}: property count",
+        iface.name(),
+    );
+    for &(name, ty, access) in expected {
+        let property = iface
+            .properties()
+            .iter()
+            .find(|p| p.name() == name)
+            .unwrap_or_else(|| panic!("property `{}.{name}` not found", iface.name()));
+        assert!(
+            property.ty() == ty,
+            "{}.{name}: type: expected `{ty}`, got `{}`",
+            iface.name(),
+            property.ty().to_string(),
+        );
+        assert_eq!(property.access(), access, "{}.{name}: access", iface.name());
+    }
+}
+
+/// Introspection XML captured verbatim from live services (see `data/real_world/README.md`),
+/// covering the XML flavors produced by sd-bus, libdbus and GDBus.
+const REAL_WORLD_DATA: &[(&str, &str)] = &[
+    (
+        "dbus_daemon",
+        include_str!("data/real_world/dbus_daemon.xml"),
+    ),
+    (
+        "systemd1_manager",
+        include_str!("data/real_world/systemd1_manager.xml"),
+    ),
+    (
+        "systemd1_scope_unit",
+        include_str!("data/real_world/systemd1_scope_unit.xml"),
+    ),
+    (
+        "systemd1_unit_list",
+        include_str!("data/real_world/systemd1_unit_list.xml"),
+    ),
+    ("hostname1", include_str!("data/real_world/hostname1.xml")),
+    ("timedate1", include_str!("data/real_world/timedate1.xml")),
+    ("locale1", include_str!("data/real_world/locale1.xml")),
+    ("login1", include_str!("data/real_world/login1.xml")),
+    ("network1", include_str!("data/real_world/network1.xml")),
+    (
+        "polkit1_authority",
+        include_str!("data/real_world/polkit1_authority.xml"),
+    ),
+    ("packagekit", include_str!("data/real_world/packagekit.xml")),
+    (
+        "dconf_writer",
+        include_str!("data/real_world/dconf_writer.xml"),
+    ),
+];
+
+#[test]
+fn real_world_data() -> Result<(), Box<dyn Error>> {
+    for (name, xml) in REAL_WORLD_DATA {
+        // `h` (file descriptor) signatures are only supported by zvariant on Unix, so documents
+        // containing them (e.g. from systemd-logind) don't parse on other platforms.
+        if cfg!(not(unix)) && xml.contains(r#"type="h""#) {
+            assert!(
+                matches!(Node::try_from(*xml), Err(zbus_xml::Error::Variant(_))),
+                "{name}: expected fd signatures to be rejected on non-Unix"
+            );
+            continue;
+        }
+
+        let node = Node::try_from(*xml).map_err(|e| format!("{name}: {e}"))?;
+        let node_r = Node::from_reader(xml.as_bytes()).map_err(|e| format!("{name}: {e}"))?;
+        assert_eq!(node, node_r, "{name}: reader and str parses differ");
+
+        // Every service implements the standard Introspectable interface.
+        assert!(
+            node.interfaces()
+                .iter()
+                .any(|i| i.name() == "org.freedesktop.DBus.Introspectable"),
+            "{name}: missing org.freedesktop.DBus.Introspectable"
+        );
+
+        // The document survives a write/parse round-trip unchanged.
+        let mut writer = Vec::new();
+        node.to_writer(&mut writer)?;
+        let written = String::from_utf8(writer)?;
+        let reparsed = Node::try_from(written.as_str()).map_err(|e| format!("{name}: {e}"))?;
+        assert_eq!(node, reparsed, "{name}: round-trip changed the tree");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn real_world_dbus_daemon() -> Result<(), Box<dyn Error>> {
+    // The dbus-daemon document is small and stable, so check its main interface exhaustively:
+    // every method, signal and property, with every argument's name, signature and direction.
+    let node = Node::try_from(include_str!("data/real_world/dbus_daemon.xml"))?;
+    let dbus = interface(&node, "org.freedesktop.DBus");
+
+    assert_methods(
+        dbus,
+        &[
+            ("Hello", &[(None, "s", OUT)]),
+            (
+                "RequestName",
+                &[(None, "s", IN), (None, "u", IN), (None, "u", OUT)],
+            ),
+            ("ReleaseName", &[(None, "s", IN), (None, "u", OUT)]),
+            (
+                "StartServiceByName",
+                &[(None, "s", IN), (None, "u", IN), (None, "u", OUT)],
+            ),
+            ("UpdateActivationEnvironment", &[(None, "a{ss}", IN)]),
+            ("NameHasOwner", &[(None, "s", IN), (None, "b", OUT)]),
+            ("ListNames", &[(None, "as", OUT)]),
+            ("ListActivatableNames", &[(None, "as", OUT)]),
+            ("AddMatch", &[(None, "s", IN)]),
+            ("RemoveMatch", &[(None, "s", IN)]),
+            ("GetNameOwner", &[(None, "s", IN), (None, "s", OUT)]),
+            ("ListQueuedOwners", &[(None, "s", IN), (None, "as", OUT)]),
+            (
+                "GetConnectionUnixUser",
+                &[(None, "s", IN), (None, "u", OUT)],
+            ),
+            (
+                "GetConnectionUnixProcessID",
+                &[(None, "s", IN), (None, "u", OUT)],
+            ),
+            (
+                "GetAdtAuditSessionData",
+                &[(None, "s", IN), (None, "ay", OUT)],
+            ),
+            (
+                "GetConnectionSELinuxSecurityContext",
+                &[(None, "s", IN), (None, "ay", OUT)],
+            ),
+            (
+                "GetConnectionAppArmorSecurityContext",
+                &[(None, "s", IN), (None, "s", OUT)],
+            ),
+            ("ReloadConfig", &[]),
+            ("GetId", &[(None, "s", OUT)]),
+            (
+                "GetConnectionCredentials",
+                &[(None, "s", IN), (None, "a{sv}", OUT)],
+            ),
+        ],
+    );
+
+    assert_signals(
+        dbus,
+        &[
+            (
+                "NameOwnerChanged",
+                &[(None, "s", NONE), (None, "s", NONE), (None, "s", NONE)],
+            ),
+            ("NameLost", &[(None, "s", NONE)]),
+            ("NameAcquired", &[(None, "s", NONE)]),
+            ("ActivatableServicesChanged", &[]),
+        ],
+    );
+
+    assert_properties(
+        dbus,
+        &[
+            ("Features", "as", PropertyAccess::Read),
+            ("Interfaces", "as", PropertyAccess::Read),
+        ],
+    );
+
+    // GDBus-style named arguments on the standard Properties interface round-trip too.
+    let properties = interface(&node, "org.freedesktop.DBus.Properties");
+    assert_signals(
+        properties,
+        &[(
+            "PropertiesChanged",
+            &[
+                (Some("interface_name"), "s", NONE),
+                (Some("changed_properties"), "a{sv}", NONE),
+                (Some("invalidated_properties"), "as", NONE),
+            ],
+        )],
+    );
+
+    Ok(())
+}
+
+#[test]
+fn real_world_systemd() -> Result<(), Box<dyn Error>> {
+    // The manager document contains `h` (file descriptor) signatures (e.g.
+    // `DumpByFileDescriptor`), which zvariant only supports on Unix.
+    if cfg!(unix) {
+        let node = Node::try_from(include_str!("data/real_world/systemd1_manager.xml"))?;
+        let manager = interface(&node, "org.freedesktop.systemd1.Manager");
+
+        // sd-bus emits named, directioned arguments; check a representative set fully.
+        assert_args(
+            "Manager.GetUnit",
+            manager
+                .methods()
+                .iter()
+                .find(|m| m.name() == "GetUnit")
+                .expect("GetUnit method")
+                .args(),
+            &[(Some("name"), "s", IN), (Some("unit"), "o", OUT)],
+        );
+        assert_args(
+            "Manager.StartUnit",
+            manager
+                .methods()
+                .iter()
+                .find(|m| m.name() == "StartUnit")
+                .expect("StartUnit method")
+                .args(),
+            &[
+                (Some("name"), "s", IN),
+                (Some("mode"), "s", IN),
+                (Some("job"), "o", OUT),
+            ],
+        );
+        assert_args(
+            "Manager.UnitNew",
+            manager
+                .signals()
+                .iter()
+                .find(|s| s.name() == "UnitNew")
+                .expect("UnitNew signal")
+                .args(),
+            &[(Some("id"), "s", NONE), (Some("unit"), "o", NONE)],
+        );
+        assert_args(
+            "Manager.JobNew",
+            manager
+                .signals()
+                .iter()
+                .find(|s| s.name() == "JobNew")
+                .expect("JobNew signal")
+                .args(),
+            &[
+                (Some("id"), "u", NONE),
+                (Some("job"), "o", NONE),
+                (Some("unit"), "s", NONE),
+            ],
+        );
+
+        let version = manager
+            .properties()
+            .iter()
+            .find(|p| p.name() == "Version")
+            .expect("Version property");
+        assert!(version.ty() == "s", "Version type");
+        assert_eq!(version.access(), PropertyAccess::Read);
+        assert!(version.access().read() && !version.access().write());
+        // sd-bus annotates properties with their change-signalling behavior.
+        let emits_changed = version
+            .annotations()
+            .iter()
+            .find(|a| a.name() == "org.freedesktop.DBus.Property.EmitsChangedSignal")
+            .expect("EmitsChangedSignal annotation");
+        assert_eq!(emits_changed.value(), "const");
+
+        // Writable properties exercise the readwrite access path.
+        for name in ["LogLevel", "LogTarget"] {
+            let property = manager
+                .properties()
+                .iter()
+                .find(|p| p.name() == name)
+                .unwrap_or_else(|| panic!("Manager.{name} property"));
+            assert!(property.ty() == "s", "Manager.{name}: type");
+            assert_eq!(property.access(), PropertyAccess::ReadWrite);
+            assert!(property.access().read() && property.access().write());
+        }
+    }
+
+    // The unit-list object carries the children of /org/freedesktop/systemd1/unit as named,
+    // interface-less sub-nodes.
+    let node = Node::try_from(include_str!("data/real_world/systemd1_unit_list.xml"))?;
+    assert!(!node.nodes().is_empty());
+    let init_scope = node
+        .nodes()
+        .iter()
+        .find(|n| n.name() == Some("init_2escope"))
+        .expect("init_2escope node");
+    assert!(init_scope.interfaces().is_empty());
+    assert!(init_scope.nodes().is_empty());
+
+    // A scope unit implements the generic Unit interface and the type-specific Scope interface,
+    // both carrying properties.
+    let node = Node::try_from(include_str!("data/real_world/systemd1_scope_unit.xml"))?;
+    for name in [
+        "org.freedesktop.systemd1.Unit",
+        "org.freedesktop.systemd1.Scope",
+    ] {
+        let iface = interface(&node, name);
+        assert!(!iface.properties().is_empty(), "{name}: has properties");
+    }
+    // The generic Unit interface exposes the well-known Id/ActiveState string properties.
+    let unit = interface(&node, "org.freedesktop.systemd1.Unit");
+    for name in ["Id", "ActiveState"] {
+        let property = unit
+            .properties()
+            .iter()
+            .find(|p| p.name() == name)
+            .unwrap_or_else(|| panic!("Unit.{name} property"));
+        assert!(property.ty() == "s", "Unit.{name}: type");
+        assert!(property.access().read(), "Unit.{name}: readable");
+    }
+
+    Ok(())
+}
+
 #[test]
 fn malformed_documents() {
     for input in [
@@ -243,6 +631,21 @@ fn error_position() {
         panic!("expected an XML error");
     };
     assert_eq!(e.position(), input.find('&').unwrap());
+
+    // A duplicate attribute points at the second (offending) name.
+    let input = r#"<node name="a" name="b"/>"#;
+    let Err(zbus_xml::Error::Xml(e)) = Node::try_from(input) else {
+        panic!("expected an XML error");
+    };
+    assert_eq!(e.position(), input.rfind("name").unwrap());
+
+    // A missing required attribute points at the element name.
+    let input = "<node><interface name=\"org.test.I\">\
+                 <property name=\"p\" type=\"s\"/></interface></node>";
+    let Err(zbus_xml::Error::Xml(e)) = Node::try_from(input) else {
+        panic!("expected an XML error");
+    };
+    assert_eq!(e.position(), input.find("property").unwrap());
 }
 
 #[test]
@@ -274,12 +677,91 @@ fn deeply_nested_documents() -> Result<(), Box<dyn Error>> {
         .join()
         .expect("parsing deeply nested documents must not overflow the stack");
 
-    // One level past the cap is rejected cleanly.
+    // One level past the cap is rejected cleanly, on both nesting axes.
     let too_deep = format!("{}{}", "<node>".repeat(1025), "</node>".repeat(1025));
     assert!(matches!(
         Node::try_from(too_deep.as_str()),
         Err(zbus_xml::Error::Xml(_))
     ));
+    let too_deep_foreign = format!(
+        "<node><interface name=\"org.test.I\">{}{}</interface></node>",
+        "<x>".repeat(1025),
+        "</x>".repeat(1025),
+    );
+    assert!(matches!(
+        Node::try_from(too_deep_foreign.as_str()),
+        Err(zbus_xml::Error::Xml(_))
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn io_error() {
+    // A failing reader surfaces as `Error::Io`.
+    struct FailingReader;
+    impl std::io::Read for FailingReader {
+        fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("boom"))
+        }
+    }
+    assert!(matches!(
+        Node::from_reader(FailingReader),
+        Err(zbus_xml::Error::Io(_))
+    ));
+}
+
+#[test]
+fn invalid_enum_attributes() -> Result<(), Box<dyn Error>> {
+    // An invalid `direction` or `access` value is a clean XML error.
+    let bad_direction = "<node><interface name=\"org.test.I\">\
+                         <method name=\"M\"><arg type=\"s\" direction=\"sideways\"/></method>\
+                         </interface></node>";
+    assert!(matches!(
+        Node::try_from(bad_direction),
+        Err(zbus_xml::Error::Xml(_))
+    ));
+
+    let bad_access = "<node><interface name=\"org.test.I\">\
+                      <property name=\"P\" type=\"s\" access=\"rw\"/></interface></node>";
+    assert!(matches!(
+        Node::try_from(bad_access),
+        Err(zbus_xml::Error::Xml(_))
+    ));
+
+    // A write-only property exercises the `PropertyAccess::Write` arm.
+    let write_only = "<node><interface name=\"org.test.I\">\
+                      <property name=\"P\" type=\"s\" access=\"write\"/></interface></node>";
+    let node = Node::try_from(write_only)?;
+    let access = node.interfaces()[0].properties()[0].access();
+    assert_eq!(access, PropertyAccess::Write);
+    assert!(access.write() && !access.read());
+
+    Ok(())
+}
+
+#[test]
+fn invalid_member_names() {
+    // An invalid method or signal name is an `Error::Name` (like the interface-name case in
+    // `malformed_documents`), exercising the same validated-name path for both members.
+    for input in [
+        "<node><interface name=\"org.test.I\"><method name=\"not valid\"/></interface></node>",
+        "<node><interface name=\"org.test.I\"><signal name=\"not valid\"/></interface></node>",
+    ] {
+        assert!(matches!(
+            Node::try_from(input),
+            Err(zbus_xml::Error::Name(_))
+        ));
+    }
+}
+
+#[test]
+fn root_element_name_is_ignored() -> Result<(), Box<dyn Error>> {
+    // The root element's name is not checked, for compatibility with servers that don't name it
+    // `node` (and with how the previous quick-xml-based versions behaved).
+    let node = Node::try_from("<weirdroot><interface name=\"org.test.I\"/></weirdroot>")?;
+    assert_eq!(node.interfaces().len(), 1);
+    assert_eq!(node.interfaces()[0].name(), "org.test.I");
 
     Ok(())
 }

--- a/zvariant_utils/src/signature/mod.rs
+++ b/zvariant_utils/src/signature/mod.rs
@@ -442,8 +442,46 @@ fn parse(bytes: &[u8], check_only: bool) -> Result<Signature, Error> {
 
     // `many1` allocates so we only want to use it when `check_only == false`
     type ManyError = winnow::error::ErrMode<()>;
-    fn many(bytes: &mut &[u8], check_only: bool, top_level: bool) -> Result<Signature, ManyError> {
-        let parser = |s: &mut _| parse_signature(s, check_only);
+
+    // The maximum struct- and array-nesting depths a signature may use, matching the limits
+    // `zvariant` enforces when (de)serializing (see its `container_depths` module). This also
+    // bounds the recursion below, so a hostile signature string — e.g. tens of thousands of `(`
+    // — cannot exhaust the stack. `maybe` (gvariant) is deliberately not bounded, to stay no
+    // stricter than what the (de)serializer accepts.
+    const MAX_STRUCT_DEPTH: u8 = 32;
+    const MAX_ARRAY_DEPTH: u8 = 32;
+
+    /// The struct- and array-nesting depth at a point in a signature, used to bound the recursion.
+    #[derive(Debug, Default, Clone, Copy)]
+    struct Depth {
+        structure: u8,
+        array: u8,
+    }
+
+    impl Depth {
+        fn inc_structure(mut self) -> Self {
+            self.structure += 1;
+            self
+        }
+
+        fn inc_array(mut self) -> Self {
+            self.array += 1;
+            self
+        }
+
+        /// Whether either nesting limit has been exceeded.
+        fn exceeded(self) -> bool {
+            self.structure > MAX_STRUCT_DEPTH || self.array > MAX_ARRAY_DEPTH
+        }
+    }
+
+    fn many(
+        bytes: &mut &[u8],
+        check_only: bool,
+        top_level: bool,
+        depth: Depth,
+    ) -> Result<Signature, ManyError> {
+        let parser = |s: &mut _| parse_signature(s, check_only, depth);
         if check_only {
             return repeat(1.., parser)
                 .map(|_: ()| Signature::Unit)
@@ -482,8 +520,19 @@ fn parse(bytes: &[u8], check_only: bool) -> Result<Signature, Error> {
             .parse_next(bytes)
     }
 
-    fn parse_signature(bytes: &mut &[u8], check_only: bool) -> Result<Signature, ManyError> {
-        let parse_with_context = |bytes: &mut _| parse_signature(bytes, check_only);
+    fn parse_signature(
+        bytes: &mut &[u8],
+        check_only: bool,
+        depth: Depth,
+    ) -> Result<Signature, ManyError> {
+        // Reject types nested past the container-depth limits. Besides matching what `zvariant`
+        // can actually encode, this keeps the recursion below — and hence the stack usage —
+        // bounded on adversarial input.
+        if depth.exceeded() {
+            return fail.parse_next(bytes);
+        }
+        let array_depth = depth.inc_array();
+        let struct_depth = depth.inc_structure();
 
         let simple_type = dispatch! {any;
             b'y' => empty.value(Signature::U8),
@@ -504,7 +553,14 @@ fn parse(bytes: &[u8], check_only: bool) -> Result<Signature, Error> {
 
         let dict = (
             b'a',
-            delimited(b'{', (parse_with_context, parse_with_context), b'}'),
+            delimited(
+                b'{',
+                (
+                    move |s: &mut _| parse_signature(s, check_only, array_depth),
+                    move |s: &mut _| parse_signature(s, check_only, array_depth),
+                ),
+                b'}',
+            ),
         )
             .map(|(_, (key, value))| {
                 if check_only {
@@ -520,24 +576,34 @@ fn parse(bytes: &[u8], check_only: bool) -> Result<Signature, Error> {
                 }
             });
 
-        let array = (b'a', parse_with_context).map(|(_, child)| {
-            if check_only {
-                return Signature::Array(Signature::Unit.into());
-            }
+        let array = (b'a', move |s: &mut _| {
+            parse_signature(s, check_only, array_depth)
+        })
+            .map(|(_, child)| {
+                if check_only {
+                    return Signature::Array(Signature::Unit.into());
+                }
 
-            Signature::Array(child.into())
-        });
+                Signature::Array(child.into())
+            });
 
-        let structure = delimited(b'(', |s: &mut _| many(s, check_only, false), b')');
+        let structure = delimited(
+            b'(',
+            move |s: &mut _| many(s, check_only, false, struct_depth),
+            b')',
+        );
 
+        // `maybe` does not count toward the depth limits (see `Depth`), so its child is parsed
+        // at the same depth.
         #[cfg(feature = "gvariant")]
-        let maybe = (b'm', parse_with_context).map(|(_, child)| {
-            if check_only {
-                return Signature::Maybe(Signature::Unit.into());
-            }
+        let maybe =
+            (b'm', move |s: &mut _| parse_signature(s, check_only, depth)).map(|(_, child)| {
+                if check_only {
+                    return Signature::Maybe(Signature::Unit.into());
+                }
 
-            Signature::Maybe(child.into())
-        });
+                Signature::Maybe(child.into())
+            });
 
         alt((
             simple_type,
@@ -554,9 +620,11 @@ fn parse(bytes: &[u8], check_only: bool) -> Result<Signature, Error> {
         .parse_next(bytes)
     }
 
-    let signature = alt((unit, |s: &mut _| many(s, check_only, true)))
-        .parse(bytes)
-        .map_err(|_| Error::InvalidSignature)?;
+    let signature = alt((unit, |s: &mut _| {
+        many(s, check_only, true, Depth::default())
+    }))
+    .parse(bytes)
+    .map_err(|_| Error::InvalidSignature)?;
 
     Ok(signature)
 }

--- a/zvariant_utils/src/signature/tests.rs
+++ b/zvariant_utils/src/signature/tests.rs
@@ -153,6 +153,31 @@ fn invalid_strings() {
 }
 
 #[test]
+fn recursion_limits() {
+    // Deeply nested structs or arrays are rejected rather than overflowing the stack — the
+    // parser fails as soon as the limit is passed, without recursing through the whole string.
+    // Both the parsing and the allocation-free `check_only` (`validate`) paths reject them.
+    let deep_structs = format!("{}i{}", "(".repeat(20_000), ")".repeat(20_000));
+    assert!(Signature::from_str(&deep_structs).is_err());
+    assert!(validate(deep_structs.as_bytes()).is_err());
+    let deep_arrays = format!("{}i", "a".repeat(20_000));
+    assert!(Signature::from_str(&deep_arrays).is_err());
+    assert!(validate(deep_arrays.as_bytes()).is_err());
+
+    // The exact per-container limits mirror zvariant's (de)serialization limits (see
+    // `zvariant::container_depths`): 32 deep is accepted, 33 rejected — for structs and arrays.
+    assert!(validate(format!("{}i{}", "(".repeat(32), ")".repeat(32)).as_bytes()).is_ok());
+    assert!(validate(format!("{}i{}", "(".repeat(33), ")".repeat(33)).as_bytes()).is_err());
+    assert!(validate(format!("{}i", "a".repeat(32)).as_bytes()).is_ok());
+    assert!(validate(format!("{}i", "a".repeat(33)).as_bytes()).is_err());
+
+    // A long but shallow signature (many fields, little nesting) is fine — there is no length
+    // limit, so a wide struct or a top-level run of many types is accepted.
+    assert!(validate("i".repeat(1000).as_bytes()).is_ok());
+    assert!(validate(format!("({})", "i".repeat(1000)).as_bytes()).is_ok());
+}
+
+#[test]
 fn hash() {
     // We need to test if all variants of Signature hold this invariant:
     test_hash(&Signature::U16, &Signature::U16);


### PR DESCRIPTION
D-Bus introspection documents only use a tiny subset of XML — elements and attributes — so a full-blown XML library is overkill. This replaces quick-xml with a small purpose-built parser (plus a matching writer) in `zbus_xml`, built on **winnow** — which zvariant, zbus_names and zbus already depend on — so the low-level parsing machinery lives in a widely-used, well-audited crate rather than hand-rolled scanning code.

The series: tidy the error module docs, add the real-world test corpus and benchmarks, add the (winnow-based) parser, port to it, test against the real-world documents, deprecate the quick-xml error variants, bump to 5.2.0, drop the dependency, and bound the signature parser's recursion.

## What the parser supports

Exactly what introspection XML needs:

- elements, attributes, entity/character references (`&lt;`, `&#66;`, …) in attribute values, with XML attribute-value whitespace normalization (literal tab/newline/CR → space; character-referenced whitespace kept)
- character references are validated against the XML `Char` production (so e.g. `&#0;` cannot smuggle a NUL into names/values) and signs are rejected; duplicate attributes are rejected
- skipping over everything else a real-world document may carry: XML declaration, doctype (including internal subsets and quoted literals), comments, CDATA, processing instructions, text content, and foreign elements such as Telepathy&#39;s `<tp:docstring>`
- the parser recognises the introspection grammar directly — one small winnow combinator per element (`<node>`, `<interface>`, `<method>`, `<signal>`, `<property>`, `<arg>`, `<annotation>`) decides which attributes are required vs optional (via `opt`) and which children are expected, building the `Node` tree in a single pass with no generic DOM or intermediate representation (same spirit as the signature parser in `zvariant_utils`); the low-level scanning is memchr-backed
- the two axes on which a document can nest arbitrarily deep — nested `<node>`s and skipped-over foreign elements — are walked iteratively, so the call stack stays flat regardless of input; a depth cap (1024) bounds only the open-element bookkeeping. Parse errors carry a byte offset, and invalid names/signatures surface directly as `Error::Name`/`Error::Variant`

## Error API

New `Error` variants: `Xml(XmlError)`, `Name(zbus_names::Error)` and `Io(Arc<io::Error>)`. Signature errors now surface as the pre-existing `Variant` variant instead of being stringified through serde.

For backwards compatibility, the `QuickXml`/`QuickXmlSer` variants are kept but deprecated — they are never returned anymore. Since their payload types came from quick-xml, they now hold our own copies of `DeError`/`SeError` (also deprecated and `doc(hidden)`), so code matching on these variants keeps compiling. The payload-type swap is technically breaking, but the chances of anyone depending on the exact quick-xml error types are negligible — and quick-xml bumps its semver on every release anyway, so such breaks were already routine for users of these variants. The version is bumped to 5.2.0 since the deprecations require a minor release.

## Writer fixes (for free)

- `Node::to_writer` now emits the standard `<node>` root element instead of `<Node>` — an artifact of quick-xml&#39;s serializer using the struct name
- no more empty `direction=""` attributes for args without a direction
- whitespace in attribute values is escaped as character references, so it survives attribute-value normalization by conforming readers (quick-xml wrote it raw, silently corrupting values on interop)
- parsing still ignores the root element&#39;s name (as quick-xml did), so documents written by older versions round-trip fine

## Real-world test data

To make sure this doesn&#39;t break anything in the wild, the introspection XML advertised by a dozen live services was captured verbatim (by launching each service on a real bus and calling `Introspect()` on it — no hand-written approximations) and checked in as test fixtures:

- **systemd 255**: `systemd --user` manager, a unit object, the unit-list node, plus `systemd-hostnamed`, `-timedated`, `-localed`, `-logind`, `-networkd`
- **dbus-daemon 1.14** (`org.freedesktop.DBus`), **polkitd 124**, **PackageKit 1.2.8**, **dconf 0.40**

Together these cover the XML produced by all three common generators: sd-bus, libdbus and GDBus. The tests parse each document through both entry points, and check the dbus-daemon and systemd manager interfaces exhaustively — every method, signal and property, with each argument&#39;s name, signature and direction — through shared helpers, plus assert write→parse round-trip fidelity. Provenance is documented in `tests/data/real_world/README.md`. (The systemd manager and logind documents contain `h` signatures, which zvariant only supports on Unix; on other platforms the tests assert clean failure — a pre-existing zvariant limitation, not new to this PR.)

## Benchmarks

Parse/write benchmarks over the largest real-world document (systemd manager, ~36K) are added at the start of the series — before any change — so the switch from quick-xml to the bespoke parser can be measured, and they run on CI via CodSpeed. Parsing measures within run-to-run noise of the previous implementation.

## Review &amp; testing

- New tests for whitespace normalization, attribute escaping, invalid/signed character references, duplicate attributes, DOCTYPE quoted literals, foreign-element/CDATA/comment skipping, malformed documents, and write→parse round-trips
- `zbus_xmlgen` codegen tests pass, workspace compiles with `--all-features`, clippy clean, Windows target cross-checked
- `zbus` e2e test (parses live introspection output from the object server) passes under `dbus-run-session`
- Each commit in the series builds and passes the tests on its own

Known, documented behavior differences vs quick-xml: `Node::from_reader` consumes the reader to end-of-stream before parsing (doc note added), and non-whitespace text around the root element is ignored rather than rejected.

## Signature parser hardening (zvariant_utils)

Parsing feeds untrusted `type=` attribute values straight into `zvariant::Signature::try_from`, whose signature parser recursed once per level of container nesting with no bound — so a deeply nested type string (tens of thousands of `(`) overflowed the stack and aborted the process. This is pre-existing (the old quick-xml path called `Signature::try_from` too) but reachable from this crate's untrusted-input entry point, so the last commit fixes it at the source: the signature parser now caps struct and array nesting at 32 each — the same limits the (de)serializer already enforces (see `zvariant::container_depths`) — and rejects deeper nesting as `Error::InvalidSignature` as soon as the limit is passed, without recursing through the rest of the string. This keeps the parser's recursion (and hence its stack usage) bounded while staying no stricter than what the (de)serializer round-trips, so it doesn't reject any encodable type (verified against both fuzz targets).


