### PR TITLE
🚨 Fix new clippy 1.97 warnings

### DIFF
--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -44,10 +44,7 @@ impl Node {
             if i.is_empty() {
                 continue;
             }
-            match node.children.get(i) {
-                Some(n) => node = n,
-                None => return None,
-            }
+            node = node.children.get(i)?;
         }
 
         Some(node)

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -687,10 +687,7 @@ impl<'a> Proxy<'a> {
     /// Use PropertiesCache::ready() to wait for the cache to be populated and to get any errors
     /// encountered in the population.
     pub(crate) fn get_property_cache(&self) -> Option<&Arc<PropertiesCache>> {
-        let cache = match &self.inner.property_cache {
-            Some(cache) => cache,
-            None => return None,
-        };
+        let cache = self.inner.property_cache.as_ref()?;
         let (cache, _) = &cache.get_or_init(|| {
             let proxy = self.owned_properties_proxy();
             let interface = self.interface().to_owned();

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -507,12 +507,10 @@ fn decode_entity(entity: &str) -> Option<char> {
         "apos" => return Some('\''),
         _ => {}
     }
-    let code = match entity.strip_prefix('#') {
-        Some(dec_or_hex) => match dec_or_hex.strip_prefix(['x', 'X']) {
-            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
-            None => dec_or_hex.parse().ok()?,
-        },
-        None => return None,
+    let dec_or_hex = entity.strip_prefix('#')?;
+    let code = match dec_or_hex.strip_prefix(['x', 'X']) {
+        Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+        None => dec_or_hex.parse().ok()?,
     };
     char::from_u32(code)
 }

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .next_back()
                     .expect("Failed to split name");
                 let filename = to_snakecase(filename);
-                std::fs::write(format!("{}.rs", &filename), output)?;
+                std::fs::write(format!("{filename}.rs"), output)?;
                 println!("Generated code for `{interface_name}` in {filename}.rs");
             }
         }

--- a/zvariant/src/dbus/ser.rs
+++ b/zvariant/src/dbus/ser.rs
@@ -473,13 +473,9 @@ where
                 "a struct".to_string(),
             ));
         };
-        let struct_field = fields.get(1).and_then(|f| {
-            if matches!(f, Signature::Structure(_)) {
-                Some(f)
-            } else {
-                None
-            }
-        });
+        let struct_field = fields
+            .get(1)
+            .filter(|&f| matches!(f, Signature::Structure(_)));
 
         ser.0.add_padding(STRUCT_ALIGNMENT_DBUS)?;
         let mut struct_ser = Self::structure(ser)?;


### PR DESCRIPTION
The CI toolchain moved to stable **1.97.0**, whose clippy denies (via `-D warnings`) a few patterns in existing code, turning `main` red. This fixes them, one commit per package:

- **🚨 zv:** `manual_filter` — replace a hand-rolled `and_then` returning `Some`/`None` in `zvariant`'s `enum_variant` with `Option::filter`.
- **🚨 zb:** `question_mark` — two `match … { Some(x) => x, None => return None }` blocks (proxy property-cache getter and object-server node lookup) become `?`. The property-cache one uses `.as_ref()?` since the value is behind `&self`.
- **🚨 xmlgen:** `question_mark` on the XML entity-decode match, and `useless_borrows_in_formatting` on a redundant `&` in a `format!` argument.

Verified locally with clippy 1.97.0: `cargo --locked clippy` is clean on the host **and** on all five cross-targets CI checks (apple-darwin, freebsd, netbsd, pc-windows-gnu, aarch64-linux-android), and `cargo fmt --all --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs

---
_Generated by [Claude Code](https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs)_