### PR TITLE
📝 zb: Add 5.18.0 changelog entries dropped by release-plz

### DIFF
--- a/zbus/CHANGELOG.md
+++ b/zbus/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - ✨ Add Connection::closed() and is_closed() API.
 
+### Documentation
+- 📝 Document ObjectManager-ancestor deadlock in ObjectServer::at.
+
+### Other
+- 🚨 Replace manual match-and-return with the ? operator.
+
+### Testing
+- ✅ Test registering an interface from a &mut self callback.
+
 ## 5.17.0 - 2026-07-07
 
 ### Changed


### PR DESCRIPTION
The 5.18.0 release generated by release-plz dropped three commits from `zbus`'s changelog:

- `📝` Document ObjectManager-ancestor deadlock in ObjectServer::at (074d6c5d)
- `🚨` Replace manual match-and-return with the `?` operator (e78bd102)
- `✅` Test registering an interface from a `&mut self` callback (d4bfc095)

All three landed on `main` between the 5.17.0 release and the merge of #1841. Because #1841's
branch was cut *before* 5.17.0 was released and merged *after* it, release-plz — which determines
"changes since last release" by walking history back from `HEAD` and comparing each revision to the
published crate rather than using the `zbus-5.17.0` tag — stopped its walk at that merge and treated
the intervening commits as already released.

Verified by re-running `release-plz update` on the same tree with #1841 excluded: all three entries
reappear, and the text added here matches exactly what release-plz produces in that case.

Normally `CHANGELOG.md` is release-plz-managed and not hand-edited, but these entries will never be
picked up automatically (future runs diff against the published 5.18.0, which already contains the
sources), so this is a deliberate one-off correction. The underlying release-plz behaviour is being
reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
