### PR TITLE
✨ Handle the Telepathy introspection extensions in zbus_xml & zbus-xmlgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,8 @@ version = "5.4.0"
 dependencies = [
  "clap",
  "pretty_assertions",
+ "serde",
+ "serde_repr",
  "snakecase",
  "zbus",
  "zbus_xml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "zbus_xmlgen"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "clap",
  "pretty_assertions",

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -19,13 +19,81 @@ pub use error::{Error, Result, XmlError};
 mod xml;
 use xml::escape;
 
+pub mod telepathy;
+
 use serde::{Deserialize, Serialize};
 use std::{
+    fmt,
     io::{BufWriter, Read, Write},
     ops::Deref,
 };
 
 use zbus_names::{InterfaceName, MemberName, PropertyName};
+
+/// A warning about document content that was ignored during parsing.
+///
+/// The D-Bus introspection format is sometimes extended with elements from other vocabularies,
+/// most notably the [Telepathy extensions] (`tp:enum`, `tp:struct`, …). The parser skips over
+/// any element it has no use for — or understands but cannot make sense of, e. g. a Telepathy
+/// type definition missing a required attribute — and records a `Warning`, which
+/// [`Node::from_reader_with_warnings`] hands back to the caller.
+///
+/// [Telepathy extensions]: https://telepathy.freedesktop.org/spec/
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Warning {
+    element: String,
+    position: usize,
+    message: String,
+}
+
+impl Warning {
+    /// A warning about a skipped element that is not part of the introspection format.
+    pub(crate) fn unsupported(element: impl Into<String>, position: usize) -> Self {
+        let element = element.into();
+        let message = format!("unsupported element `<{element}>` ignored");
+        Self {
+            element,
+            position,
+            message,
+        }
+    }
+
+    /// A warning about a skipped element that is understood but could not be parsed.
+    pub(crate) fn malformed(
+        element: impl Into<String>,
+        position: usize,
+        reason: impl fmt::Display,
+    ) -> Self {
+        let element = element.into();
+        let message = format!("malformed element `<{element}>` ignored: {reason}");
+        Self {
+            element,
+            position,
+            message,
+        }
+    }
+
+    /// The name of the element that was ignored.
+    pub fn element(&self) -> &str {
+        &self.element
+    }
+
+    /// The byte offset in the document at which the element starts.
+    pub fn position(&self) -> usize {
+        self.position
+    }
+
+    /// A message describing what was ignored, and why.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for Warning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (at byte offset {})", self.message, self.position)
+    }
+}
 
 /// Annotations are generic key/value pairs of metadata.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -86,6 +154,10 @@ pub struct Arg {
     direction: Option<ArgDirection>,
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
+    #[serde(skip)]
+    docstring: Option<String>,
+    #[serde(skip)]
+    tp_type: Option<String>,
 }
 
 impl Arg {
@@ -107,6 +179,23 @@ impl Arg {
     /// Return the associated annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// Return the named Telepathy type of the argument (its `tp:type` attribute), if any.
+    ///
+    /// The name refers to a [type definition](telepathy::TypeDef) in scope, with one `[]`
+    /// suffix per level of array nesting (e. g. `Playlist[]`).
+    pub fn tp_type(&self) -> Option<&str> {
+        self.tp_type.as_deref()
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -138,6 +227,8 @@ pub struct Method<'a> {
     args: Vec<Arg>,
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
+    #[serde(skip)]
+    docstring: Option<String>,
 }
 
 impl Method<'_> {
@@ -154,6 +245,15 @@ impl Method<'_> {
     /// Return the method annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -182,6 +282,8 @@ pub struct Signal<'a> {
     args: Vec<Arg>,
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
+    #[serde(skip)]
+    docstring: Option<String>,
 }
 
 impl Signal<'_> {
@@ -198,6 +300,15 @@ impl Signal<'_> {
     /// Return the signal annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -258,6 +369,10 @@ pub struct Property<'a> {
 
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
+    #[serde(skip)]
+    docstring: Option<String>,
+    #[serde(skip)]
+    tp_type: Option<String>,
 }
 
 impl Property<'_> {
@@ -279,6 +394,23 @@ impl Property<'_> {
     /// Return the associated annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// Return the named Telepathy type of the property (its `tp:type` attribute), if any.
+    ///
+    /// The name refers to a [type definition](telepathy::TypeDef) in scope, with one `[]`
+    /// suffix per level of array nesting (e. g. `Playlist[]`).
+    pub fn tp_type(&self) -> Option<&str> {
+        self.tp_type.as_deref()
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -314,6 +446,10 @@ pub struct Interface<'a> {
     signals: Vec<Signal<'a>>,
     #[serde(rename = "annotation", default)]
     annotations: Vec<Annotation>,
+    #[serde(skip)]
+    docstring: Option<String>,
+    #[serde(skip)]
+    telepathy_types: Vec<telepathy::TypeDef>,
 }
 
 impl<'a> Interface<'a> {
@@ -340,6 +476,20 @@ impl<'a> Interface<'a> {
     /// Return the associated annotations.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// Return the Telepathy type definitions on this interface.
+    pub fn telepathy_types(&self) -> &[telepathy::TypeDef] {
+        &self.telepathy_types
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -378,6 +528,10 @@ pub struct Node<'a> {
     interfaces: Vec<Interface<'a>>,
     #[serde(rename = "node", default, borrow)]
     nodes: Vec<Node<'a>>,
+    #[serde(skip)]
+    docstring: Option<String>,
+    #[serde(skip)]
+    telepathy_types: Vec<telepathy::TypeDef>,
 }
 
 impl<'a> Node<'a> {
@@ -385,14 +539,33 @@ impl<'a> Node<'a> {
     ///
     /// Note that `reader` is consumed until end-of-stream before parsing, so this must not be
     /// used with a reader that stays open past the end of the document (e.g. a socket).
-    pub fn from_reader<R: Read>(mut reader: R) -> Result<Node<'a>> {
+    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'a>> {
+        Ok(Node::from_reader_with_warnings(reader)?.0)
+    }
+
+    /// Parse the introspection XML document from reader, collecting warnings.
+    ///
+    /// In addition to the parsed node, a [`Warning`] is returned for every element that is not
+    /// part of the [introspection format] (except Telepathy docstrings, which are captured —
+    /// see [`Interface::docstring`]) and was therefore ignored, e. g. the type-definition
+    /// elements of the Telepathy extensions (`tp:enum`, `tp:struct`, …).
+    ///
+    /// Note that `reader` is consumed until end-of-stream before parsing, so this must not be
+    /// used with a reader that stays open past the end of the document (e.g. a socket).
+    ///
+    /// [introspection format]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
+    pub fn from_reader_with_warnings<R: Read>(mut reader: R) -> Result<(Node<'a>, Vec<Warning>)> {
         let mut input = String::new();
         reader.read_to_string(&mut input)?;
 
-        xml::parse(&input)
+        xml::parse_with_warnings(&input)
     }
 
     /// Write the XML document to writer.
+    ///
+    /// Note that data which is only captured when parsing — Telepathy docstrings, type
+    /// definitions and `tp:type` references — is not written. Consequently, a document that
+    /// carried any does not compare equal to its written-and-reparsed self.
     pub fn to_writer<W: Write>(&self, writer: W) -> Result<()> {
         let mut writer = BufWriter::new(writer);
         self.write_xml(&mut writer)?;
@@ -414,6 +587,20 @@ impl<'a> Node<'a> {
     /// Returns the interfaces on this node.
     pub fn interfaces(&self) -> &[Interface<'a>] {
         &self.interfaces
+    }
+
+    /// Return the content of the Telepathy `tp:docstring` extension element, if any.
+    ///
+    /// The content — typically HTML — is returned as it appears in the document, with the
+    /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
+    /// the writer does not emit them.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// Return the Telepathy type definitions on this node.
+    pub fn telepathy_types(&self) -> &[telepathy::TypeDef] {
+        &self.telepathy_types
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {

--- a/zbus_xml/src/telepathy.rs
+++ b/zbus_xml/src/telepathy.rs
@@ -1,0 +1,280 @@
+//! Support for the type-definition elements of the [Telepathy D-Bus introspection extensions].
+//!
+//! While the D-Bus type system only knows structural types (through signatures), the Telepathy
+//! extensions allow an introspection document to give them names and documentation:
+//!
+//! * `<tp:simple-type>` names a plain D-Bus type ([`SimpleType`]),
+//! * `<tp:enum>` enumerates the values a type can take ([`Enum`]),
+//! * `<tp:struct>` names a structure and its members ([`Struct`]),
+//! * `<tp:mapping>` names a dictionary type ([`Mapping`]).
+//!
+//! Type definitions appear as children of the `<node>` or `<interface>` elements (see
+//! [`Node::telepathy_types`](crate::Node::telepathy_types) and
+//! [`Interface::telepathy_types`](crate::Interface::telepathy_types)) and are referenced by
+//! name through the `tp:type` attribute of `<arg>`, `<property>` and `<tp:member>` elements
+//! (see e. g. [`Arg::tp_type`](crate::Arg::tp_type)), where the name may carry one `[]`
+//! suffix per level of array nesting (e. g. `Playlist[]`).
+//!
+//! A definition that cannot be parsed — a missing required attribute, an invalid signature —
+//! does not fail the document: it is skipped with a [`Warning`](crate::Warning), in the spirit
+//! of treating everything beyond the core introspection format as optional extras. Type
+//! definitions are also parse-only: [`Node::to_writer`](crate::Node::to_writer) does not emit
+//! them.
+//!
+//! [Telepathy D-Bus introspection extensions]: https://telepathy.freedesktop.org/spec/
+
+use crate::Signature;
+
+/// A named type defined through the Telepathy introspection extensions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeDef {
+    /// A name given to a plain D-Bus type (`<tp:simple-type>`).
+    SimpleType(SimpleType),
+    /// An enumeration of the values of a type (`<tp:enum>`).
+    Enum(Enum),
+    /// A named structure (`<tp:struct>`).
+    Struct(Struct),
+    /// A named dictionary type (`<tp:mapping>`).
+    Mapping(Mapping),
+}
+
+impl TypeDef {
+    /// The name of the defined type, as referenced by `tp:type` attributes.
+    pub fn name(&self) -> &str {
+        match self {
+            TypeDef::SimpleType(t) => t.name(),
+            TypeDef::Enum(e) => e.name(),
+            TypeDef::Struct(s) => s.name(),
+            TypeDef::Mapping(m) => m.name(),
+        }
+    }
+
+    /// The docstring of the definition, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        match self {
+            TypeDef::SimpleType(t) => t.docstring(),
+            TypeDef::Enum(e) => e.docstring(),
+            TypeDef::Struct(s) => s.docstring(),
+            TypeDef::Mapping(m) => m.docstring(),
+        }
+    }
+
+    /// The D-Bus signature of the defined type.
+    pub fn signature(&self) -> zvariant::Signature {
+        match self {
+            TypeDef::SimpleType(t) => t.ty().inner().clone(),
+            TypeDef::Enum(e) => e.ty().inner().clone(),
+            TypeDef::Struct(s) => s.signature(),
+            TypeDef::Mapping(m) => m.signature(),
+        }
+    }
+}
+
+/// A name given to a plain D-Bus type (`<tp:simple-type>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SimpleType {
+    pub(crate) name: String,
+    pub(crate) ty: Signature,
+    pub(crate) docstring: Option<String>,
+}
+
+impl SimpleType {
+    /// The name of the type.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The underlying D-Bus type.
+    pub fn ty(&self) -> &Signature {
+        &self.ty
+    }
+
+    /// The docstring of the definition, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+}
+
+/// An enumeration of the values of a type (`<tp:enum>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Enum {
+    pub(crate) name: String,
+    pub(crate) ty: Signature,
+    pub(crate) values: Vec<EnumValue>,
+    pub(crate) docstring: Option<String>,
+}
+
+impl Enum {
+    /// The name of the type.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The underlying D-Bus type.
+    pub fn ty(&self) -> &Signature {
+        &self.ty
+    }
+
+    /// The values of the enumeration.
+    pub fn values(&self) -> &[EnumValue] {
+        &self.values
+    }
+
+    /// The docstring of the definition, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+}
+
+/// A single value of an [`Enum`] (`<tp:enumvalue>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnumValue {
+    pub(crate) suffix: String,
+    pub(crate) value: String,
+    pub(crate) docstring: Option<String>,
+}
+
+impl EnumValue {
+    /// The name of the value.
+    pub fn suffix(&self) -> &str {
+        &self.suffix
+    }
+
+    /// The value itself — a number for numeric enumerations, or e. g. a string.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// The docstring of the value, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+}
+
+/// A named structure (`<tp:struct>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Struct {
+    pub(crate) name: String,
+    pub(crate) members: Vec<Member>,
+    pub(crate) docstring: Option<String>,
+}
+
+impl Struct {
+    /// The name of the type.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The members of the structure.
+    pub fn members(&self) -> &[Member] {
+        &self.members
+    }
+
+    /// The docstring of the definition, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// The D-Bus signature of the structure.
+    pub fn signature(&self) -> zvariant::Signature {
+        zvariant::Signature::structure(
+            self.members
+                .iter()
+                .map(|m| m.ty().inner().clone())
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+/// A member of a [`Struct`] or [`Mapping`] (`<tp:member>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Member {
+    pub(crate) name: String,
+    pub(crate) ty: Signature,
+    pub(crate) tp_type: Option<String>,
+    pub(crate) docstring: Option<String>,
+}
+
+impl Member {
+    /// The name of the member.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The D-Bus type of the member.
+    pub fn ty(&self) -> &Signature {
+        &self.ty
+    }
+
+    /// The named Telepathy type of the member (its `tp:type` attribute), if any.
+    pub fn tp_type(&self) -> Option<&str> {
+        self.tp_type.as_deref()
+    }
+
+    /// The docstring of the member, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+}
+
+/// A named dictionary type (`<tp:mapping>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Mapping {
+    pub(crate) name: String,
+    pub(crate) key: Member,
+    pub(crate) value: Member,
+    pub(crate) docstring: Option<String>,
+}
+
+impl Mapping {
+    /// The name of the type.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The key member of the dictionary.
+    pub fn key(&self) -> &Member {
+        &self.key
+    }
+
+    /// The value member of the dictionary.
+    pub fn value(&self) -> &Member {
+        &self.value
+    }
+
+    /// The docstring of the definition, if any.
+    pub fn docstring(&self) -> Option<&str> {
+        self.docstring.as_deref()
+    }
+
+    /// The D-Bus signature of the dictionary.
+    pub fn signature(&self) -> zvariant::Signature {
+        zvariant::Signature::dict(
+            self.key.ty().inner().clone(),
+            self.value.ty().inner().clone(),
+        )
+    }
+}
+
+/// Whether `ty` is a basic (i. e. non-container) D-Bus type, as required for dictionary keys.
+pub(crate) fn is_basic(ty: &Signature) -> bool {
+    use zvariant::Signature as S;
+
+    match ty.inner() {
+        S::U8
+        | S::Bool
+        | S::I16
+        | S::U16
+        | S::I32
+        | S::U32
+        | S::I64
+        | S::U64
+        | S::F64
+        | S::Str
+        | S::Signature
+        | S::ObjectPath => true,
+        #[cfg(unix)]
+        S::Fd => true,
+        _ => false,
+    }
+}

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -15,15 +15,16 @@ use winnow::{
     LocatingSlice, ModalResult, Parser,
     combinator::{alt, cut_err, delimited, eof, opt, preceded, repeat},
     error::{ErrMode, ParserError},
-    stream::Location,
+    stream::{Location, Stateful},
     token::{any, take_till, take_until, take_while},
 };
 use zbus_names::{InterfaceName, MemberName, PropertyName};
 
 use crate::{
     Annotation, Arg, ArgDirection, Interface, Method, Node, Property, PropertyAccess, Signal,
-    Signature,
+    Signature, Warning,
     error::{Error, Result, XmlError},
+    telepathy::{self, TypeDef},
 };
 
 /// The maximum element nesting depth accepted when parsing.
@@ -36,10 +37,21 @@ const MAX_DEPTH: usize = 1024;
 
 /// Parse a D-Bus introspection document into its [`Node`] tree.
 pub(crate) fn parse<'a>(document: &str) -> Result<Node<'a>> {
-    let mut input = LocatingSlice::new(document);
+    parse_with_warnings(document).map(|(node, _)| node)
+}
+
+/// Parse a D-Bus introspection document, also returning the warnings collected on the way.
+pub(crate) fn parse_with_warnings<'a>(document: &str) -> Result<(Node<'a>, Vec<Warning>)> {
+    let mut input = Input {
+        input: LocatingSlice::new(document),
+        state: State {
+            document,
+            warnings: Vec::new(),
+        },
+    };
     match document_node(&mut input) {
         // The tree owns its data, so it outlives `document` and satisfies any caller lifetime.
-        Ok(node) => Ok(node),
+        Ok(node) => Ok((node, input.state.warnings)),
         Err(ErrMode::Backtrack(error) | ErrMode::Cut(error)) => Err(error.into_error()),
         Err(ErrMode::Incomplete(_)) => Err(Error::Xml(XmlError::new(
             "unexpected end of document",
@@ -62,8 +74,23 @@ fn document_node<'i>(input: &mut Input<'i>) -> PResult<Node<'static>> {
     node(input, tag, attrs, self_closing)
 }
 
-/// The input stream: byte offsets come from [`LocatingSlice`], for error reporting.
-type Input<'i> = LocatingSlice<&'i str>;
+/// The input stream: a [`LocatingSlice`] (byte offsets for error reporting) wrapped in the
+/// parser [`State`], so the whole document and the collected warnings are reachable anywhere.
+type Input<'i> = Stateful<LocatingSlice<&'i str>, State<'i>>;
+
+/// The ambient state threaded through the parser.
+#[derive(Debug)]
+struct State<'i> {
+    /// The whole document, for slicing out the raw content of captured elements.
+    document: &'i str,
+    /// Warnings about ignored content, handed back by [`parse_with_warnings`].
+    warnings: Vec<Warning>,
+}
+
+/// Record a warning about ignored document content.
+fn warn(input: &mut Input<'_>, warning: Warning) {
+    input.state.warnings.push(warning);
+}
 
 /// A parser result, using [`ParseError`] as winnow's error type.
 type PResult<O> = ModalResult<O, ParseError>;
@@ -183,7 +210,22 @@ fn node<'i>(
                 }
                 open.push((child, empty_node(&child_attrs)));
             }
-            _ => skip_element(input, child, child_self_closing)?,
+            other if is_docstring(other) => {
+                let docstring = capture_docstring(input, other, child_self_closing)?;
+                let node = &mut open.last_mut().expect("non-empty").1;
+                node.docstring = docstring.or(node.docstring.take());
+            }
+            other => {
+                if let Some(def) =
+                    telepathy_type_def(input, other, &child_attrs, child_self_closing)?
+                {
+                    open.last_mut()
+                        .expect("non-empty")
+                        .1
+                        .telepathy_types
+                        .push(def);
+                }
+            }
         }
     }
 }
@@ -194,6 +236,8 @@ fn empty_node(attrs: &Attrs<'_>) -> Node<'static> {
         name: attrs.optional("name").map(str::to_owned),
         interfaces: Vec::new(),
         nodes: Vec::new(),
+        docstring: None,
+        telepathy_types: Vec::new(),
     }
 }
 
@@ -209,6 +253,8 @@ fn interface<'i>(
     let mut properties = Vec::new();
     let mut signals = Vec::new();
     let mut annotations = Vec::new();
+    let mut docstring = None;
+    let mut telepathy_types = Vec::new();
     children(
         input,
         tag,
@@ -230,7 +276,16 @@ fn interface<'i>(
                 annotations.push(annotation(input, child, attrs, sc)?);
                 Ok(true)
             }
-            _ => Ok(false),
+            other if is_docstring(other) => {
+                docstring = capture_docstring(input, other, sc)?.or(docstring.take());
+                Ok(true)
+            }
+            other => {
+                if let Some(def) = telepathy_type_def(input, other, &attrs, sc)? {
+                    telepathy_types.push(def);
+                }
+                Ok(true)
+            }
         },
     )?;
 
