### PR TITLE
✅ zb: Cover &mut self dynamic interface registration; document ObjectManager deadlock

### DIFF
--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -27,6 +27,10 @@ pub type ManagedObjects =
 /// under the `path` it's added at. You can use this fact to minimize the signal emissions by
 /// populating the entire (sub)tree under `path` before registering an object manager.
 ///
+/// Because registering it reads the properties of every object under `path`, adding an
+/// `ObjectManager` at an ancestor of an interface from within that interface's own `&mut self`
+/// method will deadlock. See [`ObjectServer::at`](crate::ObjectServer::at) for details.
+///
 /// [om]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
 #[derive(Debug, Clone)]
 pub struct ObjectManager;

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -118,6 +118,19 @@ impl ObjectServer {
     /// where this method becomes useful.
     ///
     /// If the interface already exists at this path, returns false.
+    ///
+    /// # Deadlocks
+    ///
+    /// It is fine to call this method from within an interface method (e.g. to register a child or
+    /// sibling object on demand), including from a `&mut self` method. There is however one
+    /// exception: registering an [`ObjectManager`] at an ancestor of the currently-executing
+    /// interface from within one of its `&mut self` methods will **deadlock**.
+    ///
+    /// This is because adding an `ObjectManager` reads the properties of every object under it (to
+    /// emit the initial `InterfacesAdded` signals), which requires a shared lock on each of those
+    /// interfaces — including the calling one, whose exclusive lock is held for the duration of the
+    /// `&mut self` method. Registering the `ObjectManager` up front (typically at connection
+    /// set-up), or from a `&self` method, avoids this.
     pub async fn at<'p, P, I>(&self, path: P, iface: I) -> Result<bool>
     where
         I: Interface,

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -367,6 +367,20 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     created_inside_proxy.ping().await?;
     proxy.destroy_obj("CreatedInside").await?;
 
+    // Same, but from a `&mut self` method, which holds a *write* lock on the calling interface
+    // across the registration. Regression test for #1845.
+    proxy
+        .inner()
+        .call_method("CreateObjInsideMut", &("CreatedInsideMut"))
+        .await?;
+    let created_inside_mut_proxy = MyIfaceProxy::builder(&conn)
+        .destination("org.freedesktop.MyService")?
+        .path("/zbus/test/CreatedInsideMut")?
+        .build()
+        .await?;
+    created_inside_mut_proxy.ping().await?;
+    proxy.destroy_obj("CreatedInsideMut").await?;
+
     // Test that interfaces emit signals when properties change
     // according to their emits_changed_signal flags.
     let mut props_changed = props_proxy.receive_properties_changed().await?;

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -181,6 +181,29 @@ impl MyIface {
             .unwrap();
     }
 
+    // Same as `create_obj_inside`, but from a `&mut self` method. Dispatch holds a *write* lock on
+    // the calling interface for the whole duration of this method, so registering a secondary
+    // interface here exercises a different locking path than the `&self` variant above. Regression
+    // test for https://github.com/z-galaxy/zbus/issues/1845.
+    #[instrument]
+    async fn create_obj_inside_mut(
+        &mut self,
+        #[zbus(object_server)] object_server: &ObjectServer,
+        key: String,
+    ) {
+        debug!("`CreateObjInsideMut` called.");
+        // Mutate `self` so the write lock on this interface is genuinely held (and used) across the
+        // registration of the secondary interface below.
+        self.count += 1;
+        object_server
+            .at(
+                format!("/zbus/test/{key}"),
+                MyIface::new(self.next_tx.clone()),
+            )
+            .await
+            .unwrap();
+    }
+
     #[instrument]
     async fn destroy_obj(&self, key: &str) {
         debug!("`DestroyObj` called.");


### PR DESCRIPTION
## Context

Investigation of #1845 ("`ObjectServer::at().await` blocks indefinitely"). The report is about registering a secondary interface from within a served interface's method callback.

## Findings

The common pattern — registering a child/sibling interface from within a served interface's method via the `#[zbus(object_server)]` reference — works without deadlock, **including from `&mut self` methods** (which hold an exclusive write lock on the calling interface across the `at().await`). Our existing `CreateObjInside` e2e test only covered the `&self` (shared read lock) case, so the `&mut self` path was untested.

There is exactly one genuine deadlock in this area: registering an **`ObjectManager` at a strict ancestor** of a currently-executing interface, from within one of that interface's **`&mut self`** methods. Adding an `ObjectManager` reads the properties of every object beneath it (to emit the initial `InterfacesAdded` signals), which needs a shared lock on each of those interfaces — including the calling one, whose exclusive lock is still held for the duration of the `&mut self` method. I confirmed this empirically (a `&mut self` method deadlocks; the identical `&self` method does not).

## Changes

- **Test** (`✅ zb: Test registering an interface from a &mut self callback`): adds a `CreateObjInsideMut` interface method — a `&mut self` variant of `CreateObjInside` that mutates `self` (so the write lock is genuinely held) and then registers a secondary interface. The e2e client drives it, pings the new object, and destroys it. Verified passing on async-io and tokio, over both bus and p2p.
- **Docs** (`📝 zb: Document ObjectManager-ancestor deadlock in ObjectServer::at`): documents the deadlock constraint (and how to avoid it) on both `ObjectServer::at` and the `ObjectManager` type.

This does not fix the ObjectManager-ancestor deadlock itself — that needs a design decision (the interface's lock must be held while `self` is borrowed, so the re-entrancy has to be avoided inside `get_managed_objects`/`get_all`, or the constraint documented). This PR documents it for now.

Related to #1845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0163qDx57s2tfu59c7hTZ58Q)_