### PR TITLE
✨ zb: Add Connection::closed() and is_closed() API

### DIFF
--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -250,6 +250,24 @@ impl Connection {
         self.inner.monitor_activity()
     }
 
+    /// Returns `true` if the connection has been closed.
+    ///
+    /// A connection is considered closed either when the remote peer disconnects, an I/O error
+    /// occurs on the socket, or [`Connection::close`] is called.
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Block until the connection is closed.
+    ///
+    /// A connection is considered closed either when the remote peer disconnects, an I/O error
+    /// occurs on the socket, or [`Connection::close`] is called.
+    ///
+    /// Returns immediately if the connection is already closed.
+    pub fn closed(&self) {
+        block_on(self.inner.closed())
+    }
+
     /// Return the peer credentials.
     ///
     /// The fields are populated on the best effort basis. Some or all fields may not even make

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -6,7 +6,10 @@ use std::{
     collections::HashMap,
     future::Future,
     io,
-    sync::{Arc, OnceLock, Weak},
+    sync::{
+        Arc, OnceLock, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 use tracing::{Instrument, debug, info_span, instrument, trace, trace_span, warn};
@@ -32,7 +35,7 @@ pub mod socket;
 pub use socket::Socket;
 
 mod socket_reader;
-use socket_reader::SocketReader;
+use socket_reader::{SocketReader, SocketStatus};
 
 mod pending_method_calls;
 use pending_method_calls::PendingMethodCalls;
@@ -54,7 +57,7 @@ pub(crate) struct ConnectionInner {
     unique_name: OnceLock<OwnedUniqueName>,
     registered_names: Mutex<HashMap<WellKnownName<'static>, NameStatus>>,
 
-    activity_event: Arc<Event>,
+    socket_status: Arc<SocketStatus>,
     socket_write: Mutex<Box<dyn socket::WriteHalf>>,
 
     // Our executor
@@ -220,7 +223,7 @@ impl Connection {
             return Err(Error::Unsupported);
         }
 
-        self.inner.activity_event.notify(usize::MAX);
+        self.inner.socket_status.activity_event.notify(usize::MAX);
         let mut write = self.inner.socket_write.lock().await;
 
         write.send_message(msg).await
@@ -1100,7 +1103,11 @@ impl Connection {
 
         let connection = Self {
             inner: Arc::new(ConnectionInner {
-                activity_event: Arc::new(Event::new()),
+                socket_status: Arc::new(SocketStatus {
+                    activity_event: Event::new(),
+                    closed: AtomicBool::new(false),
+                    closed_event: Event::new(),
+                }),
                 socket_write: Mutex::new(auth.socket_write),
                 server_guid: auth.server_guid,
                 #[cfg(unix)]
@@ -1144,7 +1151,31 @@ impl Connection {
     ///
     /// This function is meant for the caller to implement idle or timeout on inactivity.
     pub fn monitor_activity(&self) -> EventListener {
-        self.inner.activity_event.listen()
+        self.inner.socket_status.activity_event.listen()
+    }
+
+    /// Returns `true` if the connection has been closed.
+    ///
+    /// A connection is considered closed either when the remote peer disconnects, an I/O error
+    /// occurs on the socket, or [`Connection::close`] is called.
+    pub fn is_closed(&self) -> bool {
+        self.inner.socket_status.closed.load(Ordering::Relaxed)
+    }
+
+    /// Waits until the connection is closed.
+    ///
+    /// A connection is considered closed either when the remote peer disconnects, an I/O error
+    /// occurs on the socket, or [`Connection::close`] is called.
+    ///
+    /// Returns immediately if the connection is already closed.
+    pub async fn closed(&self) {
+        loop {
+            let listener = self.inner.socket_status.closed_event.listen();
+            if self.inner.socket_status.closed.load(Ordering::Acquire) {
+                return;
+            }
+            listener.await;
+        }
     }
 
     /// Return the peer credentials.
@@ -1199,14 +1230,21 @@ impl Connection {
     ///
     /// After this call, all reading and writing operations will fail.
     pub async fn close(self) -> Result<()> {
-        self.inner.activity_event.notify(usize::MAX);
-        self.inner
+        self.inner.socket_status.activity_event.notify(usize::MAX);
+        let result = self
+            .inner
             .socket_write
             .lock()
             .await
             .close()
             .await
-            .map_err(Into::into)
+            .map_err(Into::into);
+        self.inner
+            .socket_status
+            .closed
+            .store(true, Ordering::Release);
+        self.inner.socket_status.closed_event.notify(usize::MAX);
+        result
     }
 
     /// Gracefully close the connection, waiting for all other references to be dropped.
@@ -1275,7 +1313,7 @@ impl Connection {
                     already_read,
                     #[cfg(unix)]
                     already_received_fds,
-                    inner.activity_event.clone(),
+                    inner.socket_status.clone(),
                 )
                 .spawn(&inner.executor),
             )

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use event_listener::Event;
 use tracing::{debug, instrument, trace};
@@ -21,7 +27,7 @@ pub(crate) struct SocketReader {
     #[cfg(unix)]
     already_received_fds: Vec<std::os::fd::OwnedFd>,
     prev_seq: u64,
-    activity_event: Arc<Event>,
+    socket_status: Arc<SocketStatus>,
 }
 
 impl SocketReader {
@@ -31,7 +37,7 @@ impl SocketReader {
         pending_method_calls: PendingMethodCalls,
         already_received_bytes: Vec<u8>,
         #[cfg(unix)] already_received_fds: Vec<std::os::fd::OwnedFd>,
-        activity_event: Arc<Event>,
+        socket_status: Arc<SocketStatus>,
     ) -> Self {
         Self {
             socket,
@@ -41,7 +47,7 @@ impl SocketReader {
             #[cfg(unix)]
             already_received_fds,
             prev_seq: 0,
-            activity_event,
+            socket_status,
         }
     }
 
@@ -104,6 +110,8 @@ impl SocketReader {
 
             if msg.is_err() {
                 senders.clear();
+                self.socket_status.closed.store(true, Ordering::Release);
+                self.socket_status.closed_event.notify(usize::MAX);
                 trace!("Socket reading task stopped");
 
                 return;
@@ -137,7 +145,7 @@ impl SocketReader {
 
     #[instrument(skip(self), level = "trace")]
     async fn read_socket(&mut self) -> crate::Result<Message> {
-        self.activity_event.notify(usize::MAX);
+        self.socket_status.activity_event.notify(usize::MAX);
         let seq = self.prev_seq + 1;
         let msg = self
             .socket
@@ -152,4 +160,12 @@ impl SocketReader {
 
         Ok(msg)
     }
+}
+
+/// Socket-related state shared between [`super::ConnectionInner`] and the socket reader task.
+#[derive(Debug)]
+pub(super) struct SocketStatus {
+    pub activity_event: Event,
+    pub closed: AtomicBool,
+    pub closed_event: Event,
 }

--- a/zbus/tests/connection_closed.rs
+++ b/zbus/tests/connection_closed.rs
@@ -1,0 +1,79 @@
+#![cfg(all(unix, feature = "p2p"))]
+
+use std::os::unix::net::UnixStream;
+
+use ntest::timeout;
+use test_log::test;
+use zbus::{Guid, block_on, connection::Builder};
+
+#[test]
+#[timeout(15000)]
+fn closed_resolves_when_peer_disconnects() {
+    block_on(async {
+        let (s0, s1) = UnixStream::pair().unwrap();
+        let guid = Guid::generate();
+
+        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
+        let client_builder = Builder::unix_stream(s1).p2p();
+
+        let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
+        let server = server.unwrap();
+        let client = client.unwrap();
+
+        assert!(!server.is_closed());
+
+        // Drop the client connection, closing the socket.
+        drop(client);
+
+        // closed() should resolve now that the peer is gone.
+        server.closed().await;
+        assert!(server.is_closed());
+    });
+}
+
+#[test]
+#[timeout(15000)]
+fn closed_resolves_on_explicit_close() {
+    block_on(async {
+        let (s0, s1) = UnixStream::pair().unwrap();
+        let guid = Guid::generate();
+
+        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
+        let client_builder = Builder::unix_stream(s1).p2p();
+
+        let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
+        let server = server.unwrap();
+        let client = client.unwrap();
+
+        assert!(!client.is_closed());
+
+        client.close().await.unwrap();
+
+        // closed() should resolve after an explicit close() call.
+        server.closed().await;
+        assert!(server.is_closed());
+    });
+}
+
+#[test]
+#[timeout(15000)]
+fn closed_resolves_immediately_if_already_closed() {
+    block_on(async {
+        let (s0, s1) = UnixStream::pair().unwrap();
+        let guid = Guid::generate();
+
+        let server_builder = Builder::unix_stream(s0).server(guid).unwrap().p2p();
+        let client_builder = Builder::unix_stream(s1).p2p();
+
+        let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
+        let server = server.unwrap();
+        let client = client.unwrap();
+
+        drop(client);
+        server.closed().await;
+
+        // Calling closed() again should return immediately.
+        server.closed().await;
+        assert!(server.is_closed());
+    });
+}


### PR DESCRIPTION
Expose a way to detect when the underlying socket has been closed, either by the remote peer or due to an I/O error. This lets D-Bus service daemons exit cleanly instead of hanging on pending futures.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