@@ -240,6 +295,8 @@ fn interface<'i>(
         properties,
         signals,
         annotations,
+        docstring,
+        telepathy_types,
     })
 }
 
@@ -253,6 +310,7 @@ fn method<'i>(
     let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Name))?;
     let mut args = Vec::new();
     let mut annotations = Vec::new();
+    let mut docstring = None;
     children(
         input,
         tag,
@@ -266,7 +324,7 @@ fn method<'i>(
                 annotations.push(annotation(input, child, attrs, sc)?);
                 Ok(true)
             }
-            _ => Ok(false),
+            other => docstring_or_skip(input, other, &attrs, sc, &mut docstring),
         },
     )?;
 
@@ -274,6 +332,7 @@ fn method<'i>(
         name,
         args,
         annotations,
+        docstring,
     })
 }
 
@@ -287,6 +346,7 @@ fn signal<'i>(
     let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Name))?;
     let mut args = Vec::new();
     let mut annotations = Vec::new();
+    let mut docstring = None;
     children(
         input,
         tag,
@@ -300,7 +360,7 @@ fn signal<'i>(
                 annotations.push(annotation(input, child, attrs, sc)?);
                 Ok(true)
             }
-            _ => Ok(false),
+            other => docstring_or_skip(input, other, &attrs, sc, &mut docstring),
         },
     )?;
 
@@ -308,6 +368,7 @@ fn signal<'i>(
         name,
         args,
         annotations,
+        docstring,
     })
 }
 
@@ -326,7 +387,9 @@ fn property<'i>(
         "readwrite" => PropertyAccess::ReadWrite,
         other => return Err(error(format!("invalid property access `{other}`"), input)),
     };
+    let tp_type = attrs.tp_type().map(str::to_owned);
     let mut annotations = Vec::new();
+    let mut docstring = None;
     children(
         input,
         tag,
@@ -336,7 +399,7 @@ fn property<'i>(
                 annotations.push(annotation(input, child, attrs, sc)?);
                 Ok(true)
             }
-            _ => Ok(false),
+            other => docstring_or_skip(input, other, &attrs, sc, &mut docstring),
         },
     )?;
 
@@ -345,6 +408,8 @@ fn property<'i>(
         ty,
         access,
         annotations,
+        docstring,
+        tp_type,
     })
 }
 
@@ -368,7 +433,9 @@ fn arg<'i>(
         }
         None => None,
     };
+    let tp_type = attrs.tp_type().map(str::to_owned);
     let mut annotations = Vec::new();
+    let mut docstring = None;
     children(
         input,
         tag,
@@ -378,7 +445,7 @@ fn arg<'i>(
                 annotations.push(annotation(input, child, attrs, sc)?);
                 Ok(true)
             }
-            _ => Ok(false),
+            other => docstring_or_skip(input, other, &attrs, sc, &mut docstring),
         },
     )?;
 
@@ -387,6 +454,8 @@ fn arg<'i>(
         ty,
         direction,
         annotations,
+        docstring,
+        tp_type,
     })
 }
 
@@ -399,7 +468,10 @@ fn annotation<'i>(
 ) -> PResult<Annotation> {
     let name = attrs.required("name")?.to_owned();
     let value = attrs.required("value")?.to_owned();
-    children(input, tag, self_closing, |_, _, _, _| Ok(false))?;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        skip_unsupported(input, child, &attrs, sc)?;
+        Ok(true)
+    })?;
 
     Ok(Annotation { name, value })
 }
@@ -473,6 +545,390 @@ fn skip_element<'i>(input: &mut Input<'i>, tag: &'i str, self_closing: bool) -> 
     }
 
     Ok(())
+}
+
+/// Skip an element that has no place in the introspection format, recording a warning.
+fn skip_unsupported<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<()> {
+    warn(input, Warning::unsupported(tag, attrs.offset - 1));
+    skip_element(input, tag, self_closing)
+}
+
+/// The fallback child handler for an element with no type definitions of its own: capture a
+/// Telepathy docstring into `slot` (last non-empty wins), or skip an unknown element with a
+/// warning. Always reports the child consumed.
+fn docstring_or_skip<'i>(
+    input: &mut Input<'i>,
+    child: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+    slot: &mut Option<String>,
+) -> PResult<bool> {
+    if is_docstring(child) {
+        *slot = capture_docstring(input, child, self_closing)?.or(slot.take());
+    } else {
+        skip_unsupported(input, child, attrs, self_closing)?;
+    }
+    Ok(true)
+}
+
+/// Consume a Telepathy docstring element, returning its content.
+///
+/// The content is returned verbatim — typically it is HTML — with the surrounding whitespace
+/// trimmed; `None` if it is empty.
+fn capture_docstring<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    self_closing: bool,
+) -> PResult<Option<String>> {
+    if self_closing {
+        return Ok(None);
+    }
+    let start = input.current_token_start();
+    let end = skip_to_close(input, tag)?;
+    let content = input.state.document[start..end].trim();
+
+    Ok((!content.is_empty()).then(|| content.to_owned()))
+}
+
+/// Consume an element's subtree, returning the byte offset of the `<` of its matching closing
+/// tag. The `tag`'s (non-self-closing) start tag has already been read.
+///
+/// Iterative, like [`skip_element`], so deeply nested content cannot exhaust the call stack.
+fn skip_to_close<'i>(input: &mut Input<'i>, tag: &'i str) -> PResult<usize> {
+    let mut open = vec![tag];
+    loop {
+        ignorable(input)?;
+        let here = input.current_token_start();
+        let expected = *open.last().expect("non-empty until returning");
+        if opt(eof).parse_next(input)?.is_some() {
+            return Err(error(format!("missing `</{expected}>`"), input));
+        }
+        if let Some(close) = opt(closing_tag).parse_next(input)? {
+            if close != expected {
+                return Err(error(
+                    format!("unexpected `</{close}>` while parsing `<{expected}>`"),
+                    input,
+                ));
+            }
+            open.pop();
+            if open.is_empty() {
+                return Ok(here);
+            }
+            continue;
+        }
+        let (child, _, self_closing) = start_element(input)?;
+        if !self_closing {
+            if open.len() >= MAX_DEPTH {
+                return Err(error("maximum element nesting depth exceeded", input));
+            }
+            open.push(child);
+        }
+    }
+}
+
+/// The part of an element or attribute name after the namespace prefix, if any.
+fn local_name(name: &str) -> &str {
+    name.rsplit(':').next().unwrap_or(name)
+}
+
+/// Whether `name` is a Telepathy `tp:docstring` element, under any namespace prefix.
+fn is_docstring(name: &str) -> bool {
+    local_name(name) == "docstring"
+}
+
+/// Whether `name` is a Telepathy `tp:type` attribute.
+///
+/// The prefix is required: without one, `type` is the signature attribute.
+fn is_tp_type(name: &str) -> bool {
+    name.split_once(':')
+        .is_some_and(|(prefix, local)| !prefix.is_empty() && local == "type")
+}
+
+/// A `type` attribute holding a D-Bus signature, in a Telepathy type definition.
+enum SignatureAttr {
+    Missing,
+    Invalid,
+    Value(Signature),
+}
+
+impl SignatureAttr {
+    fn parse(value: Option<&str>) -> Self {
+        match value {
+            None => SignatureAttr::Missing,
+            Some(value) => match zvariant::Signature::try_from(value.as_bytes()) {
+                // The empty signature parses as `Unit`, which is only valid as a top-level
+                // signature — inside a composed signature (`Struct`/`Mapping::signature`) it
+                // produces invalid signatures.
+                Ok(zvariant::Signature::Unit) | Err(_) => SignatureAttr::Invalid,
+                Ok(signature) => SignatureAttr::Value(Signature(signature)),
+            },
+        }
+    }
+}
+
+/// Parse a Telepathy type-definition element, if `tag` is one.
+///
+/// The element is consumed in all cases; `Ok(None)` — with a warning recorded — is returned
+/// when `tag` is not a type definition, or is one that cannot be parsed.
+fn telepathy_type_def<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<TypeDef>> {
+    match local_name(tag) {
+        "simple-type" => simple_type(input, tag, attrs, self_closing),
+        "enum" => enum_def(input, tag, attrs, self_closing),
+        "struct" => struct_def(input, tag, attrs, self_closing),
+        "mapping" => mapping_def(input, tag, attrs, self_closing),
+        _ => {
+            skip_unsupported(input, tag, attrs, self_closing)?;
+            Ok(None)
+        }
+    }
+}
+
+/// Record a "malformed element" warning and return `Ok(None)`.
+fn malformed<T>(
+    input: &mut Input<'_>,
+    tag: &str,
+    position: usize,
+    reason: impl std::fmt::Display,
+) -> PResult<Option<T>> {
+    warn(input, Warning::malformed(tag, position, reason));
+    Ok(None)
+}
+
+/// Parse a `<tp:simple-type>`: a `name` given to a plain D-Bus `type`.
+fn simple_type<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<TypeDef>> {
+    let position = attrs.offset - 1;
+    let name = attrs.optional("name").map(str::to_owned);
+    let ty = SignatureAttr::parse(attrs.optional("type"));
+    let mut docstring = None;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        docstring_or_skip(input, child, &attrs, sc, &mut docstring)
+    })?;
+
+    let Some(name) = name else {
+        return malformed(input, tag, position, "missing attribute `name`");
+    };
+    let ty = match ty {
+        SignatureAttr::Value(ty) => ty,
+        SignatureAttr::Missing => {
+            return malformed(input, tag, position, "missing attribute `type`");
+        }
+        SignatureAttr::Invalid => {
+            return malformed(input, tag, position, "invalid signature in `type`");
+        }
+    };
+
+    Ok(Some(TypeDef::SimpleType(telepathy::SimpleType {
+        name,
+        ty,
+        docstring,
+    })))
+}
+
+/// Parse a `<tp:enum>`: a `name`, an underlying `type` and its `<tp:enumvalue>`s.
+fn enum_def<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<TypeDef>> {
+    let position = attrs.offset - 1;
+    let name = attrs.optional("name").map(str::to_owned);
+    let ty = SignatureAttr::parse(attrs.optional("type"));
+    let mut values = Vec::new();
+    let mut incomplete_value = false;
+    let mut docstring = None;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        if local_name(child) == "enumvalue" {
+            match enum_value(input, child, &attrs, sc)? {
+                Some(value) => values.push(value),
+                None => incomplete_value = true,
+            }
+            Ok(true)
+        } else {
+            docstring_or_skip(input, child, &attrs, sc, &mut docstring)
+        }
+    })?;
+
+    let Some(name) = name else {
+        return malformed(input, tag, position, "missing attribute `name`");
+    };
+    let ty = match ty {
+        SignatureAttr::Value(ty) => ty,
+        SignatureAttr::Missing => {
+            return malformed(input, tag, position, "missing attribute `type`");
+        }
+        SignatureAttr::Invalid => {
+            return malformed(input, tag, position, "invalid signature in `type`");
+        }
+    };
+    if incomplete_value {
+        let reason = "an enumvalue is missing its `suffix` or `value` attribute";
+        return malformed(input, tag, position, reason);
+    }
+
+    Ok(Some(TypeDef::Enum(telepathy::Enum {
+        name,
+        ty,
+        values,
+        docstring,
+    })))
+}
+
+/// Parse a `<tp:enumvalue>`: a `suffix`/`value` pair. `None` if either is missing.
+fn enum_value<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<telepathy::EnumValue>> {
+    let suffix = attrs.optional("suffix").map(str::to_owned);
+    let value = attrs.optional("value").map(str::to_owned);
+    let mut docstring = None;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        docstring_or_skip(input, child, &attrs, sc, &mut docstring)
+    })?;
+
+    Ok(suffix
+        .zip(value)
+        .map(|(suffix, value)| telepathy::EnumValue {
+            suffix,
+            value,
+            docstring,
+        }))
+}
+
+/// Parse a `<tp:struct>`: a `name` and its `<tp:member>`s.
+fn struct_def<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<TypeDef>> {
+    let position = attrs.offset - 1;
+    let name = attrs.optional("name").map(str::to_owned);
+    let (members, incomplete_member, docstring) = members(input, tag, self_closing)?;
+
+    let Some(name) = name else {
+        return malformed(input, tag, position, "missing attribute `name`");
+    };
+    if incomplete_member {
+        return malformed(input, tag, position, INCOMPLETE_MEMBER);
+    }
+    if members.is_empty() {
+        return malformed(input, tag, position, "no members");
+    }
+
+    Ok(Some(TypeDef::Struct(telepathy::Struct {
+        name,
+        members,
+        docstring,
+    })))
+}
+
+/// Parse a `<tp:mapping>`: a `name` and exactly two `<tp:member>`s (a basic key and a value).
+fn mapping_def<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<TypeDef>> {
+    let position = attrs.offset - 1;
+    let name = attrs.optional("name").map(str::to_owned);
+    let (members, incomplete_member, docstring) = members(input, tag, self_closing)?;
+
+    let Some(name) = name else {
+        return malformed(input, tag, position, "missing attribute `name`");
+    };
+    if incomplete_member {
+        return malformed(input, tag, position, INCOMPLETE_MEMBER);
+    }
+    let mut members = members.into_iter();
+    let (key, value) = match (members.next(), members.next(), members.next()) {
+        (Some(key), Some(value), None) => (key, value),
+        _ => return malformed(input, tag, position, "expected exactly 2 members"),
+    };
+    if !telepathy::is_basic(key.ty()) {
+        return malformed(input, tag, position, "the key is not a basic type");
+    }
+
+    Ok(Some(TypeDef::Mapping(telepathy::Mapping {
+        name,
+        key,
+        value,
+        docstring,
+    })))
+}
+
+const INCOMPLETE_MEMBER: &str =
+    "a member is missing its `name` or `type` attribute, or has an invalid signature";
+
+/// Parse the `<tp:member>` children (and docstring) of a `<tp:struct>` or `<tp:mapping>`,
+/// returning the members, whether any was incomplete, and the docstring.
+#[allow(clippy::type_complexity)]
+fn members<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    self_closing: bool,
+) -> PResult<(Vec<telepathy::Member>, bool, Option<String>)> {
+    let mut members = Vec::new();
+    let mut incomplete_member = false;
+    let mut docstring = None;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        if local_name(child) == "member" {
+            match member(input, child, &attrs, sc)? {
+                Some(member) => members.push(member),
+                None => incomplete_member = true,
+            }
+            Ok(true)
+        } else {
+            docstring_or_skip(input, child, &attrs, sc, &mut docstring)
+        }
+    })?;
+
+    Ok((members, incomplete_member, docstring))
+}
+
+/// Parse a `<tp:member>`: a `name`, a `type` and an optional `tp:type`. `None` if the `name`
+/// or a valid `type` is missing.
+fn member<'i>(
+    input: &mut Input<'i>,
+    tag: &'i str,
+    attrs: &Attrs<'i>,
+    self_closing: bool,
+) -> PResult<Option<telepathy::Member>> {
+    let name = attrs.optional("name").map(str::to_owned);
+    let ty = SignatureAttr::parse(attrs.optional("type"));
+    let tp_type = attrs.tp_type().map(str::to_owned);
+    let mut docstring = None;
+    children(input, tag, self_closing, |input, child, attrs, sc| {
+        docstring_or_skip(input, child, &attrs, sc, &mut docstring)
+    })?;
+
+    let (Some(name), SignatureAttr::Value(ty)) = (name, ty) else {
+        return Ok(None);
+    };
+
+    Ok(Some(telepathy::Member {
+        name,
+        ty,
+        tp_type,
+        docstring,
+    }))
 }
 
 /// Consume any content that carries no introspection data: whitespace and text, comments, CDATA
@@ -605,6 +1061,14 @@ impl<'i> Attrs<'i> {
         zvariant::Signature::try_from(self.required("type")?.as_bytes())
             .map(Signature)
             .map_err(|e| ParseError::domain(zvariant::Error::from(e).into()))
+    }
+
+    /// The value of the Telepathy `tp:type` attribute, if present.
+    fn tp_type(&self) -> Option<&str> {
+        self.pairs
+            .iter()
+            .find(|(name, _)| is_tp_type(name))
+            .map(|(_, value)| value.as_ref())
     }
 }
 

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -765,3 +765,323 @@ fn root_element_name_is_ignored() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn docstrings() -> Result<(), Box<dyn Error>> {
+    // Telepathy-style docstrings are captured on interfaces, members and args, verbatim
+    // (including markup and references) but with the surrounding whitespace trimmed.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <interface name="org.test.testinterface">
+                <tp:docstring>
+                    <p>An interface, closely modeled after the
+                    <strong>MPRIS</strong> ones &amp; documented inline.</p>
+                    <tp:rationale>
+                        <p>With a nested rationale.</p>
+                    </tp:rationale>
+                </tp:docstring>
+                <method name="TestMethod">
+                    <tp:docstring>Does the thing.</tp:docstring>
+                    <arg name="testarg" direction="in" type="s">
+                        <tp:docstring>The thing to do.</tp:docstring>
+                    </arg>
+                    <arg name="undocumented" direction="out" type="u"/>
+                </method>
+                <signal name="TestSignal">
+                    <tp:docstring>Emitted when the thing was done.</tp:docstring>
+                    <arg name="testarg" type="s">
+                        <tp:docstring>The thing that was done.</tp:docstring>
+                    </arg>
+                </signal>
+                <property name="TestProperty" type="b" access="read">
+                    <tp:docstring>Whether the thing has been done.</tp:docstring>
+                </property>
+                <property name="EmptyDocstring" type="b" access="read">
+                    <tp:docstring>   </tp:docstring>
+                    <tp:docstring/>
+                </property>
+            </interface>
+        </node>
+    "#;
+
+    let node = Node::try_from(input)?;
+    let interface = &node.interfaces()[0];
+    let docstring = interface.docstring().expect("interface docstring");
+    assert!(docstring.starts_with("<p>An interface,"));
+    assert!(docstring.contains("<strong>MPRIS</strong> ones &amp; documented inline.</p>"));
+    assert!(docstring.contains("<tp:rationale>"));
+    assert!(docstring.ends_with("</tp:rationale>"));
+
+    let method = &interface.methods()[0];
+    assert_eq!(method.docstring(), Some("Does the thing."));
+    assert_eq!(method.args()[0].docstring(), Some("The thing to do."));
+    assert_eq!(method.args()[1].docstring(), None);
+
+    let signal = &interface.signals()[0];
+    assert_eq!(signal.docstring(), Some("Emitted when the thing was done."));
+    assert_eq!(
+        signal.args()[0].docstring(),
+        Some("The thing that was done.")
+    );
+
+    assert_eq!(
+        interface.properties()[0].docstring(),
+        Some("Whether the thing has been done.")
+    );
+    // Whitespace-only and self-closing docstrings count as absent.
+    assert_eq!(interface.properties()[1].docstring(), None);
+
+    Ok(())
+}
+
+#[test]
+fn unsupported_element_warnings() -> Result<(), Box<dyn Error>> {
+    // Elements that have no place in the introspection format are skipped with a warning.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:flags name="Media_Caps" value-prefix="Cap" type="u">
+                <tp:flag suffix="Audio" value="1"/>
+            </tp:flags>
+            <interface name="org.test.testinterface">
+                <tp:docstring>Documented, not warned about.</tp:docstring>
+                <method name="TestMethod">
+                    <tp:possible-errors/>
+                </method>
+                <annotation name="org.test.Annotation" value="v">
+                    <unexpected/>
+                </annotation>
+            </interface>
+        </node>
+    "#;
+
+    let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
+    assert_eq!(node.interfaces().len(), 1);
+    assert_eq!(
+        node.interfaces()[0].docstring(),
+        Some("Documented, not warned about.")
+    );
+
+    let elements: Vec<_> = warnings.iter().map(|w| w.element()).collect();
+    assert_eq!(elements, ["tp:flags", "tp:possible-errors", "unexpected"]);
+    // Nested children of a skipped element (`tp:flag`) are not warned about separately, and
+    // warnings point at the start of the offending element.
+    assert_eq!(warnings[0].position(), input.find("<tp:flags").unwrap());
+    assert!(warnings[0].message().contains("`<tp:flags>`"));
+    assert!(warnings[0].to_string().contains("`<tp:flags>`"));
+
+    // The warning-less API still just ignores everything.
+    assert_eq!(Node::try_from(input)?, node);
+
+    Ok(())
+}
+
+#[test]
+fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:simple-type name="Playlist_Id" type="o" array-name="Playlist_Id_List">
+                <tp:docstring>Unique playlist identifier.</tp:docstring>
+            </tp:simple-type>
+            <interface name="org.test.testinterface">
+                <tp:enum name="Playlist_Ordering" type="s">
+                    <tp:docstring>The way to order playlists.</tp:docstring>
+                    <tp:enumvalue suffix="Alphabetical" value="Alphabetical">
+                        <tp:docstring>Alphabetical ordering, ascending.</tp:docstring>
+                    </tp:enumvalue>
+                    <tp:enumvalue suffix="UserDefined" value="User"/>
+                </tp:enum>
+                <tp:struct name="Playlist" array-name="Playlist_List">
+                    <tp:docstring>A data structure describing a playlist.</tp:docstring>
+                    <tp:member type="o" tp:type="Playlist_Id" name="Id">
+                        <tp:docstring>A unique identifier.</tp:docstring>
+                    </tp:member>
+                    <tp:member type="s" name="Name"/>
+                </tp:struct>
+                <tp:mapping name="String_Variant_Map">
+                    <tp:member type="s" name="Key"/>
+                    <tp:member type="v" name="Value"/>
+                </tp:mapping>
+                <method name="GetPlaylists">
+                    <arg direction="out" name="playlists" type="a(os)" tp:type="Playlist[]"/>
+                </method>
+                <property name="Orderings" type="as" tp:type="Playlist_Ordering[]" access="read"/>
+            </interface>
+        </node>
+    "#;
+
+    let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
+    assert_eq!(warnings, []);
+
+    use zbus_xml::telepathy::TypeDef;
+
+    // Node-level definitions.
+    let [TypeDef::SimpleType(id)] = node.telepathy_types() else {
+        panic!("expected a simple type on the node");
+    };
+    assert_eq!(id.name(), "Playlist_Id");
+    assert_eq!(*id.ty().inner(), Signature::ObjectPath);
+    assert_eq!(id.docstring(), Some("Unique playlist identifier."));
+
+    // Interface-level definitions.
+    let interface = &node.interfaces()[0];
+    let [
+        TypeDef::Enum(ordering),
+        TypeDef::Struct(playlist),
+        TypeDef::Mapping(map),
+    ] = interface.telepathy_types()
+    else {
+        panic!("expected enum, struct and mapping on the interface");
+    };
+
+    assert_eq!(ordering.name(), "Playlist_Ordering");
+    assert_eq!(*ordering.ty().inner(), Signature::Str);
+    assert_eq!(ordering.docstring(), Some("The way to order playlists."));
+    assert_eq!(ordering.values().len(), 2);
+    assert_eq!(ordering.values()[0].suffix(), "Alphabetical");
+    assert_eq!(ordering.values()[0].value(), "Alphabetical");
+    assert_eq!(
+        ordering.values()[0].docstring(),
+        Some("Alphabetical ordering, ascending.")
+    );
+    assert_eq!(ordering.values()[1].suffix(), "UserDefined");
+    assert_eq!(ordering.values()[1].value(), "User");
+    assert_eq!(ordering.values()[1].docstring(), None);
+
+    assert_eq!(playlist.name(), "Playlist");
+    assert_eq!(
+        playlist.docstring(),
+        Some("A data structure describing a playlist.")
+    );
+    assert_eq!(playlist.members().len(), 2);
+    assert_eq!(playlist.members()[0].name(), "Id");
+    assert_eq!(*playlist.members()[0].ty().inner(), Signature::ObjectPath);
+    assert_eq!(playlist.members()[0].tp_type(), Some("Playlist_Id"));
+    assert_eq!(
+        playlist.members()[0].docstring(),
+        Some("A unique identifier.")
+    );
+    assert_eq!(playlist.members()[1].tp_type(), None);
+    assert_eq!(playlist.signature().to_string(), "(os)");
+
+    assert_eq!(map.name(), "String_Variant_Map");
+    assert_eq!(map.key().name(), "Key");
+    assert_eq!(map.value().name(), "Value");
+    assert_eq!(map.signature().to_string(), "a{sv}");
+
+    // `tp:type` references on args and properties.
+    let method = &interface.methods()[0];
+    assert_eq!(method.args()[0].tp_type(), Some("Playlist[]"));
+    assert_eq!(
+        interface.properties()[0].tp_type(),
+        Some("Playlist_Ordering[]")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn malformed_telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
+    // A type definition that cannot be parsed doesn't fail the document; it is skipped with a
+    // warning.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:simple-type type="o"/>
+            <tp:simple-type name="Bad_Type" type="!"/>
+            <tp:simple-type name="Empty_Type" type=""/>
+            <tp:enum name="No_Type">
+                <tp:enumvalue suffix="A" value="0"/>
+            </tp:enum>
+            <tp:enum name="Bad_Value" type="u">
+                <tp:enumvalue value="0"/>
+            </tp:enum>
+            <tp:struct name="Empty"/>
+            <tp:struct name="Bad_Member">
+                <tp:member name="No_Type_Either"/>
+            </tp:struct>
+            <tp:mapping name="Not_A_Pair">
+                <tp:member type="s" name="Key"/>
+            </tp:mapping>
+            <tp:mapping name="Bad_Key">
+                <tp:member type="v" name="Key"/>
+                <tp:member type="s" name="Value"/>
+            </tp:mapping>
+            <interface name="org.test.testinterface"/>
+        </node>
+    "#;
+
+    let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
+    assert_eq!(node.telepathy_types(), []);
+    assert_eq!(node.interfaces().len(), 1);
+
+    let messages: Vec<_> = warnings.iter().map(|w| w.message()).collect();
+    assert_eq!(
+        messages,
+        [
+            "malformed element `<tp:simple-type>` ignored: missing attribute `name`",
+            "malformed element `<tp:simple-type>` ignored: invalid signature in `type`",
+            "malformed element `<tp:simple-type>` ignored: invalid signature in `type`",
+            "malformed element `<tp:enum>` ignored: missing attribute `type`",
+            "malformed element `<tp:enum>` ignored: an enumvalue is missing its `suffix` or \
+             `value` attribute",
+            "malformed element `<tp:struct>` ignored: no members",
+            "malformed element `<tp:struct>` ignored: a member is missing its `name` or `type` \
+             attribute, or has an invalid signature",
+            "malformed element `<tp:mapping>` ignored: expected exactly 2 members",
+            "malformed element `<tp:mapping>` ignored: the key is not a basic type",
+        ]
+    );
+    assert_eq!(
+        warnings[0].position(),
+        input.find("<tp:simple-type").unwrap()
+    );
+
+    // An empty struct member type composes into an invalid struct signature, so it must be
+    // rejected too.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:struct name="S"><tp:member name="m" type=""/></tp:struct>
+        </node>
+    "#;
+    let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
+    assert_eq!(node.telepathy_types(), []);
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].message().contains("`<tp:struct>`"));
+
+    Ok(())
+}
+
+#[test]
+fn unknown_children_of_telepathy_definitions() -> Result<(), Box<dyn Error>> {
+    // Unknown elements are warned about wherever they appear, including inside the leaf
+    // elements of type definitions.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:simple-type name="Token" type="s">
+                <tp:added version="0.1"/>
+            </tp:simple-type>
+            <interface name="org.test.testinterface">
+                <tp:enum name="Level" type="u">
+                    <tp:enumvalue suffix="Low" value="0">
+                        <tp:changed version="0.2"/>
+                    </tp:enumvalue>
+                </tp:enum>
+                <tp:struct name="Pair">
+                    <tp:member name="first" type="s">
+                        <bogus/>
+                    </tp:member>
+                    <tp:member name="second" type="s"/>
+                </tp:struct>
+            </interface>
+        </node>
+    "#;
+
+    let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
+    // The definitions themselves still parse fine.
+    assert_eq!(node.telepathy_types().len(), 1);
+    assert_eq!(node.interfaces()[0].telepathy_types().len(), 2);
+
+    let elements: Vec<_> = warnings.iter().map(|w| w.element()).collect();
+    assert_eq!(elements, ["tp:added", "tp:changed", "bogus"]);
+
+    Ok(())
+}

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -38,6 +38,9 @@ clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+# For the compile tests of code generated from Telepathy type definitions.
+serde.workspace = true
+serde_repr.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zbus_xmlgen"
-version = "5.3.1"
+version = "5.4.0"
 authors = [
     "Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>",
     "Federico Mena Quintero <federico@gnome.org>",

--- a/zbus_xmlgen/Cargo.toml
+++ b/zbus_xmlgen/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["cli"]
 
 [dependencies]
 zbus = { path = "../zbus", features = ["blocking-api"], version = "5.16.0" }
-zbus_xml = { path = "../zbus_xml", version = "5.1.1" }
+zbus_xml = { path = "../zbus_xml", version = "5.2.0" }
 
 snakecase.workspace = true
 clap = { workspace = true, optional = true }

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -11,6 +11,7 @@ use zbus::{
 };
 use zbus_xml::{Arg, ArgDirection, Interface};
 
+#[deprecated(since = "5.4.0", note = "use `CodeGenerator::file_code` instead")]
 pub fn write_interfaces(
     interfaces: &[Interface<'_>],
     standard_interfaces: &[Interface<'_>],
@@ -20,37 +21,19 @@ pub fn write_interfaces(
     cargo_bin_name: &str,
     cargo_bin_version: &str,
 ) -> Result<String, Box<dyn Error + 'static>> {
-    let mut unformatted = String::new();
+    let code = CodeGenerator::new()
+        .with_service(service.as_ref())
+        .with_path(path.as_ref())
+        .with_format(true)
+        .file_code(
+            interfaces,
+            standard_interfaces,
+            input_src,
+            cargo_bin_name,
+            cargo_bin_version,
+        )?;
 
-    write_doc_header(
-        &mut unformatted,
-        interfaces,
-        standard_interfaces,
-        input_src,
-        cargo_bin_name,
-        cargo_bin_version,
-    )?;
-
-    for interface in interfaces {
-        let r#gen = GenTrait {
-            interface,
-            service: service.as_ref(),
-            path: path.as_ref(),
-            format: false,
-        };
-
-        write!(unformatted, "{gen}")?;
-    }
-
-    let formatted = match format_generated_code(&unformatted) {
-        Ok(formatted) => formatted,
-        Err(e) => {
-            eprintln!("Failed to format generated code: {e}");
-            unformatted
-        }
-    };
-
-    Ok(formatted)
+    Ok(code)
 }
 
 /// Write a doc header, listing the included Interfaces and how the
@@ -128,6 +111,7 @@ fn write_doc_header<W: std::fmt::Write>(
     Ok(())
 }
 
+#[deprecated(since = "5.4.0", note = "use `CodeGenerator` instead")]
 pub struct GenTrait<'i> {
     pub interface: &'i Interface<'i>,
     pub service: Option<&'i BusName<'i>>,
@@ -135,24 +119,120 @@ pub struct GenTrait<'i> {
     pub format: bool,
 }
 
+#[allow(deprecated)]
 impl Display for GenTrait<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.format {
-            let mut unformatted = String::new();
-            self.write_interface(&mut unformatted)?;
+        let code = CodeGenerator::new()
+            .with_service(self.service)
+            .with_path(self.path)
+            .with_format(self.format)
+            .interface_code(self.interface)?;
 
-            let formatted = format_generated_code(&unformatted).unwrap_or(unformatted);
-
-            write!(f, "{formatted}")
-        } else {
-            self.write_interface(f)
-        }
+        write!(f, "{code}")
     }
 }
 
-impl GenTrait<'_> {
-    fn write_interface<W: Write>(&self, w: &mut W) -> std::fmt::Result {
-        let iface = self.interface;
+/// Generates Rust code from D-Bus introspection data.
+///
+/// The generator is configured through the builder-style `with_*` methods; the code is then
+/// produced by [`CodeGenerator::interface_code`] (a proxy trait for one interface) or
+/// [`CodeGenerator::file_code`] (a complete source file).
+#[derive(Debug, Default, Clone)]
+pub struct CodeGenerator<'i> {
+    service: Option<&'i BusName<'i>>,
+    path: Option<&'i ObjectPath<'i>>,
+    format: bool,
+}
+
+impl<'i> CodeGenerator<'i> {
+    /// Create a code generator with the default configuration.
+    ///
+    /// No default service or path, no formatting.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the well-known service name, for the proxies' `default_service`.
+    pub fn with_service(mut self, service: Option<&'i BusName<'i>>) -> Self {
+        self.service = service;
+        self
+    }
+
+    /// Set the object path, for the proxies' `default_path`.
+    pub fn with_path(mut self, path: Option<&'i ObjectPath<'i>>) -> Self {
+        self.path = path;
+        self
+    }
+
+    /// Set whether the generated code is passed through `rustfmt`.
+    ///
+    /// If `rustfmt` fails or is not available, the unformatted code is returned instead.
+    pub fn with_format(mut self, format: bool) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// The well-known service name, if any.
+    pub fn service(&self) -> Option<&'i BusName<'i>> {
+        self.service
+    }
+
+    /// The object path, if any.
+    pub fn path(&self) -> Option<&'i ObjectPath<'i>> {
+        self.path
+    }
+
+    /// Whether the generated code is passed through `rustfmt`.
+    pub fn format(&self) -> bool {
+        self.format
+    }
+
+    /// Generate the code for `interface`: a proxy trait.
+    pub fn interface_code(&self, interface: &Interface<'_>) -> Result<String, std::fmt::Error> {
+        let mut code = String::new();
+        self.write_interface(&mut code, interface)?;
+
+        Ok(if self.format {
+            format_generated_code(&code).unwrap_or(code)
+        } else {
+            code
+        })
+    }
+
+    /// Generate a complete source file: a doc header followed by the code for `interfaces`.
+    ///
+    /// `standard_interfaces` are only mentioned in the header, as zbus provides their
+    /// implementation; `input_src`, `cargo_bin_name` and `cargo_bin_version` document where
+    /// the code came from.
+    pub fn file_code(
+        &self,
+        interfaces: &[Interface<'_>],
+        standard_interfaces: &[Interface<'_>],
+        input_src: &str,
+        cargo_bin_name: &str,
+        cargo_bin_version: &str,
+    ) -> Result<String, std::fmt::Error> {
+        let mut code = String::new();
+        write_doc_header(
+            &mut code,
+            interfaces,
+            standard_interfaces,
+            input_src,
+            cargo_bin_name,
+            cargo_bin_version,
+        )?;
+        for interface in interfaces {
+            self.write_interface(&mut code, interface)?;
+        }
+
+        Ok(if self.format {
+            format_generated_code(&code).unwrap_or(code)
+        } else {
+            code
+        })
+    }
+
+    fn write_interface<W: Write>(&self, w: &mut W, iface: &Interface<'_>) -> std::fmt::Result {
         let idx = iface.name().rfind('.').unwrap() + 1;
         let name = &iface.name()[idx..];
 

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -156,6 +156,9 @@ impl GenTrait<'_> {
         let idx = iface.name().rfind('.').unwrap() + 1;
         let name = &iface.name()[idx..];
 
+        if let Some(docstring) = iface.docstring() {
+            write_doc_lines(w, docstring, "")?;
+        }
         write!(w, "#[proxy(interface = \"{}\"", iface.name())?;
         if let Some(service) = self.service {
             write!(w, ", default_service = \"{service}\"")?;
@@ -176,6 +179,7 @@ impl GenTrait<'_> {
             let name = to_identifier(&to_snakecase(m.name().as_str()));
             writeln!(w)?;
             writeln!(w, "    /// {} method", m.name())?;
+            write_member_docs(w, m.docstring(), m.args())?;
             if pascal_case(&name) != m.name().as_str() {
                 writeln!(w, "    #[zbus(name = \"{}\")]", m.name())?;
             }
@@ -190,6 +194,7 @@ impl GenTrait<'_> {
             let name = to_identifier(&to_snakecase(signal.name().as_str()));
             writeln!(w)?;
             writeln!(w, "    /// {} signal", signal.name())?;
+            write_member_docs(w, signal.docstring(), signal.args())?;
             if pascal_case(&name) != signal.name().as_str() {
                 writeln!(w, "    #[zbus(signal, name = \"{}\")]", signal.name())?;
             } else {
@@ -210,6 +215,7 @@ impl GenTrait<'_> {
 
             writeln!(w)?;
             writeln!(w, "    /// {} property", p.name())?;
+            write_member_docs(w, p.docstring(), &[])?;
             if p.access().read() {
                 writeln!(w, "{fn_attribute}")?;
                 let output = to_rust_type(p.ty(), false, false);
@@ -228,6 +234,192 @@ impl GenTrait<'_> {
         }
         writeln!(w, "}}")
     }
+}
+
+/// Write a docstring (from the Telepathy introspection extensions) as rustdoc comment lines.
+///
+/// The content is typically HTML, which rustdoc passes through; only the indentation is
+/// rewritten, as the original one is meaningless after the lines are prefixed with `///`.
+fn write_doc_lines<W: Write>(w: &mut W, docstring: &str, indent: &str) -> std::fmt::Result {
+    for line in doc_markdown(docstring).lines() {
+        if line.is_empty() {
+            writeln!(w, "{indent}///")?;
+        } else {
+            writeln!(w, "{indent}/// {line}")?;
+        }
+    }
+    Ok(())
+}
+
+/// Convert a Telepathy docstring — an HTML fragment — into Markdown for a rustdoc comment.
+///
+/// The docstrings embedded by the Telepathy extensions are HTML (`<p>`, `<em>`, and their own
+/// `<tp:rationale>`, …). Emitting them verbatim would leak the tags into the generated docs, so
+/// they are converted: block-level tags become paragraph breaks (a blank line), `<em>`,
+/// `<strong>` and `<code>` become their Markdown equivalents, any other tag is stripped, entity
+/// references are resolved and insignificant HTML whitespace is collapsed. The result is a
+/// sequence of single-line paragraphs separated by blank lines — so a bare carriage return
+/// cannot survive into a doc comment either.
+fn doc_markdown(docstring: &str) -> String {
+    fn flush(paragraphs: &mut Vec<String>, current: &mut String) {
+        let paragraph = current.split_whitespace().collect::<Vec<_>>().join(" ");
+        current.clear();
+        if !paragraph.is_empty() {
+            paragraphs.push(paragraph);
+        }
+    }
+
+    let mut paragraphs = Vec::new();
+    let mut current = String::new();
+    let mut rest = docstring;
+    while let Some(open) = rest.find('<') {
+        push_text(&mut current, &rest[..open]);
+        rest = &rest[open..];
+
+        // Comments, CDATA sections and processing instructions.
+        if let Some(after) = rest.strip_prefix("<!--") {
+            rest = after.split_once("-->").map_or("", |(_, after)| after);
+            continue;
+        }
+        if let Some(after) = rest.strip_prefix("<![CDATA[") {
+            let (cdata, after) = after.split_once("]]>").unwrap_or((after, ""));
+            current.push_str(cdata); // CDATA content is literal text.
+            rest = after;
+            continue;
+        }
+        if rest.starts_with("<?") {
+            rest = rest.split_once("?>").map_or("", |(_, after)| after);
+            continue;
+        }
+
+        let Some(close) = rest.find('>') else {
+            push_text(&mut current, rest);
+            return finish(paragraphs, current);
+        };
+        let tag = &rest[1..close];
+        rest = &rest[close + 1..];
+
+        let name = tag
+            .trim_start_matches('/')
+            .split([' ', '\t', '\n', '\r', '/'])
+            .next()
+            .unwrap_or("");
+        // Match on the local name, so a namespace prefix (e. g. `tp:`) doesn't matter.
+        match name
+            .rsplit(':')
+            .next()
+            .unwrap_or(name)
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "strong" | "b" => current.push_str("**"),
+            "em" | "i" => current.push('*'),
+            "code" | "tt" => current.push('`'),
+            "p" | "br" | "div" | "blockquote" | "ul" | "ol" | "li" | "dl" | "dt" | "dd" | "pre"
+            | "rationale" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+                flush(&mut paragraphs, &mut current)
+            }
+            _ => {} // Strip any other tag.
+        }
+    }
+    push_text(&mut current, rest);
+    finish(paragraphs, current)
+}
+
+/// Join a docstring's paragraphs, flushing any final one.
+fn finish(mut paragraphs: Vec<String>, current: String) -> String {
+    let last = current.split_whitespace().collect::<Vec<_>>().join(" ");
+    if !last.is_empty() {
+        paragraphs.push(last);
+    }
+    paragraphs.join("\n\n")
+}
+
+/// Append `text` to `out`, resolving XML entity references (`&amp;`, `&#65;`, …).
+fn push_text(out: &mut String, text: &str) {
+    let mut rest = text;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        rest = &rest[amp..];
+        match rest[1..]
+            .split_once(';')
+            .and_then(|(entity, after)| decode_entity(entity).map(|c| (c, after)))
+        {
+            Some((c, after)) => {
+                out.push(c);
+                rest = after;
+            }
+            // Not a recognized reference: keep the `&` literal.
+            None => {
+                out.push('&');
+                rest = &rest[1..];
+            }
+        }
+    }
+    out.push_str(rest);
+}
+
+/// Resolve an XML entity reference (the part between `&` and `;`).
+fn decode_entity(entity: &str) -> Option<char> {
+    match entity {
+        "amp" => return Some('&'),
+        "lt" => return Some('<'),
+        "gt" => return Some('>'),
+        "quot" => return Some('"'),
+        "apos" => return Some('\''),
+        _ => {}
+    }
+    let code = match entity.strip_prefix('#') {
+        Some(dec_or_hex) => match dec_or_hex.strip_prefix(['x', 'X']) {
+            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+            None => dec_or_hex.parse().ok()?,
+        },
+        None => return None,
+    };
+    char::from_u32(code)
+}
+
+/// Write the docstrings of an interface member and of its args, if any, as rustdoc comments.
+fn write_member_docs<W: Write>(
+    w: &mut W,
+    docstring: Option<&str>,
+    args: &[Arg],
+) -> std::fmt::Result {
+    if let Some(docstring) = docstring {
+        writeln!(w, "    ///")?;
+        write_doc_lines(w, docstring, "    ")?;
+    }
+
+    let mut wrote_header = false;
+    for arg in args {
+        let (Some(name), Some(docstring)) = (arg.name(), arg.docstring()) else {
+            continue;
+        };
+        if !wrote_header {
+            writeln!(w, "    ///")?;
+            writeln!(w, "    /// # Arguments")?;
+            writeln!(w, "    ///")?;
+            wrote_header = true;
+        }
+        let markdown = doc_markdown(docstring);
+        let mut lines = markdown.lines();
+        writeln!(
+            w,
+            "    /// * `{}` - {}",
+            to_identifier(name),
+            lines.next().unwrap_or_default()
+        )?;
+        // Indent continuation lines so they stay part of the list item.
+        for line in lines {
+            if line.is_empty() {
+                writeln!(w, "    ///")?;
+            } else {
+                writeln!(w, "    ///   {line}")?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn hide_clippy_lints<W: Write>(write: &mut W, method: &zbus_xml::Method<'_>) -> std::fmt::Result {

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -1,5 +1,6 @@
 use snakecase::ascii::to_snakecase;
 use std::{
+    collections::{HashMap, HashSet},
     error::Error,
     fmt::{Display, Formatter, Write},
     process::{Command, Stdio},
@@ -9,7 +10,10 @@ use zbus::{
     names::BusName,
     zvariant::{ObjectPath, Signature},
 };
-use zbus_xml::{Arg, ArgDirection, Interface};
+use zbus_xml::{
+    Arg, ArgDirection, Interface, Property,
+    telepathy::{self, TypeDef},
+};
 
 #[deprecated(since = "5.4.0", note = "use `CodeGenerator::file_code` instead")]
 pub fn write_interfaces(
@@ -42,6 +46,7 @@ fn write_doc_header<W: std::fmt::Write>(
     w: &mut W,
     interfaces: &[Interface<'_>],
     standard_interfaces: &[Interface<'_>],
+    node_types: &[TypeDef],
     input_src: &str,
     cargo_bin_name: &str,
     cargo_bin_version: &str,
@@ -99,6 +104,29 @@ fn write_doc_header<W: std::fmt::Write>(
         )?;
     }
 
+    let emitted_types: Vec<_> = interfaces
+        .iter()
+        .flat_map(|interface| Types::new(interface, node_types).emit)
+        .collect();
+    if !emitted_types.is_empty() {
+        let serde_repr = emitted_types.iter().any(
+            |def| matches!(def, TypeDef::Enum(e) if matches!(enum_repr(e), Some(EnumRepr::Int(_)))),
+        );
+        let crates = if serde_repr {
+            "`serde` and `serde_repr` crates"
+        } else {
+            "`serde` crate"
+        };
+        write!(
+            w,
+            "//!
+             //! This file also contains Rust definitions for the Telepathy type extensions
+             //! (`tp:struct`, `tp:enum`, …) found in the introspection data. They rely on the
+             //! {crates}, which the crate this code is placed in needs to depend on.
+            ",
+        )?;
+    }
+
     write!(
         w,
         "//!
@@ -135,10 +163,14 @@ impl Display for GenTrait<'_> {
 /// Generates Rust code from D-Bus introspection data.
 ///
 /// The generator is configured through the builder-style `with_*` methods; the code is then
-/// produced by [`CodeGenerator::interface_code`] (a proxy trait for one interface) or
+/// produced by [`CodeGenerator::interface_code`] (a proxy trait for one interface, along with
+/// Rust definitions for the [Telepathy type definitions] it carries or references) or
 /// [`CodeGenerator::file_code`] (a complete source file).
+///
+/// [Telepathy type definitions]: zbus_xml::telepathy::TypeDef
 #[derive(Debug, Default, Clone)]
 pub struct CodeGenerator<'i> {
+    node_types: &'i [TypeDef],
     service: Option<&'i BusName<'i>>,
     path: Option<&'i ObjectPath<'i>>,
     format: bool,
@@ -147,9 +179,18 @@ pub struct CodeGenerator<'i> {
 impl<'i> CodeGenerator<'i> {
     /// Create a code generator with the default configuration.
     ///
-    /// No default service or path, no formatting.
+    /// No type definitions in scope, no default service or path, no formatting.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set the Telepathy type definitions from the enclosing `<node>`.
+    ///
+    /// The ones an interface references get a Rust definition generated alongside the
+    /// definitions from the interface itself.
+    pub fn with_node_types(mut self, node_types: &'i [TypeDef]) -> Self {
+        self.node_types = node_types;
+        self
     }
 
     /// Set the well-known service name, for the proxies' `default_service`.
@@ -172,6 +213,11 @@ impl<'i> CodeGenerator<'i> {
         self
     }
 
+    /// The Telepathy type definitions from the enclosing `<node>`.
+    pub fn node_types(&self) -> &'i [TypeDef] {
+        self.node_types
+    }
+
     /// The well-known service name, if any.
     pub fn service(&self) -> Option<&'i BusName<'i>> {
         self.service
@@ -187,16 +233,13 @@ impl<'i> CodeGenerator<'i> {
         self.format
     }
 
-    /// Generate the code for `interface`: a proxy trait.
+    /// Generate the code for `interface`: a proxy trait, preceded by Rust definitions for the
+    /// Telepathy type definitions it carries or references.
     pub fn interface_code(&self, interface: &Interface<'_>) -> Result<String, std::fmt::Error> {
         let mut code = String::new();
-        self.write_interface(&mut code, interface)?;
+        self.write_interface(&mut code, interface, &mut HashSet::new())?;
 
-        Ok(if self.format {
-            format_generated_code(&code).unwrap_or(code)
-        } else {
-            code
-        })
+        Ok(format_if(self.format, code))
     }
 
     /// Generate a complete source file: a doc header followed by the code for `interfaces`.
@@ -217,24 +260,32 @@ impl<'i> CodeGenerator<'i> {
             &mut code,
             interfaces,
             standard_interfaces,
+            self.node_types,
             input_src,
             cargo_bin_name,
             cargo_bin_version,
         )?;
+        // Interfaces in one file may reference the same node-level type definitions; each
+        // Rust definition is written only once.
+        let mut emitted = HashSet::new();
         for interface in interfaces {
-            self.write_interface(&mut code, interface)?;
+            self.write_interface(&mut code, interface, &mut emitted)?;
         }
 
-        Ok(if self.format {
-            format_generated_code(&code).unwrap_or(code)
-        } else {
-            code
-        })
+        Ok(format_if(self.format, code))
     }
 
-    fn write_interface<W: Write>(&self, w: &mut W, iface: &Interface<'_>) -> std::fmt::Result {
+    fn write_interface<W: Write>(
+        &self,
+        w: &mut W,
+        iface: &Interface<'_>,
+        emitted: &mut HashSet<String>,
+    ) -> std::fmt::Result {
         let idx = iface.name().rfind('.').unwrap() + 1;
         let name = &iface.name()[idx..];
+
+        let types = Types::new(iface, self.node_types);
+        write_type_defs(w, &types, emitted)?;
 
         if let Some(docstring) = iface.docstring() {
             write_doc_lines(w, docstring, "")?;
@@ -255,7 +306,7 @@ impl<'i> CodeGenerator<'i> {
         let mut methods = iface.methods().to_vec();
         methods.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for m in &methods {
-            let (inputs, output) = inputs_output_from_args(m.args());
+            let (inputs, output) = inputs_output_from_args(m.args(), &types);
             let name = to_identifier(&to_snakecase(m.name().as_str()));
             writeln!(w)?;
             writeln!(w, "    /// {} method", m.name())?;
@@ -263,14 +314,14 @@ impl<'i> CodeGenerator<'i> {
             if pascal_case(&name) != m.name().as_str() {
                 writeln!(w, "    #[zbus(name = \"{}\")]", m.name())?;
             }
-            hide_clippy_lints(w, m)?;
+            hide_clippy_lints(w, m, &types)?;
             writeln!(w, "    fn {name}({inputs}){output};")?;
         }
 
         let mut signals = iface.signals().to_vec();
         signals.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for signal in &signals {
-            let args = parse_signal_args(signal.args());
+            let args = parse_signal_args(signal.args(), &types);
             let name = to_identifier(&to_snakecase(signal.name().as_str()));
             writeln!(w)?;
             writeln!(w, "    /// {} signal", signal.name())?;
@@ -296,16 +347,23 @@ impl<'i> CodeGenerator<'i> {
             writeln!(w)?;
             writeln!(w, "    /// {} property", p.name())?;
             write_member_docs(w, p.docstring(), &[])?;
+            // Named types satisfy both directions of the property value conversions, owned.
+            let named = types.resolve(p.tp_type(), p.ty(), false);
             if p.access().read() {
                 writeln!(w, "{fn_attribute}")?;
-                let output = to_rust_type(p.ty(), false, false);
-                hide_clippy_type_complexity_lint(w, p.ty())?;
+                let output = match &named {
+                    Some(named) => named.clone(),
+                    None => {
+                        hide_clippy_type_complexity_lint(w, p.ty())?;
+                        to_rust_type(p.ty(), false, false)
+                    }
+                };
                 writeln!(w, "    fn {name}(&self) -> zbus::Result<{output}>;",)?;
             }
 
             if p.access().write() {
                 writeln!(w, "{fn_attribute}")?;
-                let input = to_property_setter_type(p.ty());
+                let input = named.unwrap_or_else(|| to_property_setter_type(p.ty()));
                 writeln!(
                     w,
                     "    fn set_{name}(&self, value: {input}) -> zbus::Result<()>;",
@@ -502,7 +560,444 @@ fn write_member_docs<W: Write>(
     Ok(())
 }
 
-fn hide_clippy_lints<W: Write>(write: &mut W, method: &zbus_xml::Method<'_>) -> std::fmt::Result {
+/// The Telepathy type definitions in scope for an interface.
+struct Types<'i> {
+    /// The definitions whose Rust definition is generated, by their Telepathy name.
+    ///
+    /// Only these are used when resolving `tp:type` references; anything else falls back to
+    /// the structural Rust type.
+    generated: HashMap<&'i str, &'i TypeDef>,
+    /// The same definitions in emission order (the interface's own first, then the
+    /// referenced node-level ones).
+    emit: Vec<&'i TypeDef>,
+}
+
+impl<'i> Types<'i> {
+    fn new(interface: &'i Interface<'i>, node_types: &'i [TypeDef]) -> Self {
+        // All definitions in scope, the interface's own shadowing same-named node-level ones.
+        let mut by_name = HashMap::new();
+        for def in node_types.iter().chain(interface.telepathy_types()) {
+            by_name.insert(def.name(), def);
+        }
+
+        // The names the interface references through `tp:type`, transitively through other
+        // definitions' members.
+        let mut referenced = HashSet::new();
+        let mut pending: Vec<&str> = interface
+            .methods()
+            .iter()
+            .flat_map(|m| m.args())
+            .chain(interface.signals().iter().flat_map(|s| s.args()))
+            .filter_map(Arg::tp_type)
+            .chain(interface.properties().iter().filter_map(Property::tp_type))
+            .collect();
+        for def in interface.telepathy_types() {
+            member_references(def, &mut pending);
+        }
+        while let Some(reference) = pending.pop() {
+            let (name, _) = strip_arrays(reference);
+            if !referenced.insert(name) {
+                continue;
+            }
+            if let Some(def) = by_name.get(name) {
+                member_references(def, &mut pending);
+            }
+        }
+
+        // Each Rust type name is only generated once. Names that clash with the items the
+        // `proxy` macro will emit for this interface are off-limits from the start; the
+        // remaining conflicts (distinct Telepathy names mapping to one Rust name) are won by
+        // the first taker, in priority order: the interface's own definitions, then the
+        // referenced node-level ones. Losers are not generated, so references to them fall
+        // back to the structural type.
+        let idx = interface.name().rfind('.').unwrap() + 1;
+        let trait_name = &interface.name()[idx..];
+        let mut taken: HashSet<String> = ["Proxy", "ProxyBlocking"]
+            .iter()
+            .map(|suffix| format!("{trait_name}{suffix}"))
+            .chain(interface.signals().iter().flat_map(|signal| {
+                let signal = pascal_case(signal.name().as_str());
+                [
+                    signal.clone(),
+                    format!("{signal}Args"),
+                    format!("{signal}Stream"),
+                ]
+            }))
+            .collect();
+
+        let mut generated = HashMap::new();
+        let mut emit = Vec::new();
+        let node_defs = node_types
+            .iter()
+            .filter(|def| referenced.contains(def.name()));
+        for def in interface.telepathy_types().iter().chain(node_defs) {
+            if generatable(def)
+                && !generated.contains_key(def.name())
+                && taken.insert(type_name(def.name()))
+            {
+                generated.insert(def.name(), def);
+                emit.push(def);
+            }
+        }
+
+        Self { generated, emit }
+    }
+
+    /// Resolve a `tp:type` reference against `signature` into a generated Rust type.
+    ///
+    /// Returns `None` — leaving the caller to fall back to the structural Rust type — when
+    /// there is no reference, it doesn't name a generated definition, or `signature` doesn't
+    /// match the definition. `input` selects the borrowed form used for method inputs.
+    fn resolve(
+        &self,
+        reference: Option<&str>,
+        signature: &Signature,
+        input: bool,
+    ) -> Option<String> {
+        let (name, arrays) = strip_arrays(reference?);
+        let def = *self.generated.get(name)?;
+
+        let mut signature = signature;
+        for _ in 0..arrays {
+            match signature {
+                Signature::Array(child) => signature = child.signature(),
+                _ => return None,
+            }
+        }
+        if *signature != def.signature() {
+            return None;
+        }
+
+        let base = type_name(def.name());
+        if !input {
+            return Some((0..arrays).fold(base, |ty, _| format!("Vec<{ty}>")));
+        }
+        Some(if arrays > 0 {
+            let inner = (0..arrays - 1).fold(base, |ty, _| format!("Vec<{ty}>"));
+            format!("&[{inner}]")
+        } else if passed_by_value(def) {
+            base
+        } else {
+            format!("&{base}")
+        })
+    }
+
+    /// Like [`Types::resolve`], but only for names given to plain D-Bus types.
+    ///
+    /// Dictionary keys must remain basic types on the Rust side too — a struct or enum key
+    /// would not satisfy the dictionary conversions — so only [`telepathy::SimpleType`]
+    /// aliases are resolved for them.
+    fn resolve_simple(&self, reference: Option<&str>, signature: &Signature) -> Option<String> {
+        let (name, _) = strip_arrays(reference?);
+        match self.generated.get(name) {
+            Some(TypeDef::SimpleType(_)) => self.resolve(reference, signature, false),
+            _ => None,
+        }
+    }
+}
+
+/// Push the `tp:type` references of `def`'s members, if any, onto `pending`.
+fn member_references<'i>(def: &'i TypeDef, pending: &mut Vec<&'i str>) {
+    match def {
+        TypeDef::Struct(s) => pending.extend(s.members().iter().filter_map(|m| m.tp_type())),
+        TypeDef::Mapping(m) => {
+            pending.extend([m.key(), m.value()].into_iter().filter_map(|m| m.tp_type()))
+        }
+        _ => (),
+    }
+}
+
+/// Split a `tp:type` reference into the type name and its number of `[]` suffixes.
+fn strip_arrays(reference: &str) -> (&str, usize) {
+    let mut name = reference;
+    let mut arrays = 0;
+    while let Some(stripped) = name.strip_suffix("[]") {
+        name = stripped;
+        arrays += 1;
+    }
+    (name, arrays)
+}
+
+/// Whether a Rust definition can be generated for `def`.
+fn generatable(def: &TypeDef) -> bool {
+    if !is_valid_ident(&type_name(def.name())) {
+        return false;
+    }
+    match def {
+        TypeDef::SimpleType(_) | TypeDef::Mapping(_) => true,
+        TypeDef::Enum(e) => {
+            let Some(repr) = enum_repr(e) else {
+                return false;
+            };
+            // Variant names must be distinct identifiers (e. g. `Foo_Bar` and `FooBar` map
+            // to the same name), and the values must be distinct too: on the Rust side
+            // duplicate discriminants don't compile, and for string enums a duplicate makes
+            // the wire mapping ambiguous.
+            let mut names = HashSet::new();
+            let mut values = HashSet::new();
+            !e.values().is_empty()
+                && e.values().iter().all(|v| {
+                    let name = variant_name(v);
+                    is_valid_ident(&name)
+                        && names.insert(name)
+                        && match repr {
+                            EnumRepr::Int(int) => match enum_value(int, v.value()) {
+                                Some(value) => values.insert(value.to_string()),
+                                None => false,
+                            },
+                            EnumRepr::Str => values.insert(v.value().to_owned()),
+                        }
+                })
+        }
+        TypeDef::Struct(s) => {
+            let mut names = HashSet::new();
+            s.members().iter().all(|m| {
+                let name = field_name(m.name());
+                is_valid_ident(&name) && names.insert(name)
+            })
+        }
+    }
+}
+
+/// Parse the value of a numeric enum, checking that it fits the representation.
+fn enum_value(repr: &str, value: &str) -> Option<i128> {
+    let (min, max) = match repr {
+        "u8" => (0, u8::MAX as i128),
+        "i16" => (i16::MIN as i128, i16::MAX as i128),
+        "u16" => (0, u16::MAX as i128),
+        "i32" => (i32::MIN as i128, i32::MAX as i128),
+        "u32" => (0, u32::MAX as i128),
+        "i64" => (i64::MIN as i128, i64::MAX as i128),
+        "u64" => (0, u64::MAX as i128),
+        _ => return None,
+    };
+
+    value
+        .parse()
+        .ok()
+        .filter(|value| (min..=max).contains(value))
+}
+
+/// How a generated enum is represented on the wire.
+enum EnumRepr {
+    /// As an integer type, e. g. `u32`.
+    Int(&'static str),
+    /// As a string.
+    Str,
+}
+
+fn enum_repr(e: &telepathy::Enum) -> Option<EnumRepr> {
+    match e.ty().inner() {
+        Signature::U8 => Some(EnumRepr::Int("u8")),
+        Signature::I16 => Some(EnumRepr::Int("i16")),
+        Signature::U16 => Some(EnumRepr::Int("u16")),
+        Signature::I32 => Some(EnumRepr::Int("i32")),
+        Signature::U32 => Some(EnumRepr::Int("u32")),
+        Signature::I64 => Some(EnumRepr::Int("i64")),
+        Signature::U64 => Some(EnumRepr::Int("u64")),
+        Signature::Str => Some(EnumRepr::Str),
+        _ => None,
+    }
+}
+
+/// Whether values of the generated type are cheap enough to pass inputs by value.
+fn passed_by_value(def: &TypeDef) -> bool {
+    match def {
+        // Generated enums are `Copy`.
+        TypeDef::Enum(_) => true,
+        TypeDef::SimpleType(t) => matches!(
+            t.ty().inner(),
+            Signature::U8
+                | Signature::Bool
+                | Signature::I16
+                | Signature::U16
+                | Signature::I32
+                | Signature::U32
+                | Signature::I64
+                | Signature::U64
+                | Signature::F64
+        ),
+        _ => false,
+    }
+}
+
+/// The Rust name for a Telepathy type, e. g. `Playlist_Id` -> `PlaylistId`.
+fn type_name(name: &str) -> String {
+    to_identifier(&pascal_case(name))
+}
+
+/// The Rust name for an enum variant, from the value's `suffix`.
+fn variant_name(value: &telepathy::EnumValue) -> String {
+    to_identifier(&pascal_case(value.suffix()))
+}
+
+/// The Rust name for a struct field, from the member's `name`.
+fn field_name(name: &str) -> String {
+    to_identifier(&to_snakecase(name))
+}
+
+fn is_valid_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Format `code` through rustfmt if `format` is set, falling back to it unformatted.
+fn format_if(format: bool, code: String) -> String {
+    if !format {
+        return code;
+    }
+    match format_generated_code(&code) {
+        Ok(formatted) => formatted,
+        Err(e) => {
+            eprintln!("Failed to format generated code: {e}");
+            code
+        }
+    }
+}
+
+/// Write the Rust definitions for the type definitions in scope.
+///
+/// Definitions whose Rust name is already in `emitted` — node-level definitions shared with
+/// an earlier interface in the same file — are skipped.
+fn write_type_defs<W: Write>(
+    w: &mut W,
+    types: &Types<'_>,
+    emitted: &mut HashSet<String>,
+) -> std::fmt::Result {
+    for def in &types.emit {
+        if !emitted.insert(type_name(def.name())) {
+            continue;
+        }
+        match def {
+            TypeDef::SimpleType(t) => write_simple_type(w, t)?,
+            TypeDef::Enum(e) => write_enum(w, e)?,
+            TypeDef::Struct(s) => write_struct(w, s, types)?,
+            TypeDef::Mapping(m) => write_mapping(w, m, types)?,
+        }
+        writeln!(w)?;
+    }
+    Ok(())
+}
+
+fn write_simple_type<W: Write>(w: &mut W, t: &telepathy::SimpleType) -> std::fmt::Result {
+    if let Some(docstring) = t.docstring() {
+        write_doc_lines(w, docstring, "")?;
+    }
+    writeln!(
+        w,
+        "pub type {} = {};",
+        type_name(t.name()),
+        to_rust_type(t.ty(), false, false)
+    )
+}
+
+fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum) -> std::fmt::Result {
+    if let Some(docstring) = e.docstring() {
+        write_doc_lines(w, docstring, "")?;
+    }
+    let repr = enum_repr(e).expect("only generatable enums are emitted");
+    match repr {
+        EnumRepr::Int(int) => {
+            writeln!(
+                w,
+                "#[derive(Debug, Clone, Copy, PartialEq, Eq, \
+                 serde_repr::Deserialize_repr, serde_repr::Serialize_repr, \
+                 zbus::zvariant::Type, zbus::zvariant::Value, zbus::zvariant::OwnedValue)]"
+            )?;
+            writeln!(w, "#[zvariant(crate = \"zbus::zvariant\")]")?;
+            writeln!(w, "#[repr({int})]")?;
+            writeln!(w, "pub enum {} {{", type_name(e.name()))?;
+            for value in e.values() {
+                if let Some(docstring) = value.docstring() {
+                    write_doc_lines(w, docstring, "    ")?;
+                }
+                // Writing the parsed value normalizes forms Rust does not accept verbatim,
+                // like a leading `+`.
+                let discriminant =
+                    enum_value(int, value.value()).expect("only generatable enums are emitted");
+                writeln!(w, "    {} = {discriminant},", variant_name(value))?;
+            }
+        }
+        EnumRepr::Str => {
+            writeln!(
+                w,
+                "#[derive(Debug, Clone, Copy, PartialEq, Eq, \
+                 serde::Serialize, serde::Deserialize, \
+                 zbus::zvariant::Type, zbus::zvariant::Value, zbus::zvariant::OwnedValue)]"
+            )?;
+            writeln!(
+                w,
+                "#[zvariant(signature = \"s\", crate = \"zbus::zvariant\")]"
+            )?;
+            writeln!(w, "pub enum {} {{", type_name(e.name()))?;
+            for value in e.values() {
+                if let Some(docstring) = value.docstring() {
+                    write_doc_lines(w, docstring, "    ")?;
+                }
+                let variant = variant_name(value);
+                if variant != value.value() {
+                    writeln!(w, "    #[serde(rename = {0:?})]", value.value())?;
+                    writeln!(w, "    #[zvariant(rename = {0:?})]", value.value())?;
+                }
+                writeln!(w, "    {variant},")?;
+            }
+        }
+    }
+    writeln!(w, "}}")
+}
+
+fn write_struct<W: Write>(w: &mut W, s: &telepathy::Struct, types: &Types<'_>) -> std::fmt::Result {
+    if let Some(docstring) = s.docstring() {
+        write_doc_lines(w, docstring, "")?;
+    }
+    writeln!(
+        w,
+        "#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, \
+         zbus::zvariant::Type, zbus::zvariant::Value, zbus::zvariant::OwnedValue)]"
+    )?;
+    writeln!(w, "#[zvariant(crate = \"zbus::zvariant\")]")?;
+    writeln!(w, "pub struct {} {{", type_name(s.name()))?;
+    for member in s.members() {
+        if let Some(docstring) = member.docstring() {
+            write_doc_lines(w, docstring, "    ")?;
+        }
+        let ty = types
+            .resolve(member.tp_type(), member.ty(), false)
+            .unwrap_or_else(|| to_rust_type(member.ty(), false, false));
+        writeln!(w, "    pub {}: {},", field_name(member.name()), ty)?;
+    }
+    writeln!(w, "}}")
+}
+
+fn write_mapping<W: Write>(
+    w: &mut W,
+    m: &telepathy::Mapping,
+    types: &Types<'_>,
+) -> std::fmt::Result {
+    if let Some(docstring) = m.docstring() {
+        write_doc_lines(w, docstring, "")?;
+    }
+    let key = types
+        .resolve_simple(m.key().tp_type(), m.key().ty())
+        .unwrap_or_else(|| to_rust_type(m.key().ty(), false, false));
+    let value = types
+        .resolve(m.value().tp_type(), m.value().ty(), false)
+        .unwrap_or_else(|| to_rust_type(m.value().ty(), false, false));
+    writeln!(
+        w,
+        "pub type {} = std::collections::HashMap<{key}, {value}>;",
+        type_name(m.name()),
+    )
+}
+
+fn hide_clippy_lints<W: Write>(
+    write: &mut W,
+    method: &zbus_xml::Method<'_>,
+    types: &Types<'_>,
+) -> std::fmt::Result {
     // check for <https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_arguments>
     // triggers when a functions has at least 7 paramters
     if method.args().len() >= 7 {
@@ -511,6 +1006,10 @@ fn hide_clippy_lints<W: Write>(write: &mut W, method: &zbus_xml::Method<'_>) -> 
 
     // check for <https://rust-lang.github.io/rust-clippy/master/index.html#/type_complexity>
     for arg in method.args() {
+        // A named type keeps the written-out type simple, no matter the signature.
+        if types.resolve(arg.tp_type(), arg.ty(), false).is_some() {
+            continue;
+        }
         let signature = arg.ty();
         hide_clippy_type_complexity_lint(write, signature)?;
     }
@@ -529,7 +1028,7 @@ fn hide_clippy_type_complexity_lint<W: Write>(
     Ok(())
 }
 
-fn inputs_output_from_args(args: &[Arg]) -> (String, String) {
+fn inputs_output_from_args(args: &[Arg], types: &Types<'_>) -> (String, String) {
     let mut inputs = vec!["&self".to_string()];
     let mut output: Vec<OutputArg> = vec![];
     let mut n = 0;
@@ -541,7 +1040,9 @@ fn inputs_output_from_args(args: &[Arg]) -> (String, String) {
     for a in args {
         match a.direction() {
             None | Some(ArgDirection::In) => {
-                let ty = to_rust_type(a.ty(), true, true);
+                let ty = types
+                    .resolve(a.tp_type(), a.ty(), true)
+                    .unwrap_or_else(|| to_rust_type(a.ty(), true, true));
                 let arg = if let Some(name) = a.name() {
                     to_identifier(name)
                 } else {
@@ -550,7 +1051,9 @@ fn inputs_output_from_args(args: &[Arg]) -> (String, String) {
                 inputs.push(format!("{arg}: {ty}"));
             }
             Some(ArgDirection::Out) => {
-                let ty = to_rust_type(a.ty(), false, false);
+                let ty = types
+                    .resolve(a.tp_type(), a.ty(), false)
+                    .unwrap_or_else(|| to_rust_type(a.ty(), false, false));
                 let is_struct = matches!(a.ty().inner(), Signature::Structure(_));
                 output.push(OutputArg { ty, is_struct });
             }
@@ -593,7 +1096,7 @@ struct OutputArg {
     is_struct: bool,
 }
 
-fn parse_signal_args(args: &[Arg]) -> String {
+fn parse_signal_args(args: &[Arg], types: &Types<'_>) -> String {
     let mut inputs = vec!["&self".to_string()];
     let mut n = 0;
     let mut gen_name = || {
@@ -602,7 +1105,10 @@ fn parse_signal_args(args: &[Arg]) -> String {
     };
 
     for a in args {
-        let ty = to_rust_type(a.ty(), true, false);
+        // Signal args are deserialized, so a named type is used in its owned form.
+        let ty = types
+            .resolve(a.tp_type(), a.ty(), false)
+            .unwrap_or_else(|| to_rust_type(a.ty(), true, false));
         let arg = if let Some(name) = a.name() {
             to_identifier(name)
         } else {
@@ -642,14 +1148,10 @@ fn to_rust_type(ty: &Signature, input: bool, as_ref: bool) -> String {
                 }
             }
             Signature::ObjectPath => "zbus::zvariant::OwnedObjectPath".into(),
-            Signature::Signature if input => {
-                if as_ref {
-                    "&zbus::zvariant::Signature<'_>".into()
-                } else {
-                    "zbus::zvariant::Signature<'_>".into()
-                }
-            }
-            Signature::Signature => "zbus::zvariant::OwnedSignature".into(),
+            // `zvariant::Signature` has been lifetime-less (with no `Owned` counterpart)
+            // since zvariant 5.
+            Signature::Signature if input && as_ref => "&zbus::zvariant::Signature".into(),
+            Signature::Signature => "zbus::zvariant::Signature".into(),
             Signature::Variant if input => {
                 if as_ref {
                     "&zbus::zvariant::Value<'_>".into()

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 use std::{
+    collections::HashSet,
     error::Error,
     fs::{File, OpenOptions},
     io::Write,
@@ -13,7 +14,7 @@ use zbus::{
     names::BusName,
     zvariant::ObjectPath,
 };
-use zbus_xml::{Interface, Node};
+use zbus_xml::{Interface, Node, Warning};
 
 use zbus_xmlgen::write_interfaces;
 
@@ -49,7 +50,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         cli::Command::File { path } => {
             let input_src = path.file_name().unwrap().to_string_lossy().to_string();
             let f = File::open(path)?;
-            DBusInfo(Node::from_reader(f)?, None, None, input_src)
+            let (node, warnings) = Node::from_reader_with_warnings(f)?;
+            report_warnings(&warnings);
+            DBusInfo(node, None, None, input_src)
         }
     };
 
@@ -139,11 +142,19 @@ impl DBusInfo<'_> {
             .unwrap()
             .introspect()?;
 
-        Ok(DBusInfo(
-            Node::from_reader(xml.as_bytes())?,
-            Some(service),
-            Some(path),
-            input_src,
-        ))
+        let (node, warnings) = Node::from_reader_with_warnings(xml.as_bytes())?;
+        report_warnings(&warnings);
+
+        Ok(DBusInfo(node, Some(service), Some(path), input_src))
+    }
+}
+
+/// Warn on stderr about ignored, unsupported XML elements, once per element name.
+fn report_warnings(warnings: &[Warning]) {
+    let mut seen = HashSet::new();
+    for warning in warnings {
+        if seen.insert(warning.element()) {
+            eprintln!("Ignoring unsupported element `<{}>`", warning.element());
+        }
     }
 }

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -16,7 +16,7 @@ use zbus::{
 };
 use zbus_xml::{Interface, Node, Warning};
 
-use zbus_xmlgen::write_interfaces;
+use zbus_xmlgen::CodeGenerator;
 
 mod cli;
 
@@ -82,12 +82,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         _ => OutputTarget::MultipleFiles,
     };
 
+    let generator = CodeGenerator::new()
+        .with_service(service.as_ref())
+        .with_path(path.as_ref())
+        .with_format(true);
+
     for interface in needed_ifaces {
-        let output = write_interfaces(
+        let output = generator.file_code(
             std::slice::from_ref(&interface),
             &fdo_standard_ifaces,
-            service.clone(),
-            path.clone(),
             &input_src,
             env!("CARGO_BIN_NAME"),
             env!("CARGO_PKG_VERSION"),

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
     }
 
-    let mut output_target = match args.output.as_deref() {
+    let output_target = match args.output.as_deref() {
         Some("-") => OutputTarget::Stdout,
         Some(path) => {
             let file = OpenOptions::new()
@@ -83,27 +83,25 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let generator = CodeGenerator::new()
+        .with_node_types(node.telepathy_types())
         .with_service(service.as_ref())
         .with_path(path.as_ref())
         .with_format(true);
-
-    for interface in needed_ifaces {
-        let output = generator.file_code(
-            std::slice::from_ref(&interface),
+    let file_code = |interfaces: &[Interface<'_>]| {
+        generator.file_code(
+            interfaces,
             &fdo_standard_ifaces,
             &input_src,
             env!("CARGO_BIN_NAME"),
             env!("CARGO_PKG_VERSION"),
-        )?;
+        )
+    };
 
-        let interface_name = interface.name();
-        match output_target {
-            OutputTarget::Stdout => println!("{output}"),
-            OutputTarget::SingleFile(ref mut file) => {
-                file.write_all(output.as_bytes())?;
-                println!("Generated code for `{interface_name}`");
-            }
-            OutputTarget::MultipleFiles => {
+    match output_target {
+        OutputTarget::MultipleFiles => {
+            for interface in &needed_ifaces {
+                let output = file_code(std::slice::from_ref(interface))?;
+                let interface_name = interface.name();
                 let filename = interface_name
                     .split('.')
                     .next_back()
@@ -112,7 +110,17 @@ fn main() -> Result<(), Box<dyn Error>> {
                 std::fs::write(format!("{}.rs", &filename), output)?;
                 println!("Generated code for `{interface_name}` in {filename}.rs");
             }
-        };
+        }
+        // A single output is one document: all interfaces go into one `file_code` call, so
+        // the doc header and any shared type definitions appear only once.
+        _ if needed_ifaces.is_empty() => (),
+        OutputTarget::Stdout => println!("{}", file_code(&needed_ifaces)?),
+        OutputTarget::SingleFile(mut file) => {
+            file.write_all(file_code(&needed_ifaces)?.as_bytes())?;
+            for interface in &needed_ifaces {
+                println!("Generated code for `{}`", interface.name());
+            }
+        }
     }
 
     Ok(())
@@ -152,12 +160,12 @@ impl DBusInfo<'_> {
     }
 }
 
-/// Warn on stderr about ignored, unsupported XML elements, once per element name.
+/// Warn on stderr about ignored XML content, once per distinct message.
 fn report_warnings(warnings: &[Warning]) {
     let mut seen = HashSet::new();
     for warning in warnings {
-        if seen.insert(warning.element()) {
-            eprintln!("Ignoring unsupported element `<{}>`", warning.element());
+        if seen.insert(warning.message()) {
+            eprintln!("Warning: {}", warning.message());
         }
     }
 }

--- a/zbus_xmlgen/tests/compile.rs
+++ b/zbus_xmlgen/tests/compile.rs
@@ -18,6 +18,17 @@ mod property_setters {
 }
 
 mod telepathy_docstrings {
+    // The generated type aliases are only referenced from the (macro-consumed) trait.
+    #![allow(dead_code)]
+
     use zbus::proxy;
     include!("data/telepathy_docstrings.rs");
+}
+
+mod telepathy_edge_cases {
+    // The generated type aliases are only referenced from the (macro-consumed) trait.
+    #![allow(dead_code)]
+
+    use zbus::proxy;
+    include!("data/telepathy_edge_cases.rs");
 }

--- a/zbus_xmlgen/tests/compile.rs
+++ b/zbus_xmlgen/tests/compile.rs
@@ -16,3 +16,8 @@ mod property_setters {
     use zbus::proxy;
     include!("data/property_setters.rs");
 }
+
+mod telepathy_docstrings {
+    use zbus::proxy;
+    include!("data/telepathy_docstrings.rs");
+}

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -29,6 +29,12 @@ pub trait SampleInterface0 {
         foo: i32,
     ) -> zbus::Result<(String, std::collections::HashMap<u32, String>)>;
 
+    /// GetSignature method
+    fn get_signature(
+        &self,
+        challenge: &zbus::zvariant::Signature,
+    ) -> zbus::Result<zbus::zvariant::Signature>;
+
     /// MogrifyMe method
     fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::zvariant::Value<'_>])) -> zbus::Result<()>;
 

--- a/zbus_xmlgen/tests/data/sample_object0.xml
+++ b/zbus_xmlgen/tests/data/sample_object0.xml
@@ -23,6 +23,10 @@
      <method name="MogrifyMe">
        <arg name="bar" type="(iiav)" direction="in"/>
      </method>
+     <method name="GetSignature">
+       <arg name="challenge" type="g" direction="in"/>
+       <arg name="response" type="g" direction="out"/>
+     </method>
      <method name="BarplexSig">
        <arg direction="in" name="rule" type="(aiia{ss}iaiiasib)"/>
        <arg direction="out" type="a(so)"/>

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.rs
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.rs
@@ -1,0 +1,72 @@
+/// Provides access to the media player's playlists.
+///
+/// Since D-Bus does not directly support enums, or a **maybe** type, they are described in this interface.
+#[proxy(interface = "com.example.Playlists", assume_defaults = true)]
+pub trait Playlists {
+    /// ActivatePlaylist method
+    ///
+    /// Starts playing the given playlist.
+    ///
+    /// It is up to the media player whether this completely replaces the current tracklist, or whether it is merely inserted into the tracklist and the first track starts.
+    ///
+    /// # Arguments
+    ///
+    /// * `playlist_id` - The id of the playlist to activate.
+    fn activate_playlist(&self, playlist_id: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// GetPlaylists method
+    ///
+    /// Gets a set of playlists.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The index of the first playlist to be fetched (according to the ordering).
+    /// * `max_count` - The maximum number of playlists to fetch.
+    /// * `order` - The ordering that should be used.
+    /// * `reverse_order` - Whether the order should be reversed.
+    /// * `playlists` - A list of (at most *max_count*) playlists.
+    fn get_playlists(
+        &self,
+        index: u32,
+        max_count: u32,
+        order: &str,
+        reverse_order: bool,
+    ) -> zbus::Result<Vec<(zbus::zvariant::OwnedObjectPath, String, String)>>;
+
+    /// PlaylistChanged signal
+    ///
+    /// Indicates that either the Name or Icon attribute of a playlist has changed.
+    ///
+    /// Client implementations should be aware that this signal may not be implemented.
+    ///
+    /// Without this signal, media players have no way to notify clients of a change in the attributes of a playlist.
+    ///
+    /// # Arguments
+    ///
+    /// * `playlist` - The playlist which details have changed.
+    #[zbus(signal)]
+    fn playlist_changed(
+        &self,
+        playlist: (zbus::zvariant::ObjectPath<'_>, &str, &str),
+    ) -> zbus::Result<()>;
+
+    /// Orderings property
+    ///
+    /// The available orderings. At least one must be offered.
+    ///
+    /// Media players may not have access to all the data required for some orderings.
+    #[zbus(property)]
+    fn orderings(&self) -> zbus::Result<Vec<String>>;
+
+    /// PlaylistCount property
+    ///
+    /// The number of playlists available.
+    #[zbus(property)]
+    fn playlist_count(&self) -> zbus::Result<u32>;
+
+    /// Undocumented property
+    #[zbus(property)]
+    fn undocumented(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_undocumented(&self, value: &str) -> zbus::Result<()>;
+}

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.rs
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.rs
@@ -1,3 +1,95 @@
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(signature = "s", crate = "zbus::zvariant")]
+pub enum PlaylistOrdering {
+    /// Alphabetical ordering by name, ascending.
+    Alphabetical,
+    /// A user-defined ordering.
+    #[serde(rename = "User")]
+    #[zvariant(rename = "User")]
+    UserDefined,
+}
+
+/// A repeat / loop status.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde_repr::Deserialize_repr,
+    serde_repr::Serialize_repr,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(crate = "zbus::zvariant")]
+#[repr(u32)]
+pub enum LoopStatus {
+    /// The playback will stop when there are no more tracks to play.
+    None = 0,
+    /// The current track will start again from the beginning once it has finished playing.
+    Track = 1,
+    /// The playback loops through a list of tracks.
+    Playlist = 2,
+}
+
+/// A data structure describing a playlist.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(crate = "zbus::zvariant")]
+pub struct Playlist {
+    /// A unique identifier for the playlist.
+    pub id: PlaylistId,
+    /// The name of the playlist, typically given by the user.
+    pub name: String,
+    /// The URI of an (optional) icon.
+    pub icon: String,
+}
+
+/// A data structure describing a playlist, or nothing.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(crate = "zbus::zvariant")]
+pub struct MaybePlaylist {
+    /// Whether this structure refers to a valid playlist.
+    pub valid: bool,
+    /// The playlist, providing Valid is true.
+    pub playlist: Playlist,
+}
+
+/// A mapping from metadata attribute names to values.
+pub type MetadataMap = std::collections::HashMap<String, zbus::zvariant::OwnedValue>;
+
+/// Unique playlist identifier.
+pub type PlaylistId = zbus::zvariant::OwnedObjectPath;
+
 /// Provides access to the media player's playlists.
 ///
 /// Since D-Bus does not directly support enums, or a **maybe** type, they are described in this interface.
@@ -12,7 +104,17 @@ pub trait Playlists {
     /// # Arguments
     ///
     /// * `playlist_id` - The id of the playlist to activate.
-    fn activate_playlist(&self, playlist_id: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
+    fn activate_playlist(&self, playlist_id: &PlaylistId) -> zbus::Result<()>;
+
+    /// GetMetadata method
+    ///
+    /// Gets the metadata of a playlist.
+    ///
+    /// # Arguments
+    ///
+    /// * `mismatch` - A tp:type not matching the signature falls back to the plain type.
+    /// * `metadata` - The metadata of the playlist.
+    fn get_metadata(&self, mismatch: &str) -> zbus::Result<MetadataMap>;
 
     /// GetPlaylists method
     ///
@@ -29,9 +131,9 @@ pub trait Playlists {
         &self,
         index: u32,
         max_count: u32,
-        order: &str,
+        order: PlaylistOrdering,
         reverse_order: bool,
-    ) -> zbus::Result<Vec<(zbus::zvariant::OwnedObjectPath, String, String)>>;
+    ) -> zbus::Result<Vec<Playlist>>;
 
     /// PlaylistChanged signal
     ///
@@ -45,10 +147,23 @@ pub trait Playlists {
     ///
     /// * `playlist` - The playlist which details have changed.
     #[zbus(signal)]
-    fn playlist_changed(
-        &self,
-        playlist: (zbus::zvariant::ObjectPath<'_>, &str, &str),
-    ) -> zbus::Result<()>;
+    fn playlist_changed(&self, playlist: Playlist) -> zbus::Result<()>;
+
+    /// ActivePlaylist property
+    ///
+    /// The currently-active playlist.
+    ///
+    /// If there is no currently-active playlist, the structure's Valid field will be false, and the Playlist details are undefined.
+    #[zbus(property)]
+    fn active_playlist(&self) -> zbus::Result<MaybePlaylist>;
+
+    /// LoopStatus property
+    ///
+    /// The current loop / repeat status.
+    #[zbus(property)]
+    fn loop_status(&self) -> zbus::Result<LoopStatus>;
+    #[zbus(property)]
+    fn set_loop_status(&self, value: LoopStatus) -> zbus::Result<()>;
 
     /// Orderings property
     ///
@@ -56,7 +171,7 @@ pub trait Playlists {
     ///
     /// Media players may not have access to all the data required for some orderings.
     #[zbus(property)]
-    fn orderings(&self) -> zbus::Result<Vec<String>>;
+    fn orderings(&self) -> zbus::Result<Vec<PlaylistOrdering>>;
 
     /// PlaylistCount property
     ///

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.xml
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.xml
@@ -2,6 +2,14 @@
 <!-- Modeled after the MPRIS org.mpris.MediaPlayer2.Playlists interface, which documents
      itself through the Telepathy D-Bus introspection extensions. -->
 <node name="/com/example/Playlists" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+  <tp:simple-type name="Playlist_Id" type="o" array-name="Playlist_Id_List">
+    <tp:docstring>Unique playlist identifier.</tp:docstring>
+  </tp:simple-type>
+
+  <tp:simple-type name="Unreferenced" type="s">
+    <tp:docstring>Not referenced by the interface, so no Rust definition is generated.</tp:docstring>
+  </tp:simple-type>
+
   <interface name="com.example.Playlists">
     <tp:docstring>
       <p>Provides access to the media player's playlists.</p>
@@ -11,16 +19,25 @@
       </p>
     </tp:docstring>
 
-    <tp:simple-type name="Playlist_Id" type="o" array-name="Playlist_Id_List">
-      <tp:docstring>Unique playlist identifier.</tp:docstring>
-    </tp:simple-type>
-
     <tp:enum name="Playlist_Ordering" type="s">
       <tp:enumvalue suffix="Alphabetical" value="Alphabetical">
         <tp:docstring>Alphabetical ordering by name, ascending.</tp:docstring>
       </tp:enumvalue>
-      <tp:enumvalue suffix="UserDefined" value="UserDefined">
+      <tp:enumvalue suffix="User_Defined" value="User">
         <tp:docstring>A user-defined ordering.</tp:docstring>
+      </tp:enumvalue>
+    </tp:enum>
+
+    <tp:enum name="Loop_Status" type="u">
+      <tp:docstring>A repeat / loop status.</tp:docstring>
+      <tp:enumvalue suffix="None" value="0">
+        <tp:docstring>The playback will stop when there are no more tracks to play.</tp:docstring>
+      </tp:enumvalue>
+      <tp:enumvalue suffix="Track" value="1">
+        <tp:docstring>The current track will start again from the beginning once it has finished playing.</tp:docstring>
+      </tp:enumvalue>
+      <tp:enumvalue suffix="Playlist" value="2">
+        <tp:docstring>The playback loops through a list of tracks.</tp:docstring>
       </tp:enumvalue>
     </tp:enum>
 
@@ -36,6 +53,26 @@
         <tp:docstring>The URI of an (optional) icon.</tp:docstring>
       </tp:member>
     </tp:struct>
+
+    <tp:struct name="Maybe_Playlist">
+      <tp:docstring>A data structure describing a playlist, or nothing.</tp:docstring>
+      <tp:member type="b" name="Valid">
+        <tp:docstring>Whether this structure refers to a valid playlist.</tp:docstring>
+      </tp:member>
+      <tp:member type="(oss)" tp:type="Playlist" name="Playlist">
+        <tp:docstring>The playlist, providing Valid is true.</tp:docstring>
+      </tp:member>
+    </tp:struct>
+
+    <tp:mapping name="Metadata_Map">
+      <tp:docstring>A mapping from metadata attribute names to values.</tp:docstring>
+      <tp:member type="s" name="Attribute">
+        <tp:docstring>The name of the attribute.</tp:docstring>
+      </tp:member>
+      <tp:member type="v" name="Value">
+        <tp:docstring>The value of the attribute.</tp:docstring>
+      </tp:member>
+    </tp:mapping>
 
     <method name="ActivatePlaylist">
       <tp:docstring>
@@ -72,6 +109,16 @@
       </arg>
     </method>
 
+    <method name="GetMetadata">
+      <tp:docstring>Gets the metadata of a playlist.</tp:docstring>
+      <arg direction="in" name="mismatch" type="s" tp:type="Playlist">
+        <tp:docstring>A tp:type not matching the signature falls back to the plain type.</tp:docstring>
+      </arg>
+      <arg direction="out" name="metadata" type="a{sv}" tp:type="Metadata_Map">
+        <tp:docstring>The metadata of the playlist.</tp:docstring>
+      </arg>
+    </method>
+
     <signal name="PlaylistChanged">
       <tp:docstring>
         <p>Indicates that either the Name or Icon attribute of a
@@ -94,6 +141,20 @@
           orderings.
         </tp:rationale>
       </tp:docstring>
+    </property>
+
+    <property name="ActivePlaylist" type="(b(oss))" tp:type="Maybe_Playlist" access="read">
+      <tp:docstring>
+        <p>The currently-active playlist.</p>
+        <p>
+          If there is no currently-active playlist, the structure's Valid field
+          will be false, and the Playlist details are undefined.
+        </p>
+      </tp:docstring>
+    </property>
+
+    <property name="LoopStatus" type="u" tp:type="Loop_Status" access="readwrite">
+      <tp:docstring>The current loop / repeat status.</tp:docstring>
     </property>
 
     <property name="PlaylistCount" type="u" access="read">

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.xml
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Modeled after the MPRIS org.mpris.MediaPlayer2.Playlists interface, which documents
+     itself through the Telepathy D-Bus introspection extensions. -->
+<node name="/com/example/Playlists" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+  <interface name="com.example.Playlists">
+    <tp:docstring>
+      <p>Provides access to the media player's playlists.</p>
+      <p>
+        Since D-Bus does not directly support enums, or a
+        <strong>maybe</strong> type, they are described in this interface.
+      </p>
+    </tp:docstring>
+
+    <tp:simple-type name="Playlist_Id" type="o" array-name="Playlist_Id_List">
+      <tp:docstring>Unique playlist identifier.</tp:docstring>
+    </tp:simple-type>
+
+    <tp:enum name="Playlist_Ordering" type="s">
+      <tp:enumvalue suffix="Alphabetical" value="Alphabetical">
+        <tp:docstring>Alphabetical ordering by name, ascending.</tp:docstring>
+      </tp:enumvalue>
+      <tp:enumvalue suffix="UserDefined" value="UserDefined">
+        <tp:docstring>A user-defined ordering.</tp:docstring>
+      </tp:enumvalue>
+    </tp:enum>
+
+    <tp:struct name="Playlist" array-name="Playlist_List">
+      <tp:docstring>A data structure describing a playlist.</tp:docstring>
+      <tp:member type="o" tp:type="Playlist_Id" name="Id">
+        <tp:docstring>A unique identifier for the playlist.</tp:docstring>
+      </tp:member>
+      <tp:member type="s" name="Name">
+        <tp:docstring>The name of the playlist, typically given by the user.</tp:docstring>
+      </tp:member>
+      <tp:member type="s" name="Icon">
+        <tp:docstring>The URI of an (optional) icon.</tp:docstring>
+      </tp:member>
+    </tp:struct>
+
+    <method name="ActivatePlaylist">
+      <tp:docstring>
+        <p>Starts playing the given playlist.</p>
+        <p>
+          It is up to the media player whether this completely replaces the
+          current tracklist, or whether it is merely inserted into the
+          tracklist and the first track starts.
+        </p>
+      </tp:docstring>
+      <arg direction="in" name="playlist_id" type="o" tp:type="Playlist_Id">
+        <tp:docstring>The id of the playlist to activate.</tp:docstring>
+      </arg>
+    </method>
+
+    <method name="GetPlaylists">
+      <tp:docstring>Gets a set of playlists.</tp:docstring>
+      <arg direction="in" name="index" type="u">
+        <tp:docstring>The index of the first playlist to be fetched (according to the ordering).</tp:docstring>
+      </arg>
+      <arg direction="in" name="max_count" type="u">
+        <tp:docstring>The maximum number of playlists to fetch.</tp:docstring>
+      </arg>
+      <arg direction="in" name="order" type="s" tp:type="Playlist_Ordering">
+        <tp:docstring>The ordering that should be used.</tp:docstring>
+      </arg>
+      <arg direction="in" name="reverse_order" type="b">
+        <tp:docstring>Whether the order should be reversed.</tp:docstring>
+      </arg>
+      <arg direction="out" name="playlists" type="a(oss)" tp:type="Playlist[]">
+        <tp:docstring>
+          A list of (at most <em>max_count</em>) playlists.
+        </tp:docstring>
+      </arg>
+    </method>
+
+    <signal name="PlaylistChanged">
+      <tp:docstring>
+        <p>Indicates that either the Name or Icon attribute of a
+        playlist has changed.</p>
+        <p>Client implementations should be aware that this signal
+        may not be implemented.</p>
+        <tp:rationale>Without this signal, media players have no way to
+        notify clients of a change in the attributes of a playlist.</tp:rationale>
+      </tp:docstring>
+      <arg name="playlist" type="(oss)" tp:type="Playlist">
+        <tp:docstring>The playlist which details have changed.</tp:docstring>
+      </arg>
+    </signal>
+
+    <property name="Orderings" type="as" tp:type="Playlist_Ordering[]" access="read">
+      <tp:docstring>
+        <p>The available orderings. At least one must be offered.</p>
+        <tp:rationale>
+          Media players may not have access to all the data required for some
+          orderings.
+        </tp:rationale>
+      </tp:docstring>
+    </property>
+
+    <property name="PlaylistCount" type="u" access="read">
+      <tp:docstring>
+        <p>The number of playlists available.</p>
+      </tp:docstring>
+    </property>
+
+    <property name="Undocumented" type="s" access="readwrite"/>
+  </interface>
+</node>

--- a/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
+++ b/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
@@ -1,0 +1,83 @@
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(crate = "zbus::zvariant")]
+pub struct PlayList {
+    pub name: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde_repr::Deserialize_repr,
+    serde_repr::Serialize_repr,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(crate = "zbus::zvariant")]
+#[repr(i32)]
+pub enum OddValues {
+    Plus = 7,
+    Minus = -1,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+    zbus::zvariant::Value,
+    zbus::zvariant::OwnedValue,
+)]
+#[zvariant(signature = "s", crate = "zbus::zvariant")]
+pub enum Status {
+    Ok,
+}
+
+pub type StatusName = String;
+
+pub type StatusMap = std::collections::HashMap<String, Status>;
+
+pub type NamedKeyMap = std::collections::HashMap<StatusName, String>;
+
+#[proxy(interface = "com.example.EdgeCases", assume_defaults = true)]
+pub trait EdgeCases {
+    /// Probe method
+    ///
+    /// A docstring with a carriage return in the middle.
+    fn probe(
+        &self,
+        play_list: &PlayList,
+        dropped_twin: &(u32,),
+        dropped_enum: u32,
+    ) -> zbus::Result<StatusMap>;
+
+    /// Changed signal
+    #[zbus(signal)]
+    fn changed(&self, status: Status) -> zbus::Result<()>;
+
+    /// NamedKeys property
+    #[zbus(property)]
+    fn named_keys(&self) -> zbus::Result<NamedKeyMap>;
+
+    /// OddValues property
+    #[zbus(property)]
+    fn odd_values(&self) -> zbus::Result<OddValues>;
+    #[zbus(property)]
+    fn set_odd_values(&self, value: OddValues) -> zbus::Result<()>;
+}

--- a/zbus_xmlgen/tests/data/telepathy_edge_cases.xml
+++ b/zbus_xmlgen/tests/data/telepathy_edge_cases.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Adversarial Telepathy type definitions: everything that cannot become valid Rust must be
+     skipped, with the references falling back to the structural types. -->
+<node name="/com/example/EdgeCases" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+  <interface name="com.example.EdgeCases">
+    <!-- Two distinct Telepathy names mapping to the same Rust name: the first wins. -->
+    <tp:struct name="Play_List">
+      <tp:member type="s" name="Name"/>
+    </tp:struct>
+    <tp:struct name="PlayList">
+      <tp:member type="u" name="Count"/>
+    </tp:struct>
+
+    <!-- Colliding with the items the proxy macro generates for this interface. -->
+    <tp:struct name="Edge_Cases_Proxy">
+      <tp:member type="s" name="Inner"/>
+    </tp:struct>
+    <tp:struct name="Changed_Args">
+      <tp:member type="s" name="Inner"/>
+    </tp:struct>
+
+    <!-- Enums that cannot be represented: duplicate discriminants, negative or out-of-range
+         values for the representation, colliding variant names, ambiguous string values. -->
+    <tp:enum name="Dup_Value" type="u">
+      <tp:enumvalue suffix="A" value="1"/>
+      <tp:enumvalue suffix="B" value="1"/>
+    </tp:enum>
+    <tp:enum name="Negative" type="u">
+      <tp:enumvalue suffix="MinusOne" value="-1"/>
+    </tp:enum>
+    <tp:enum name="Too_Big" type="y">
+      <tp:enumvalue suffix="Overflow" value="256"/>
+    </tp:enum>
+    <tp:enum name="Dup_Suffix" type="s">
+      <tp:enumvalue suffix="Foo_Bar" value="a"/>
+      <tp:enumvalue suffix="FooBar" value="b"/>
+    </tp:enum>
+    <tp:enum name="Dup_String" type="s">
+      <tp:enumvalue suffix="First" value="same"/>
+      <tp:enumvalue suffix="Second" value="same"/>
+    </tp:enum>
+
+    <!-- Unusual but representable values are normalized (leading + and zeros). -->
+    <tp:enum name="Odd_Values" type="i">
+      <tp:enumvalue suffix="Plus" value="+007"/>
+      <tp:enumvalue suffix="Minus" value="-1"/>
+    </tp:enum>
+
+    <!-- A named enum key would not satisfy the dictionary conversions, so keys are only
+         aliased to simple types; values may use any named type. -->
+    <tp:enum name="Status" type="s">
+      <tp:enumvalue suffix="Ok" value="Ok"/>
+    </tp:enum>
+    <tp:simple-type name="Status_Name" type="s"/>
+    <tp:mapping name="Status_Map">
+      <tp:member type="s" tp:type="Status" name="Key"/>
+      <tp:member type="s" tp:type="Status" name="Value"/>
+    </tp:mapping>
+    <tp:mapping name="Named_Key_Map">
+      <tp:member type="s" tp:type="Status_Name" name="Key"/>
+      <tp:member type="s" name="Value"/>
+    </tp:mapping>
+
+    <method name="Probe">
+      <tp:docstring>A docstring with a carriagereturn in the middle.</tp:docstring>
+      <arg direction="in" name="play_list" type="(s)" tp:type="Play_List"/>
+      <arg direction="in" name="dropped_twin" type="(u)" tp:type="PlayList"/>
+      <arg direction="in" name="dropped_enum" type="u" tp:type="Dup_Value"/>
+      <arg direction="out" name="statuses" type="a{ss}" tp:type="Status_Map"/>
+    </method>
+
+    <property name="OddValues" type="i" tp:type="Odd_Values" access="readwrite"/>
+    <property name="NamedKeys" type="a{ss}" tp:type="Named_Key_Map" access="read"/>
+
+    <signal name="Changed">
+      <arg name="status" type="s" tp:type="Status"/>
+    </signal>
+  </interface>
+</node>

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -2,7 +2,7 @@ use pretty_assertions::assert_eq;
 use std::{env, error::Error, io::Write, path::Path};
 
 use zbus_xml::Node;
-use zbus_xmlgen::GenTrait;
+use zbus_xmlgen::CodeGenerator;
 
 macro_rules! gen_diff {
     ($infile:literal, $outfile:literal) => {{
@@ -11,13 +11,9 @@ macro_rules! gen_diff {
         #[cfg(windows)]
         let expected = expected.replace("\r\n", "\n");
         let node = Node::from_reader(input.as_bytes())?;
-        let r#gen = GenTrait {
-            interface: &node.interfaces()[0],
-            path: None,
-            service: None,
-            format: true,
-        }
-        .to_string();
+        let r#gen = CodeGenerator::new()
+            .with_format(true)
+            .interface_code(&node.interfaces()[0])?;
 
         if env::var("TEST_OVERWRITE").is_ok() {
             let path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -56,4 +52,27 @@ fn property_setters() -> Result<(), Box<dyn Error>> {
 #[test]
 fn telepathy_docstrings() -> Result<(), Box<dyn Error>> {
     gen_diff!("telepathy_docstrings.xml", "telepathy_docstrings.rs")
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_gen_trait() -> Result<(), Box<dyn Error>> {
+    // The deprecated `GenTrait` still works, matching `CodeGenerator`.
+    let input = include_str!("data/sample_object0.xml");
+    let node = Node::from_reader(input.as_bytes())?;
+    let interface = &node.interfaces()[0];
+
+    let gen_trait = zbus_xmlgen::GenTrait {
+        interface,
+        path: None,
+        service: None,
+        format: true,
+    }
+    .to_string();
+    let code = CodeGenerator::new()
+        .with_format(true)
+        .interface_code(interface)?;
+    assert_eq!(gen_trait, code);
+
+    Ok(())
 }

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -12,6 +12,7 @@ macro_rules! gen_diff {
         let expected = expected.replace("\r\n", "\n");
         let node = Node::from_reader(input.as_bytes())?;
         let r#gen = CodeGenerator::new()
+            .with_node_types(node.telepathy_types())
             .with_format(true)
             .interface_code(&node.interfaces()[0])?;
 
@@ -55,9 +56,49 @@ fn telepathy_docstrings() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn telepathy_edge_cases() -> Result<(), Box<dyn Error>> {
+    gen_diff!("telepathy_edge_cases.xml", "telepathy_edge_cases.rs")
+}
+
+#[test]
+fn shared_node_types_in_one_file() -> Result<(), Box<dyn Error>> {
+    // Two interfaces referencing the same node-level definition in a single file: the Rust
+    // definition must be generated only once.
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <tp:struct name="Shared_Info">
+                <tp:member type="s" name="Info"/>
+            </tp:struct>
+            <interface name="org.test.iface1">
+                <method name="GetInfo">
+                    <arg direction="out" name="info" type="(s)" tp:type="Shared_Info"/>
+                </method>
+            </interface>
+            <interface name="org.test.iface2">
+                <method name="SetInfo">
+                    <arg direction="in" name="info" type="(s)" tp:type="Shared_Info"/>
+                </method>
+            </interface>
+        </node>
+    "#;
+
+    let node = Node::from_reader(input.as_bytes())?;
+    let code = CodeGenerator::new()
+        .with_node_types(node.telepathy_types())
+        .file_code(node.interfaces(), &[], "test", "test", "test")?;
+
+    assert_eq!(code.matches("pub struct SharedInfo").count(), 1);
+    // Both interfaces still use the shared type.
+    assert!(code.contains("zbus::Result<(SharedInfo,)>"));
+    assert!(code.contains("info: &SharedInfo"));
+
+    Ok(())
+}
+
+#[test]
 #[allow(deprecated)]
 fn deprecated_gen_trait() -> Result<(), Box<dyn Error>> {
-    // The deprecated `GenTrait` still works, matching `CodeGenerator`.
+    // The deprecated `GenTrait` still works, matching `CodeGenerator` sans node-level types.
     let input = include_str!("data/sample_object0.xml");
     let node = Node::from_reader(input.as_bytes())?;
     let interface = &node.interfaces()[0];

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -52,3 +52,8 @@ fn struct_return() -> Result<(), Box<dyn Error>> {
 fn property_setters() -> Result<(), Box<dyn Error>> {
     gen_diff!("property_setters.xml", "property_setters.rs")
 }
+
+#[test]
+fn telepathy_docstrings() -> Result<(), Box<dyn Error>> {
+    gen_diff!("telepathy_docstrings.xml", "telepathy_docstrings.rs")
+}


### PR DESCRIPTION
Fixes #255. Fixes #256.

Built on top of #1839 (now merged); this branch is rebased onto `main`. Since #1839 reworked introspection-tree construction into a bespoke winnow parser, the zbus_xml side here is a reimplementation against it (one commit) rather than three; the six zbus_xmlgen commits, which only consume zbus_xml's public API, replayed unchanged. The debug-build deep-nesting stack-overflow this series had carried a fix for now lives in #1839's parser itself, so it's dropped here.

## What this does

The Telepathy D-Bus introspection extensions — used most prominently by MPRIS — embed documentation (`tp:docstring`) and named type definitions (`tp:simple-type`, `tp:enum`, `tp:struct`, `tp:mapping`, referenced via `tp:type` attributes) in introspection XML. Previously all of it was skipped silently (and before #1839, it broke parsing outright — the original complaint of #255).

### zbus_xml

- **Docstrings** are captured on nodes, interfaces, methods, signals, properties and args, exposed via `docstring()` accessors. Content is kept verbatim (it's typically HTML) with surrounding whitespace trimmed, matched under any namespace prefix. Parse-only: the writer doesn't emit them (documented on `Node::to_writer`, including the equality implication for round-trips).
- **Type definitions** are parsed into a new `telepathy` module from both `<node>` and `<interface>` level (`telepathy_types()` accessors), and `tp:type` references are exposed on `Arg`, `Property` and `telepathy::Member`.
- **Warnings** (#256): anything that still gets skipped — unsupported elements like `tp:flags`, or a malformed type definition (missing attribute, invalid/empty signature, non-basic mapping key) — is recorded as a `Warning` (element name, byte offset, message) returned by the new `Node::from_reader_with_warnings()`. Malformed definitions never fail the document. The existing entry points are unchanged.

Implementation-wise, the parser threads the document and a warning collector through a `winnow::Stateful` input and hooks docstring capture and type-def parsing into the points where it would otherwise skip a foreign element.

### zbus-xmlgen

- **New `CodeGenerator` API**: configuration lives behind private fields with a constructor, builder-style `with_*` setters (`with_node_types`, `with_service`, `with_path`, `with_format`) and getters; `interface_code()` generates one interface's code, `file_code()` a complete source file. `GenTrait` and `write_interfaces()` keep their released shapes and are deprecated shims delegating to it (with a test pinning `GenTrait`'s output to the new implementation), so nothing breaks and future knobs stay additive. Version bumped to 5.4.0 for the deprecations.
- **Docstrings become doc comments**: the interface docstring on the trait, member docstrings under the synthesized `/// Xyz method` lines, arg docstrings as a `# Arguments` list. rustdoc passes the HTML through.
- **Type definitions become Rust types**: aliases for `tp:simple-type`/`tp:mapping`; structs and fieldless enums with serde + zvariant `Type`/`Value`/`OwnedValue` derives (through the re-export, via `#[zvariant(crate = "zbus::zvariant")]`). Numeric enums get `#[repr]`, explicit discriminants and serde_repr derives; string enums get `#[zvariant(signature = "s")]` with renames where the wire value differs from the variant name. Generated signatures use the named types wherever a `tp:type` reference resolves to a generated definition and matches the actual signature:

  ```rust
  fn get_playlists(&self, index: u32, max_count: u32, order: PlaylistOrdering, reverse_order: bool)
      -> zbus::Result<Vec<Playlist>>;
  #[zbus(property)]
  fn active_playlist(&self) -> zbus::Result<MaybePlaylist>;
  ```

  The `Value`/`OwnedValue` derives make the types work for properties (`TryFrom<OwnedValue>`/`Into<Value>`), not just method bodies. Node-level definitions are generated only when the interface (transitively) references them; interface-level ones always; in single-file/stdout output, all interfaces form one document so shared definitions (and the header) appear once. The generated file's doc header calls out the serde/serde_repr dependency.
- **Anything that cannot become valid Rust falls back**: unresolvable or signature-mismatched `tp:type` references, definitions whose names collide (with each other or with the proxy macro's own items), enums with duplicate/out-of-range/unrepresentable values — all degrade to the structural types instead of emitting broken code.
- **Warnings go to stderr** (#256), deduplicated by message.

## Review & testing

Three independent review agents earlier went over this work (parser correctness + adversarial input, codegen validity, API/backwards-compat); all confirmed findings are folded into the commits here. Highlights:

- The adversarial parser pass (thousands of truncations, mutations and hostile splices; 10k-value enums; MAX_DEPTH probes; UTF-8 boundary checks) found no panics or hangs; it caught the empty-signature (`Unit`) acceptance and two warning-contract violations, all fixed.
- The codegen pass compiled generator output for adversarial definitions and caught 10 ways to emit non-compiling Rust (name collisions, discriminant issues, enum mapping keys, bare CR in docstrings, duplicated shared types in single-file output, and the pre-existing invalid `Signature<'_>`/`OwnedSignature` emission) — all fixed, pinned by the `telepathy_edge_cases` fixture, which is diff- and compile-tested through the real `#[proxy]` macro.
- The compat pass verified serde wire format unchanged, a 5.3.1-style consumer compiles with only deprecation warnings, docs clean under `-D warnings`, and MSRV 1.87.

Also, on this rebase onto `main`: 24 zbus_xml + 7 zbus_xmlgen tests pass (docstring capture, warning positions/messages, well-formed and nine kinds of malformed definitions, the MPRIS-modeled fixtures); clippy and tests clean under CI's `-D warnings`; rustfmt, docs, Windows cross-check and the zbus e2e test under `dbus-run-session` all pass; every commit builds and tests standalone.

## Deliberate scope edges

- `tp:flags` is *not* generated (stays a warning): the natural mapping is enumflags2, but zvariant's `BitFlags` support is feature-gated and zbus doesn't re-export enumflags2, so generated code couldn't rely on it without extra setup. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVM3TqQzUHJSB7sUqvVRDJ